### PR TITLE
The plan that drives this lives in it

### DIFF
--- a/docs/design/the-engine-fails-out-loud.md
+++ b/docs/design/the-engine-fails-out-loud.md
@@ -1,0 +1,496 @@
+# Fase 9: falhar em voz alta — o desenho
+
+Entregue. O plano de registro é
+[the engine fails out loud](../../plans/the-engine-fails-out-loud.md) e o que
+prova é o gate `plugin-serial-engine`. Este documento é o desenho que veio
+antes, guardado porque explica as decisões que o plano só cita.
+
+## Contexto
+
+Do plano mestre (`~/.claude/plans/kind-strolling-castle.md`), fases 1 a 8
+fechadas. A 9 é a que assume que o sistema **vai** falhar: a API do GitHub cai,
+o Claude sai do ar. Não tem shutdown elegante — falha, avisa, e segue.
+
+Três mudanças, e o que cada uma conserta hoje:
+
+1. **Hoje você descobre na quinta tentativa.** `Worker.recordFailure()`
+   (`plugins/serial-engine/src/Worker.ts:284`) é o único leitor de
+   `maxItemAttempts`, e só avisa quando `attempt >= maxItemAttempts`. As
+   tentativas do meio são silenciosas e a volta não avisa nada.
+2. **Um canal de notificação quebrado derruba o tick.** A porta `notifier`
+   monta um `FanOutNotifier` novo por anúncio
+   (`plugins/notify-fanout/src/plugin.ts:13`), que lança quando
+   *todos* os canais falham. Num install de um canal só, isso sobe pelo
+   `Worker.announce()` e o tick inteiro vira `failed`.
+3. **`EventKind` é uma união TS solta.** Sem versão, sem schema, sem doc.
+   `packages/core/src/ports/EventLog.ts` é o único lugar onde os 15 nomes
+   existem, e `detail` é `Record<string, unknown>` que cada leitor adivinha.
+
+Decisões já tomadas: **gate L3 novo sobre o engine**, o aviso do teto
+**continua** (com texto novo), e o contrato do log trava **os kinds e o
+formato do `detail`**.
+
+---
+
+## Um bug que apareceu no caminho, e que vem primeiro
+
+`Worker.parked()` diz, em comentário, que o record não é salvo de propósito
+"so the ticket keeps its state and its attempt count". Isso é verdade do
+`WorkRecord.attempts` (o contador por estado) e **falso** do
+`QueueItem.attempt`: o branch de park em `advance()` (Worker.ts:203)
+reenfileira sem `attempt`, e `FileQueue.enqueue` faz `request.attempt ?? 0`
+(`plugins/file-queue/src/FileQueue.ts:40`).
+
+Hoje: um ticket na quarta tentativa que bate num park ganha o orçamento de
+retry de volta, de graça. Depois desta fase seria pior — o tick seguinte leria
+`attempt === 0` e anunciaria uma recuperação que não houve.
+
+Conserto: `attempt: item.attempt` naquele `enqueue`, e o comentário passa a
+dizer de qual contador ele está falando.
+
+---
+
+## (a) Um aviso na queda, silêncio no meio, um na volta
+
+**O sinal é o `QueueItem.attempt`**, que já é durável (um JSON por item em
+`.amy/queue/`), já atravessa processo, já significa *falhas consecutivas
+deste trabalho*, e já é zerado pelo evento que significa recuperação.
+
+As alternativas caem por motivo próprio: um campo no work record passaria pelo
+`applyTicketPlan`, que é função pura do workflow e descartaria — engine
+escrevendo no record do workflow é a camada que este repo existe pra impedir;
+`deps.log.read()` não serve porque `log` é opcional (`WorkerDeps.log?`), e o
+contrato do aviso não pode variar por install; contador no `Worker` não serve
+porque `amy tick` é um processo novo a cada vez.
+
+### As edições
+
+**`recordFailure()`** ganha um privado que concentra a decisão, e devolve o
+texto ou `null`:
+
+```ts
+private failureNotice(item, record, attempt, message): string | null
+```
+
+- `attempt >= maxItemAttempts` → texto do teto (**o teto ganha do que cai**,
+  então `maxItemAttempts: 1` dá um aviso, não dois)
+- `item.attempt === 0` → texto da queda
+- resto → `null`, que é o silêncio
+
+A guarda é `item.attempt === 0`, não `attempt === 1`: lê-se "este item nunca
+tinha falhado", que é a condição de verdade. Extrair mantém o branch count de
+`recordFailure` embaixo do `L1.COMPLEXITY_CEILING` e deixa
+queda/silêncio/teto testável direto.
+
+Textos:
+
+- queda: `${workId} is failing in ${state} and I am retrying: ${message}`
+- teto: `${workId} failed ${attempt} times in ${state}, I have given up, and
+  it is off the queue: ${message}` — texto novo, mantendo a substring
+  `is off the queue` que o teste existente já procura
+
+**`advance()`** ganha um privado chamado dos dois pontos onde ele já registra
+o desfecho (o branch `settled` e o de sucesso), pra não ganhar branch novo:
+
+```ts
+private async announceRecovery(item, state): Promise<void>
+```
+
+No-op quando `item.attempt === 0`. Texto: `${workId} is moving again in
+${state} after ${item.attempt} failed attempt(s).`
+
+Chamar no `settled` também: chegar num estado terminal depois de uma queda
+*é* "o ticket continuou de onde estava".
+
+**Não** entra: recuperação depois do teto. Passado o teto o item sai da fila,
+nada mais carrega `attempt > 0` daquele workId, e o próximo item vem do
+`amy discover` com `attempt: 0`. Isso é correto e vai escrito no plano como
+não-objetivo: o aviso do teto já diz "parei, vem olhar", e anunciar
+"recuperou" um trabalho que a pessoa mesma reenfileirou seria dar à máquina o
+crédito do conserto de um humano.
+
+Dois `EventKind` novos: `work.degraded` (`detail: { attempt, error }`) e
+`work.recovered` (`detail: { afterAttempts }`). Sem eles, toda UI reconstrói
+"houve uma queda" pareando `work.failed` com o `work.advanced` seguinte, que é
+a mesma fragilidade derivada que desqualificou o `log.read()` acima — só que
+replicada em cada leitor em vez de resolvida no engine uma vez.
+
+E `WorkerConfig.maxItemAttempts` muda de significado: o comentário diz "before
+the operator is told" e vira "before the machine gives up on it".
+
+---
+
+## (b) Isolamento, e onde exatamente fica a linha
+
+A regra, dita como regra, e que vai literal no plano do repo:
+
+> **Uma chamada de porta só pode ser engolida quando a falha dela não torna o
+> record uma mentira.**
+
+`advance()` calcula `next = applyTicketPlan(...)` e salva. Record e mundo têm
+que concordar depois disso. Então:
+
+| Porta | Decisão | Porque |
+| :-- | :-- | :-- |
+| `tracker` | falha o tick | engolir `setStatus` deixa o record em `HANDED_OFF` com o ticket ainda In Progress, e como o estado andou, ninguém retenta |
+| `code-host` | falha o tick | engolir `openPullRequest` deixa o record afirmando um PR com `pullRequestNumber: undefined` |
+| `agent`, `gate` | falha o tick | o resultado deles *é* `outcomes`; é o que o `refuseAnIncompleteRun()` já existe pra impedir |
+| `notifier` | isolada | nada a jusante lê |
+| event log | isolada | nada a jusante lê *dentro do tick* |
+
+A frase da fase ("um plugin que morre não derruba o tick") é mais larga que o
+próprio critério dela ("um canal de notificação quebrado não impede o tick de
+terminar"). Constrói-se o critério, e a regra estreita vai escrita pra que a
+frase larga nunca seja citada como licença.
+
+### Três edições
+
+**`Worker.announce()`** (Worker.ts:553) ganha try/catch e grava
+`notify.failed` com `{ error, text }`. Tem que ser aqui e não só no fan-out,
+porque `notifier` é uma **porta** e um install pode montar outro plugin: a
+promessa "notificação não custa ticket" é do engine, não de quem estiver
+montado.
+
+Isso conserta um bug de perda de trabalho que existe hoje: `recordFailure()`
+chama `this.deps.notifier.announce(...)` **direto**, e **depois** de
+`queue.complete(item)`. Canal único quebrado ⇒ o anúncio do teto lança, sobe
+pelo `tick()` sem ninguém pegar, e o item já foi completado sem reenfileirar.
+O ticket some da fila sem registro do motivo. Rotear por `this.announce`
+fecha.
+
+**`Worker.record()`** (Worker.ts:584) ganha try/catch. Disco cheio ou permissão
+ruim em `.amy/log` não pode custar um ticket, mas não pode ser silencioso, ou
+a máquina parece saudável e não tem log. Vai pra `console.error` **uma vez por
+instância de Worker** (flag privada), porque um log quebrado lança nas ~8
+chamadas de `record()` por tick, e enxurrada em stderr é a sua própria queda.
+Não anuncia: `announce` numa máquina cujo log quebrou pode estar quebrado
+também (os dois escrevem embaixo de `.amy/`).
+
+**`plugin-notify-fanout/src/plugin.ts`** passa um sink apoiado no `ctx.log`
+em vez do `console.error` default, e mantém o stderr junto — quem está olhando
+`amy run` tem que ver na hora. `PluginContext` já expõe `log` e `now`.
+
+O `throw` do `FanOutNotifier` quando **todos** os canais falham **fica**. Ele
+fazia dois trabalhos e só um sobrevive: "não deixe uma notificação perdida
+passar despercebida" continua, agora melhor, na linha `notify.failed` que nomeia
+o workId e o estado; "faça o operador saber que a máquina travou" não é
+executável por um notificador que, por construção, não tem mais canal nenhum —
+aquele throw só transformava "você não foi avisado" em "você não foi avisado
+**e** o ticket parou".
+
+**Não** se constrói um helper genérico `isolated(port, fn)`. No instante em que
+ele existe alguém embrulha `tracker.setStatus`, e "não pode tornar o record uma
+mentira" não é coisa que helper cheque. Dois `catch` explícitos, cada um com o
+comentário do argumento, é a versão que um revisor audita.
+
+Fora de escopo, e anotado: `mount()` já isola o throw de `register`/`ready`
+por plugin, mas qualquer problema recusa o boot inteiro — um install com três
+canais onde um tem config ruim não sobe. Fazer um plugin *contribuinte* falhar
+sem derrubar o boot, enquanto um *dono de porta* continua fatal, é o análogo
+disso no boot. Não é o critério desta fase.
+
+---
+
+## (c) O log vira contrato versionado
+
+### O arquivo
+
+`packages/core/events.json`, mantido à mão e vendorado, do mesmo jeito que
+`packages/model-specs/specs.json` fica ao lado do `src` dele:
+
+```json
+{
+  "version": 1,
+  "kinds": {
+    "agent.run": {
+      "says": "An agent ran: which harness, which model, what it cost.",
+      "requires": ["workId", "state"],
+      "detail": {
+        "harness": "string",
+        "model": "string?",
+        "outcome": "string",
+        "durationMs": "number",
+        "costSource": "string",
+        "costUsd": "number?",
+        "tokens": "object?"
+      }
+    }
+  }
+}
+```
+
+Vocabulário mínimo: `string`, `number`, `boolean`, `object`, `array`, com `?`
+de opcional. `requires` diz quais campos de topo aquele kind exige
+(`run.idle` não exige nenhum; os `work.*` exigem `workId`).
+
+`version` sobe em rename ou remoção; acrescentar kind ou campo não sobe.
+**E isso não é checado por máquina** — precisaria de uma regra que compara com
+o commit anterior, que o `sf` não tem. O lock garante que o revisor *vê o
+diff*; quem faz valer a versão é o revisor. É uma garantia real, e não é a
+mesma coisa que um check. Vai dito assim no plano.
+
+### O que impede o arquivo de apodrecer
+
+Declarar o `detail` só ajuda se algo compara a declaração com o que é
+realmente escrito. Um validador puro em `@amy/core`:
+
+```ts
+export function checkEvent(event: Event, contract = EVENT_CONTRACT): string[]
+```
+
+Devolve as violações: kind desconhecido, campo de topo exigido e ausente,
+campo de `detail` exigido e ausente, tipo errado, e **campo de `detail` não
+declarado** — porque se campo novo passa calado, o contrato apodrece do mesmo
+jeito que o JSDoc apodreceu.
+
+Três consumidores, e nenhum deles no caminho quente de produção:
+
+1. `packages/core/tests/event-contract.test.ts` — nomes do arquivo e da união
+   batem, `version` é inteiro positivo, toda descrição é não-vazia.
+2. `RecordingEventLog` (`packages/test-fixtures/src/fakes.ts:103`) passa a
+   **lançar** numa violação. Com isso, cada um dos ~45 arquivos de teste que
+   já dirige o engine e o relay vira teste de conformidade de graça. Esperar
+   trabalho aqui: a primeira rodada vai acusar declarações faltando, e é
+   exatamente esse o serviço.
+3. O probe do e2e lê as linhas reais do `.amy/log/*.jsonl` e checa todas.
+
+### O par que solda nomes em tempo de compilação
+
+Em `packages/core/src/ports/EventLog.ts`, no mesmo arquivo da união pra não
+poderem se separar:
+
+```ts
+export const EVENT_KINDS: Readonly<Record<EventKind, string>> = { ... };
+export function isEventKind(value: string): value is EventKind
+```
+
+`Record<EventKind, string>` solda nos dois sentidos: tirar ou renomear um
+membro da união dá *Property 'x' is missing*; acrescentar um membro dá o mesmo
+erro pro novo; pôr uma chave que não está na união dá *Object literal may only
+specify known properties*.
+
+`isEventKind` ganha consumidor real (o knip exige) em
+`FileEventLog.eventsIn()`, que hoje faz `JSON.parse` e casta pra `Event` **sem
+validação nenhuma** — uma linha corrompida com `kind: "banana"` entra direto no
+`spendSince`. Filtrar no `read()`, **nunca** no `append()`, e a ressalva vai
+escrita: um binário velho lendo log novo descarta as linhas novas caladinho.
+
+### O lock, e o que fica vermelho
+
+Acrescenta `"packages/core/events.json"` no `options.scope` do
+`L2.GENERATED_FILES_ARE_LOCKED` (`.software-factory/policy.yaml:114-118`) e
+roda `sf lock`, que escreve o SHA-256 em
+`.software-factory/locks/generated.lock.json` ao lado dos dois que já estão
+lá. Nada mais é preciso: a regra já tem fixture de mutação, o
+`L5.EVERY_CHECK_HAS_A_MUTATION_TEST` é por *regra* e não por arquivo, e
+acrescentar caminho aperta, então o `L2.POLICY_ONLY_TIGHTENS` fica satisfeito.
+
+Renomear `work.failed` pra `work.errored` sem `sf lock`, passo a passo:
+
+1. `npm run build` quebra primeiro — `EVENT_KINDS` e todo `record("work.failed")`.
+2. `npm run test:coverage` quebra em seguida — o teste de contrato acha
+   `work.failed` no JSON e `work.errored` no código.
+3. `sf check --allow-commands` quebra por último —
+   `L2.GENERATED_FILES_ARE_LOCKED`, severidade crítica, sem grandfathering: o
+   hash não bate. **É este o vermelho que a fase pede.**
+4. `sf lock` reescreve o hash, e o diff de uma linha de hash ao lado de um kind
+   renomeado é o que obriga o revisor a perguntar quem lê aquele kind.
+
+Ressalva honesta: *acrescentar* um kind percorre o mesmo caminho, só que sem
+subir `version`. Lock por cima de um arquivo que lista os kinds não deixa
+adição virar coisa sem cerimônia. Então "acrescentar campo é seguro, renomear é
+breaking" vale como **"os dois são visíveis, só um é breaking"**.
+
+E "falha o gate" aqui é `sf check`, que é *regra*, não gate L3 — verdade via
+`npm run gate`, e o plano do repo diz `npm run gate`, não "sf gate".
+
+Antes de travar, reconferir que todo kind da união é realmente escrito por
+alguém. Hoje sim (`stop.requested` sai do `packages/cli/src/index.ts:189`,
+`agent.handoff` do `AgentRelay.ts:154,175`), mas travar um kind que ninguém
+escreve congela uma mentira num arquivo cujo propósito inteiro é ser verdade.
+E o comentário do `EventLog.ts` cita `amy observe`, **que não existe** — ou
+conserta aqui, ou o contrato nasce mentindo.
+
+---
+
+## O gate
+
+`plugin-serial-engine` é o único pacote grande sem gate, e é o que decide se um
+ticket se perde. E o argumento é o mesmo que
+`plans/the-relay-is-proven-end-to-end.md` faz por si: os caminhos que isto
+existe pra cobrir são caminhos que um dia bom nunca alcança. Nenhum teste
+unitário alcança o `mount()` de verdade, o fan-out com um canal que lança de
+verdade, ou o `plugin-github` contra um `gh` fora do ar — e o que de fato
+quebra é estado de arquivo **entre ticks**, quer dizer, entre processos.
+
+Em `.software-factory/policy.yaml`:
+
+```yaml
+  plugin-serial-engine:
+    activation:
+      - "plugins/serial-engine/src/**"
+      - "plugins/notify-fanout/src/**"
+    evidence: ".software-factory/evidence/plugin-serial-engine.json"
+    plan: "plans/the-engine-fails-out-loud.md"
+    required_assertions:
+      - "engine.warns_once_on_the_first_failure"
+      - "engine.stays_quiet_on_the_middle_attempts"
+      - "engine.warns_once_when_it_recovers"
+      - "engine.carries_on_from_where_it_was"
+      - "engine.keeps_the_attempt_count_across_a_park"
+      - "engine.announces_once_at_the_ceiling"
+      - "engine.finishes_the_tick_when_a_channel_throws"
+      - "engine.records_the_notification_it_could_not_send"
+      - "engine.finishes_the_tick_when_every_channel_throws"
+      - "engine.finishes_the_tick_when_the_log_cannot_be_written"
+      - "engine.every_line_matches_the_contract"
+```
+
+`plugin-notify-fanout/src/**` entra na ativação pelo mesmo motivo que o gate do
+relay lista `agent-kit/src/**`: o fan-out é a outra metade da afirmação de
+isolamento.
+
+**`packages/core/src/ports/EventLog.ts` fica fora da ativação, de propósito.**
+Incluir faria toda adição de kind expirar a evidência: conserto de compilação,
+conserto de teste, `sf lock` **e** re-seal — quatro cerimônias pra uma mudança
+aditiva é onde as pessoas começam a caçar a saída de emergência. O contrato se
+prova por compilação, teste e lock; o gate fica sobre (a) e (b), onde o
+argumento do artefato buildado é real.
+
+### O scenario
+
+`.software-factory/evidence/plugin-serial-engine-scenario.sh`, moldado no
+`plugin-agent-relay-scenario.sh`: mesmo cabeçalho, mesmo `mktemp -d` + `trap`,
+mesmo preflight do `dist/index.js`, mesmo probe `node --input-type=module`
+escrevendo um report JSON.
+
+Derrubar o GitHub no meio do tick: um `gh` falso em `$work/bin` (o scenario do
+relay já faz isso com `claude`/`codex`) cujo comportamento é um arquivo que o
+probe cria e remove entre ticks:
+
+```sh
+if [ -f "$AMY_E2E_GH_DOWN" ]; then
+  echo "gh: could not connect to api.github.com" >&2; exit 1
+fi
+```
+
+O probe monta os plugins **buildados** (`core`, `plugin-file-queue`,
+`plugin-file-store`, `plugin-file-log`, `plugin-github`,
+`plugin-serial-engine`, `plugin-notify-fanout`) mais um plugin de canal
+descartável, definido inline no probe, que contribui pro `CHANNEL_COLLECTION` e
+grava ou lança sob comando. O canal é o falso; o fan-out e o engine são reais,
+exatamente como o scenario do relay falsifica a CLI e não o relay.
+
+A sequência:
+
+1. `touch $AMY_E2E_GH_DOWN`, tick → **um** anúncio, nomeando ticket e falha.
+2. Mais dois ticks → **nenhum** anúncio novo, e o `attempt` do item subiu. O
+   item está atrás do `pollBackoffMs`, então o probe adianta o relógio — `now`
+   é serviço de host passado pro `mount()`, então o probe é dono dele.
+3. `rm $AMY_E2E_GH_DOWN`, tick → **um** anúncio novo dizendo que voltou a
+   andar, e o record no estado que estava mais o movimento que devia.
+4. Canal passa a lançar, tick → o resultado **não** é `failed`, o record andou,
+   e tem uma linha `notify.failed` no `.amy/log/*.jsonl`.
+5. Log impossível de escrever, tick → ainda devolve `worked`.
+6. Todas as linhas escritas passam pelo `checkEvent`.
+
+Armadilha do passo 5, que vale antecipar: `chmod 000` no diretório de log não
+resolve (o construtor do `FileEventLog` faz `mkdirSync`, e root ignora o modo).
+Apontar o caminho do log pra um diretório cujo **pai** é um arquivo comum — aí
+o `mkdirSync` lança `ENOTDIR` de forma determinística pra qualquer um.
+
+Depois: `sf seal plugin-serial-engine`, e o script entra no `npm run e2e`.
+
+### O plano no repo
+
+`plans/the-engine-fails-out-loud.md`, com linha 4 no `plans/next-steps.md`:
+
+> | 4 | [The engine fails out loud](../../plans/the-engine-fails-out-loud.md) | A dependency that goes down produces one warning on the way down, silence while it is down, and one warning when it comes back, and no broken notification channel ever costs a ticket a move |
+
+Cada critério carrega `(proof: assertion:engine.<nome>)` batendo com o
+`required_assertions` — `L3.GATE_COVERS_THE_PLAN` checa um sentido,
+`L4.PLAN_CRITERION_NAMES_ITS_CHECK` o outro.
+
+O item (c) **não** vira critério com `assertion:`: ele é provado por regra
+(`sf check`), não por asserção de scenario. Vai na prosa do corpo, que a regra
+não varre, numa seção de fecho como a que o plano do relay tem.
+
+---
+
+## Ordem
+
+Seis commits, cada um verde no `npm run gate` sozinho. O contrato entra em
+segundo pra que os dois commits seguintes ensaiem o lock de ponta a ponta.
+
+| # | Commit | O que entra |
+| :-- | :-- | :-- |
+| 1 | o attempt atravessa o park | `attempt: item.attempt` no branch de park, comentário corrigido, teste em `tests/budget.test.ts` |
+| 2 | o contrato do log | `events.json`, `EVENT_KINDS`, `isEventKind`, `checkEvent`, filtro no `eventsIn()`, `RecordingEventLog` lançando, teste de contrato, `files` do `package.json` do core, escopo no `policy.yaml`, `sf lock` no mesmo commit |
+| 3 | isolamento | try/catch no `announce()` e no `record()`, teto roteado por `this.announce`, sink do fan-out via `ctx.log`, kind `notify.failed`, `ThrowingNotifier`/`ThrowingEventLog` nas fixtures |
+| 4 | queda e volta | `failureNotice()`, `announceRecovery()`, kinds `work.degraded` e `work.recovered` |
+| 5 | o gate | scenario, `npm run e2e`, `sf seal`, bloco no `policy.yaml`, `plans/the-engine-fails-out-loud.md`, linha no `next-steps.md` — **não dá pra partir**, as quatro regras se referenciam |
+| 6 | README | qualquer promessa nova precisa de `<!-- claim: ... proven-by: plugin-serial-engine -->` (`L4.CLAIM_CITES_ITS_EVIDENCE`) |
+
+Testes existentes que mudam:
+
+- `plugins/serial-engine/tests/Worker.test.ts:248` — "retries after an
+  error, behind a backoff" afirma hoje que **não** houve notificação, e essa
+  afirmação *é* o comportamento velho. Vira "warns once on the first failure
+  and retries behind a backoff", com um único anúncio nomeando ticket e erro.
+  As asserções de fila não mudam.
+- `plugins/serial-engine/tests/Worker.test.ts:260` — enfileira com
+  `attempt: maxItemAttempts - 1`, então `item.attempt !== 0` e o aviso da queda
+  não dispara. **Passa sem mudar**, o que é sinal útil de que a guarda está na
+  condição certa. Apertar pra `toHaveLength(1)`, pra que o teto nunca vire dois
+  anúncios calado.
+
+Testes novos: silêncio no meio; um anúncio na volta com o item reenfileirado em
+`attempt: 0`; "não confunde um park com uma recuperação" (o que fixa o commit
+1); e uma tabela direto no `failureNotice()`.
+
+Dois ratchets pra vigiar: os commits 3 e 4 acrescentam branch no `Worker.ts`, e
+cada `catch` novo precisa do teste dele ou o piso de 83% de branches escorrega
+— é pra isso que servem as fixtures que lançam. **Piso nunca desce.** E se
+`recordFailure` ou `advance` bater no `L1.COMPLEXITY_CEILING`, extrai mais; não
+acrescenta chave no `ratchet.yaml`, que o cabeçalho do próprio arquivo chama de
+"the one move this file exists to make visible in review".
+
+---
+
+## Verificação
+
+```sh
+npm run build && npm test && npm run lint && npm run knip && npm run audit \
+  && sf check --allow-commands && sf verify
+npm run e2e
+```
+
+E, ponta a ponta:
+
+1. `gh` falso fora do ar no meio de um tick: **um** aviso na queda, silêncio
+   nas tentativas do meio, **um** aviso na volta, e o ticket continua de onde
+   estava.
+2. Canal de notificação quebrado: o tick termina, o record anda, e a linha
+   `notify.failed` diz o que não foi entregue.
+3. Log impossível de escrever: o tick termina, e o stderr avisa uma vez.
+4. Renomear um `EventKind` sem `sf lock`: `npm run gate` fica vermelho no
+   `L2.GENERATED_FILES_ARE_LOCKED`. Rodar `sf lock` fecha.
+5. Um park não zera o `attempt` e não é lido como recuperação.
+
+## O que não fica provado, e vai dito
+
+- **"Um aviso na queda" é por ticket, não por queda.** `item.attempt` é por
+  item de fila, então uma queda do GitHub afetando cinco tickets dá cinco
+  avisos de queda e cinco de volta. Um scenario de um ticket só nunca percebe.
+  A versão por **porta** exige estado de saúde por dependência, é
+  materialmente maior, e fica anotada como follow-up pra quando alguém rodar
+  mais que um punhado de tickets.
+- **Não há recuperação depois do teto**, pelo motivo argumentado acima.
+- **Um crash não produz aviso de queda.** `FileQueue.recover()` devolve o item
+  por `rename`, preservando o `attempt`, então um worker morto no meio volta no
+  *mesmo* attempt. Defensável — crash não é queda de dependência — e vale
+  escrito.
+- **A convenção de `version` é do revisor, não da máquina**, pelo motivo da
+  seção (c).
+- **Binário velho lendo log novo descarta as linhas que não conhece**, que é o
+  preço de filtrar por `isEventKind` no `read()`.

--- a/plans/next-steps.md
+++ b/plans/next-steps.md
@@ -6,6 +6,9 @@ weekly, and the file an agent reads to know what is next.
 A plan not listed here is written, valid, and off the critical path until its
 precondition exists. Park it in the second table rather than deleting it.
 
+O roadmap inteiro, com as treze fases e o estado de cada uma, está em
+[the roadmap](the-roadmap.md). Este arquivo é a ordem de execução dele.
+
 | # | Work | Exit condition |
 | --- | --- | --- |
 | 1 | [Every plugin is proven end to end](every-plugin-is-proven-end-to-end.md) | Changing a plugin's source turns the build red until its end-to-end run happens again |

--- a/plans/the-roadmap.md
+++ b/plans/the-roadmap.md
@@ -1,0 +1,742 @@
+# O roadmap
+
+Este é o documento que dirige o trabalho todo. Ele viveu em
+`~/.claude/plans/` — fora de qualquer repo, sem exit condition validada e sem
+estar em nenhuma ordem de execução, que é exatamente o problema que a fase 12
+descreve: o sf não via o plano que dirige o sf. Agora vê.
+
+Está em português porque foi escrito assim, e traduzir 800 linhas não é o
+trabalho de hoje. O resto do repositório é em inglês.
+
+## Onde cada fase está
+
+| Fase | Estado | O que responde por ela |
+| :-- | :-- | :-- |
+| 1 a 5 | entregues | os guardrails, o log, a config por plugin, a contabilidade do agente e o relay estão de pé e cobertos por teste |
+| 6 | entregue, com a resposta trocada | [what runs is not this repo](what-runs-is-not-this-repo.md), e o binário compilado sai em [plugins are installed, not compiled in](plugins-are-installed-not-compiled-in.md) |
+| 7 | entregue | o budget e o teto de reviewer, provados pelo gate `plugin-agent-relay` |
+| 8 | entregue pela metade | a escada de skills por passo existe no `@amy/plugin-agent-relay`; o scaffolder não |
+| 9 | entregue | [the engine fails out loud](the-engine-fails-out-loud.md), gate `plugin-serial-engine`, e o desenho em [docs/design](../docs/design/the-engine-fails-out-loud.md) |
+| 10 | próxima | ainda sem plano próprio neste diretório |
+| 11 | depois da 10 | ainda sem plano próprio |
+| 12 | depois da 11 | ainda sem plano próprio; sobe para o software-factory |
+| 13 | parada | esperando as três anteriores |
+
+O que cada fase entregue provou de verdade está no gate dela, não aqui: uma
+linha nesta tabela envelhece, um digest expira.
+
+**Exit condition:** cada fase de 10 a 13 tem um plano próprio neste diretório,
+listado em [next-steps.md](next-steps.md), ou está parada lá com a
+precondição que espera escrita; e cada fase marcada entregue acima nomeia o
+gate ou o plano que responde por ela.
+
+---
+
+## Contexto
+
+O amy está em `nicolasmelo1/automate-my-work` (privado): **20 pacotes `@amy/*`
+(24 no fim desta fase), 413 testes, e as regras do `sf` todas provadas por
+fixture de mutação**, `amy doctor` dando `ready`, e o `amy discover` lendo o
+Linear de verdade pelo engine montado. O core não conhece domínio: ele é dono do
+catálogo de ações e o workflow é só a ordem delas.
+
+**Feito:** fase 1 (guardrails, incluindo a regra local que impede o core de
+conhecer um workflow), fase 2 (log de eventos e o freio de mão que mata
+processo em voo, verificado de outro processo), fase 3 (cada plugin declara
+sua config, o notifier quebrado em três, README em cada pacote, e o `mount()`
+carregando plugins do config em vez de o CLI construir adapter na mão).
+
+**Feito:** fase 4 (o envelope `AgentRun`, o `@amy/model-specs` vendorado com
+preço de 10 modelos, e o custo com `costSource` honesto). Um bug real só
+apareceu contra envelope de verdade: o `ephemeral_1h_input_tokens` era
+ignorado e o custo calculado saía 60% curto.
+
+**Feito:** fase 5 (troca de harness por quota, escalonamento de modelo por
+falha, e o relay como único dono da porta `agent`). O e2e achou um bug que
+teste unitário não pegava: `triage` e `addressThreads` lançavam quando a
+corrida não completava, então o relay nunca via a causa e o escalonamento
+inteiro era pulado justamente quando era necessário.
+
+**Feito:** fase 6 (`amy` virou binário instalado em `~/.local/bin`, e o log
+carimba qual build escreveu cada linha). O bug que a fase pegou antes de
+existir: o loader resolvia plugin com `import(spec)`, que nenhum bundler
+consegue seguir, então o primeiro binário compilado teria montado **zero**
+plugins passando todos os 512 testes.
+
+**Em andamento:** a fase 7, budget e teto de reviewer.
+
+O que amarra o resto: **tudo tem que ser reportável pro logion, e nada tem
+que reportar.** Reportável não é reportando. O logion é opcional, e é essa a
+ideia de tudo ser plugin: quem instala o amy e quer o logion, ótimo; quem não
+quer, também. O tracking acontece porque eu tenho o logion instalado, não
+porque o amy quer. Uma pessoa que baixou o amy hoje não precisa abrir issue
+no amy, nem saber que o software-factory e o logion existem.
+
+O que o logion ganha com isso é real: ele vê o que funciona e o que não
+funciona, e depois o amy roda em outra máquina com outros agentes e reporta
+também, o que prova que dois agentes usando um sistema melhoram ele mais que
+um sozinho. Mas isso é um consumidor do log, não uma condição para o amy
+andar.
+
+### A espinha: um log de eventos
+
+Quatro dos sete pedidos leem ou escrevem a mesma coisa: acompanhar o fluxo
+(6), parar em caso de falha (6), controlar gasto (7), e reportar pro logion.
+Se cada um tiver seu próprio estado, eles vão discordar entre si.
+
+Então tudo passa por **um log append-only** em `.amy/log/<data>.jsonl`, uma
+linha por evento, e todo o resto é leitura dele. `amy observe` lê. O ledger de
+budget agrega. O reporter do logion projeta. Uma fonte, quatro consumidores.
+
+### A restrição que o logion impõe, e que vira guardrail
+
+Li o contrato: `packages/cli/cli/usage/observations.py` define o envelope
+`UsageObservation`, e as regras do
+`packages/agent-companion/references/use-observation-and-feedback.md` são
+explícitas:
+
+> Never put a prompt, repository name, source code, customer data, or personal
+> information in a feedback body.
+>
+> Never enable a harness integration on your own. Show the diff, then ask.
+>
+> `DO_NOT_TRACK=1` forces `off` everywhere — do not try to work around it.
+
+O amy trabalha em repos do meu empregador, com ID de ticket real e nome de
+colega.
+Então o reporter **não pode** mandar nome de repo, conteúdo de ticket ou
+pessoa. Isso não pode depender de disciplina: vira **regra local do sf** que
+falha o build. É o dogfood na veia, o software-factory checando se o amy
+respeita o contrato do logion.
+
+O que sai é só: qual plugin, qual versão, `outcome` de
+`completed|failed|abandoned|unknown`, `duration_bucket` de
+`instant|seconds|minutes|hours`, `task_class`, e escopo opaco. Modo default
+`off`, e o amy mostra o diff e pergunta antes de ligar.
+
+**Decisões tomadas:** escalonamento pela causa (rate-limit troca de harness,
+falha escala modelo). Handoff continua de onde o agente anterior parou.
+CodeForge entra como plugin de agente, pinado no meu fork enquanto os PRs não
+mergeiam.
+
+---
+
+## Fase 1: os guardrails que protegem o resto
+
+Primeiro, porque tudo depois fica mais seguro. O `sf` tem 36 regras e o amy
+usa 14.
+
+**Regra local, e é a mais valiosa que o amy pode ter.** A arquitetura que
+acabamos de construir hoje é sustentada só por disciplina. Em
+`.software-factory/rules/core-stays-ignorant.yaml`:
+
+```yaml
+id: L0.CORE_STAYS_IGNORANT
+layer: L0
+severity: high
+title: The core imports no workflow and no plugin
+statement: Nothing under packages/core/src imports an @amy/workflow-* or @amy/plugin-* package.
+why: >-
+  The core owns the catalogue of actions and nothing else. The moment it
+  imports a workflow it learns a domain, and every workflow after the first
+  becomes a fork rather than a package. This is the one invariant the whole
+  plugin model rests on, and it is one import away from being lost.
+fix: Move the type into the workflow package, or make the core generic over it.
+ratchet: allowlist
+check:
+  kind: text_pattern
+defaults:
+  scope: ["packages/core/src/**"]
+  forbidden:
+    - regex: 'from "@amy/(workflow|plugin)-'
+      message: "The core must not know a workflow or a plugin."
+```
+
+**Do catálogo, o que se aplica:**
+
+| Regra | Por que no amy |
+| :-- | :-- |
+| `L0.NO_CROSS_LAYER_IMPORT` | força importar do barrel do pacote, não de `src/` fundo |
+| `L0.EXCEPTIONS_HAVE_ONE_HOME` | hoje é `throw new Error` solto em 9 pacotes |
+| `L2` (as 7) | locks: catálogo, policy, dependências, artefatos derivados, e nenhuma exceção permanente |
+| `L6.DEAD_CODE_IS_DETECTED` | "não ter código redundante", via `knip` |
+| `L6.DEPENDENCY_VULNERABILITIES_ARE_SCANNED` | `npm audit` no CI |
+| `L6.SECRETS_ARE_SCANNED` | há um `.env` com chave do Linear nesse repo |
+| `L6.INSECURE_PATTERNS_ARE_SCANNED` | `eslint-plugin-security` ou semgrep |
+| `L6.WORKFLOWS_ARE_SCANNED` | `zizmor` no `.github/workflows` |
+
+Não aplicáveis, e não vou fingir: `L0.ONE_ENTRYPOINT_PER_FILE` e
+`L0.PERSISTENCE_STAYS_IN_REPOSITORIES` (não há superfície HTTP nem banco), e
+as três de concorrência do L6 (não há lock nem thread). Habilitar qualquer uma
+delas cai em `L5.NO_INERT_RULE`, que é justamente a regra que impede fingir
+cobertura.
+
+**"Garantir que testamos tudo":** `vitest --coverage` com piso por pacote,
+dentro do gate. Cobertura não é regra do sf, é comando do gate.
+
+Vale rodar o `sf interview` (a skill `factory-init` já está instalada) e
+re-inicializar com `--answers`: o amy é `kind: cli`,
+`architecture: hexagonal`, `errors_home: per-module`, e as regras saem
+tayloradas em vez de genéricas.
+
+`L3` fica pra fase 8, porque `L3.GATE_COVERS_THE_PLAN` precisa de um plano com
+critérios que nomeiem checks, e esses critérios são o trabalho das fases 2 a 7.
+
+## Fase 2: o log de eventos, e o freio de mão
+
+`@amy/core` ganha `EventLog` (porta) e `@amy/plugin-file-log` a
+implementação, `.amy/log/<data>.jsonl`. Toda transição, toda ação, todo
+resultado de agente, todo gasto vira uma linha.
+
+`amy stop` escreve `.amy/STOP`. O engine checa antes de reivindicar item da
+fila e antes de despachar ação, e mata processo filho em voo. Determinístico:
+existe o arquivo, não começa trabalho novo. `amy start` remove.
+
+Ficam duas paradas distintas, e a diferença importa: `amy stop` é o freio de
+mão que tu puxa, e a parada por budget da fase 6 é automática e temporária.
+
+## Fase 3: `amy.conf`, e cada plugin dono da sua config
+
+Hoje o `.amy/config.yaml` é um objeto único que o CLI conhece inteiro. Passa a
+ser por plugin, e **cada plugin declara o schema da sua**:
+
+```yaml
+plugins:
+  "@amy/plugin-linear":
+    workingStatusName: In Progress
+    repoByTeam: { TBO: acme/backend }
+  "@amy/plugin-notify-hermes":
+    target: slack:nico-and-his-bot
+  "@amy/plugin-agent-relay":
+    ladder: [claude, codex, hermes]
+```
+
+`Plugin` ganha `configSchema` opcional, e o loader valida na montagem. Config
+desconhecida ou inválida falha alto, no boot.
+
+**E o rename que tu pediu.** O `plugin-slack-hermes` está errado em dois
+sentidos: não é específico de Slack, e junta três canais que não são do Hermes.
+Quebra em:
+
+- `@amy/plugin-notify-fanout` — o fan-out genérico, sem canal nenhum
+- `@amy/plugin-notify-hermes` — o canal Hermes, alvo configurável
+- `@amy/plugin-notify-inbox` — arquivo em disco mais notificação de desktop
+- o canal que comenta no ticket vai pro `@amy/plugin-linear`, que é quem é o tracker
+
+## Fase 4: o agente sabe dizer o que aconteceu com ele
+
+Pré-requisito das fases 5 e 6. Sem isso, as duas são chute.
+
+**Os três harnesses expõem uso por invocação**, o que derruba o risco que este
+plano assumia. Confirmei os três:
+
+| Harness | Invocação | Tokens | Custo | Classificação |
+| :-- | :-- | :-- | :-- | :-- |
+| claude | `-p --output-format json` | `usage` e `modelUsage` | `total_cost_usd` | `api_error_status`, `stop_reason`, `is_error` |
+| codex | `exec --json` (JSONL de eventos) | evento de uso, nomes variam por versão | calculado | exit code e stream |
+| hermes | `--usage-file PATH` | `input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_write_tokens` | `estimated_cost_usd` | exit code e `guardrail` |
+
+A fase 4 faz **só o claude**. Codex e Hermes são a fase 5, e o contrato nasce
+com a forma deles em mente.
+
+### O contrato
+
+Um envelope só, genérico sobre o que o método já devolvia, para não mudar três
+assinaturas de três formas diferentes:
+
+```ts
+export type AgentOutcome = "completed" | "failed" | "rate-limited" | "abandoned";
+
+export interface TokenUsage {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+}
+
+/** De onde veio o número, porque estimativa e medição não são a mesma coisa. */
+export type CostSource = "reported" | "computed" | "unknown";
+
+export interface AgentRun {
+  outcome: AgentOutcome;
+  harness: string;
+  model: string;
+  /** Ausente quando o harness não diz. Nunca estimado. */
+  tokens?: TokenUsage;
+  costUsd?: number;
+  costSource: CostSource;
+  durationMs: number;
+  /** Verbatim, para o próximo prompt. */
+  output: string;
+}
+
+export interface AgentResult<T> {
+  value: T;
+  run: AgentRun;
+}
+```
+
+`triage`, `implement` e `addressThreads` passam a devolver
+`AgentResult<TriageOutcome>`, `AgentResult<AttemptOutcome>` e
+`AgentResult<ThreadVerdict[]>`. O engine loga o `run` e passa o `value`
+adiante, então cada call site muda numa linha.
+
+**`costSource` é a peça que eu não teria posto sozinho, e é do Hermes.** Ele
+grava `estimated_cost_usd` junto com `cost_source` e `cost_status`, ou seja,
+ele diz quando o número é estimativa. Sem esse campo, um custo calculado de
+tabela desatualizada e um custo reportado pelo harness ficam
+indistinguíveis no log e no report pro logion.
+
+### `@amy/model-specs`
+
+Pacote próprio, porque preço não é kernel e não é domínio, e porque a fase 6
+também lê. Modelado no `ModelsDevPricingInfo` do CodexBar, que tem uma
+sutileza que eu não teria previsto: **o preço muda acima de um limiar de
+tokens**.
+
+```ts
+export interface ModelSpec {
+  provider: string;
+  model: string;
+  inputPerToken: number;
+  outputPerToken: number;
+  cacheReadPerToken?: number;
+  cacheWritePerToken?: number;
+  contextWindow?: number;
+  /** Acima deste tanto de input, as taxas trocam. */
+  thresholdTokens?: number;
+  aboveThreshold?: Omit<ModelSpec, "provider" | "model" | "thresholdTokens" | "aboveThreshold">;
+}
+
+export function specFor(model: string): ModelSpec | undefined;
+export function costOf(spec: ModelSpec, tokens: TokenUsage): number;
+```
+
+`specs.json` **vendorado e versionado**, sem rede no caminho que decide gasto.
+Mais `amy models refresh`, que puxa do models.dev quando eu mandar, e
+`amy models show`. O `L2.GENERATED_FILES_ARE_LOCKED` tranca o `specs.json`,
+então um refresh aparece no diff como ato deliberado em vez de drift.
+
+**Normalizar o id do modelo importa.** O claude reporta
+`claude-opus-5[1m]` no `modelUsage`, com sufixo de janela. A busca tem que
+normalizar, ou toda linha cai em `unknown` e o custo calculado nunca existe.
+
+### Onde o custo vem de cada lugar
+
+Ordem, e sem misturar:
+
+1. o harness reportou custo, e ele sabe do plano e dos descontos que eu não
+   sei → `costSource: "reported"`
+2. o harness reportou só token, e a tabela tem o modelo →
+   `costSource: "computed"`
+3. nem um nem outro → `costUsd` ausente e `costSource: "unknown"`
+
+Nunca estimar contagem de token. Se o harness não disser, `tokens` fica
+ausente, e a fase 6 conta só o que sabe.
+
+## Fase 5: trocar de agente e escalar modelo
+
+### Contexto: por que a fase existe, e o que já está de pé
+
+Um harness só é um ponto único de falha em cima de uma quota que não é minha.
+Quando o claude bate no limite às 3 da manhã, o ticket morre ali. A fase 4 deu
+a peça que faltava para resolver isso sem chutar: o `AgentRun` agora diz
+**por que** uma tentativa não deu certo, e `rate-limited` e `failed` pedem
+reações opostas.
+
+Já escrito e compilando: o `@amy/agent-kit` (a interface `Harness`, o
+`HarnessAgent` com os prompts que saíram verbatim do `ClaudeAgent`, e o
+`NamedAgent`), os três harnesses (`ClaudeHarness`, `CodexHarness`,
+`HermesHarness`), e o `AgentRelay` com a política. Duas convenções opostas de
+`input_tokens` foram confirmadas contra envelope real, e é por isso que os
+parsers não são compartilhados:
+
+- codex **inclui** o cache no total, então `input = 17571 - 11008`
+- hermes **exclui**, e `7466 + 8704 + 5 = 16175` fecha com o total dele
+
+### A política, e as duas decisões que a fecham
+
+```text
+rate-limited  -> pula todo o resto daquele harness, vai pro proximo harness
+failed        -> proximo modelo do mesmo harness, e quando acabarem,
+                 o proximo harness
+abandoned     -> para a escada, ponto
+esgotou tudo  -> a acao falha e o workflow escala pra ti
+```
+
+Confirmado: **falha anda na escada inteira**, os dois eixos, porque um bug do
+harness não se resolve trocando de modelo dentro dele. O preço é que um ticket
+impossível queima os três antes de me chamar, e o teto da fase 6 é o que
+limita isso.
+
+E `abandoned` **não** avança, que é a decisão que não estava no plano
+original. Um `abandoned` vem de duas causas: binário que não existe, ou o
+`amy stop` matando o filho. Retentar a segunda subiria um processo novo no
+instante em que eu puxei o freio de mão. Binário faltando é trabalho do
+`amy doctor`, antes de um ticket ser tocado.
+
+O handoff continua de onde o anterior parou: a árvore fica como está e o
+próximo recebe o texto do anterior mais "isso é trabalho meio feito, continue,
+não comece de novo". Só o `implement` carrega esse contexto, porque é o único
+método da porta com canal pra isso.
+
+### A inversão que faz três harnesses coexistirem
+
+Uma porta tem um dono só, então três harnesses querendo ser *o* `agent` se
+recusam a montar juntos. Cada harness passa a **contribuir** um `NamedAgent`
+por tier de modelo (`claude:sonnet`, `claude:opus`, `codex:gpt-5`), e o relay
+é o único que monta a porta, lendo as contribuições **na primeira chamada** e
+não na montagem, senão a ordem dos plugins passaria a importar.
+
+Ladder vazia significa tudo que foi contribuído, na ordem de montagem. Um nome
+que ninguém contribuiu é **recusado** em vez de ignorado: uma ladder com typo
+ficaria mais curta do que eu acredito, e o primeiro sintoma seria um ticket
+escalando sem motivo.
+
+### O que falta, em ordem
+
+1. **Os 7 erros de build**, todos em `plugin-agent-relay/src/plugin.ts` e de
+   duas causas: importei `Agent` de `@amy/core`, onde ele não vive (é
+   `@amy/workflow-ticket-to-qa`), e deleguei com rest-spread, que o
+   TypeScript não estreita. Vira três métodos explícitos. O `registry.port`
+   aceita `object`, então o proxy não precisa do tipo pra montar, só pra eu
+   não errar a forma.
+2. **`@amy/agent-kit` na dependência do relay**, que está faltando no
+   `package.json` dele.
+3. **`plugin.ts` e `config.ts` do codex e do hermes**, no formato do claude:
+   um `NamedAgent` por tier, `contribute(AGENT_COLLECTION, ...)`.
+4. **A fiação, e é aqui que mora o estrago.** O `unmetNeeds` recusa a
+   montagem quando a porta de uma ação não tem dono, e o claude acabou de
+   parar de montar `agent`. Então **sem o relay no `DEFAULT_PLUGINS`, todo
+   boot passa a ser recusado.** Entra o relay no default; codex e hermes ficam
+   opt-in, montados quando a ladder nomeia eles, no mesmo padrão que o
+   `notify-hermes` já usa. Install novo continua se comportando como hoje.
+   `AmyConfig.agent` ganha `ladder`, e o `pluginSlices` passa ela adiante.
+5. **`tests/ClaudeAgent.test.ts`** ainda importa a classe que virou
+   `ClaudeHarness`. Reescreve como `ClaudeHarness.test.ts`.
+6. **Testes.** Não é opcional: o piso de cobertura é global (87/83/85/89) e
+   cinco arquivos novos sem teste derrubam o gate. O `nextRung` é função pura,
+   então a matriz de política testa direto. Mais o `AgentRelay` com harness
+   falso, o `CodexHarness` e o `HermesHarness` contra os envelopes reais que
+   eu já capturei, e o `HarnessAgent`.
+7. **README nos quatro pacotes**, e o do relay explica a política pela causa.
+8. **A prova e2e do relay**, em `.software-factory/evidence/`, no formato que
+   o `plugin-file-queue` estabeleceu: `dist/index.js` importado de outro
+   processo, com executáveis de mentira no `PATH` (um que sai 429, um que sai
+   1, um que funciona). É o que o item 5 da verificação sempre pediu, e não
+   precisa de credencial nenhuma. Sela com `sf seal`.
+9. **`sf lock`** no mesmo commit, porque as dependências mudaram, e o gate.
+
+Cada troca é uma linha `agent.handoff` no log, com harness, modelo, causa e
+qual eixo andou. É disso que sai o `reliability` do report pro logion.
+
+## Fase 6: o que executa deixa de ser este repo
+
+Primeiro, e isso mudou de lugar. Tudo o que vem depois passa a ser testado
+como coisa **instalada** em vez de coisa rodada de dentro do checkout, e o
+risco de vazar algo do meu empregador neste repo acaba antes de existir em
+depois.
+
+Passa a haver duas coisas distintas: **o código fonte**, que é este repo, e
+**o que roda**, que é um binário instalado na máquina. Bun, não por
+velocidade, mas porque ele compila para um executável só.
+
+Consequência que decorre disso e que precisa existir junto: **o log grava
+qual build produziu cada linha.** Sem isso, "melhoramos o repo" e "o que
+falhou ontem" deixam de ser comparáveis, e o report pro logion passa a somar
+versões diferentes no mesmo número.
+
+## Fase 7: budget, e o teto de reviewer
+
+`.amy/budget.json`, agregado do log, com janelas configuráveis:
+
+```yaml
+"@amy/plugin-agent-relay":
+  budget:
+    perFiveHours: { tokens: 2000000, costUsd: 20 }
+    perWeek: { tokens: 30000000, costUsd: 150 }
+    stopAt: 0.9   # a que fracao do teto para de comecar trabalho novo
+```
+
+**Dois tetos, e o primeiro que estourar para.** Token é o que a assinatura
+limita e é o que bloqueia às 3 da manhã; USD é o que importa se o gasto for
+por API.
+
+Uma linha do log com `costSource: "unknown"` conta **token** e não conta USD.
+Somar um custo que ninguém mediu no teto em dólar seria inventar o número que
+decide a parada. E `costSource: "included"` conta zero de verdade, porque a
+assinatura já pagou.
+
+Checado **antes** de cada chamada, não depois. Passou do `stopAt`, o engine
+não começa ação nova e reenfileira com atraso até a janela virar. O ticket
+nunca é perdido, só estacionado.
+
+**E o teto de reviewer, que é gasto de outra moeda.** Ninguém aqui quer abrir
+vinte PRs na cara dos colegas. Isso já quase existe: o `machine.ts` escolhe
+por `leastLoadedReviewer(roster, obs.reviewLoad)` e já tem o caminho "nenhum
+reviewer disponível, espera e avisa uma vez". Teto por pessoa é um campo na
+`Policy` e uma condição a mais nesse mesmo branch:
+
+```yaml
+policy:
+  maxOpenReviewsPerReviewer: 2
+```
+
+Estourado o teto de todos, o PR fica **aberto e sem ninguém atribuído**, e o
+ticket espera na fila. O trabalho continua andando; só a fila de revisão
+humana respeita a paciência de quem revisa.
+
+## Fase 8: uma skill por evento, que é o relay generalizado
+
+O pedido é poder escolher quem faz cada passo: um `code-review` que pode ser
+`/antikus-code-review` ou `/logion`, e usar o logion de verdade em vez de só
+reportar pra ele.
+
+Isso é **a mesma máquina da fase 5**. Contribuições nomeadas, uma escada, e
+recusa no boot. `@amy/plugin-skill-relay` monta uma porta `skill` e compõe o
+que os plugins contribuíram, exatamente como o `AgentRelay` compõe
+`NamedAgent`. O `nextRung` provavelmente sai de lá para um pacote comum.
+
+```yaml
+skills:
+  code-review: [/antikus-code-review, /logion]
+  triage: [/logion]
+```
+
+**Skill nomeada que não está instalada é recusa no boot**, nomeando o que
+havia para escolher, igual à ladder de agentes. Config é verdade ou não é.
+
+E o ponto que fecha o ciclo do logion: se a skill é de terceiro, usamos e
+reportamos uso, e na segunda passagem ela entra na escada mais alto porque
+**se provou**. Se a skill é nossa e falhou, isso não é report, é trabalho: cai
+na fase 10.
+
+### Scaffolder é uma skill, e é a razão mais forte pra fase existir
+
+Toda convenção que uma regra checa é uma convenção que algo poderia ter
+escrito. Chega uma task pedindo uma query, um router e um service; a forma dos
+três já era conhecida antes do agente começar. Pagar modelo pra redescobrir
+isso é a maneira mais cara de obter algo que ninguém tinha dúvida sobre.
+
+Então um scaffolder entra na escada como qualquer skill: `code-scaffold`
+antes de `implement`, e o agente chama uma CLI em vez de escrever a mesma
+coisa de novo. **Nada disso mora no amy**, porque a forma de um router de um
+empregador é dele, não deste repo. O amy só chama.
+
+A parte difícil, que é provar que o gerador continua correto quando a
+convenção muda, é trabalho do software-factory e virou plano lá:
+`plans/scaffolds-are-proven-in-micro-sandboxes.md`. O resumo: a regra e o
+scaffolder são duas declarações da mesma convenção, e o build falha no
+instante em que discordam.
+
+E a economia deixa de ser conversa: a fase 7 já grava token por ação, então
+um passo scaffoldado custa perto de zero contra alguns milhares de um agente
+escrevendo à mão. Isso é exatamente a dimensão `token-efficiency` do report da
+fase 11, medida em vez de afirmada.
+
+## Fase 9: falhar em voz alta
+
+O sistema vai falhar. A API do GitHub vai cair, o Claude vai sair do ar. Não
+tem shutdown elegante nenhum: falha, avisa, e segue.
+
+Três mudanças, e uma delas é só generalizar o que já existe:
+
+**Avisa na primeira falha, e continua tentando por baixo.** Hoje o engine
+tenta até `maxItemAttempts` e só avisa no fim, o que é o comportamento errado:
+você descobre na quinta tentativa. Passa a avisar na queda, ficar em silêncio
+nas tentativas do meio, e avisar de novo quando voltar. Um aviso na queda, um
+na volta.
+
+**Um plugin que morre não derruba o tick.** É literalmente a regra que o
+`FanOutNotifier` já aplica a canal de notificação: um que falha não para os
+outros, e só lança quando todos falharam. Sobe de canal para plugin em geral.
+
+**O log vira contrato versionado.** A partir do momento em que quatro
+harnesses e uma UI leem `.amy/log/*.jsonl`, o `EventKind` deixa de ser detalhe
+interno. Acrescentar campo é seguro, renomear é breaking, e isso quer um lock
+do mesmo naipe do que tranca o `specs.json`.
+
+## Fase 10: a fila aberta, e a auto-melhoria
+
+**A fila aceita coisa que não é ticket do Linear.** `EnqueueRequest` já é
+`{workId, reason}`, genérico. O bloqueio é um só e é pequeno: `observe()`
+chama `requireTicket(record.id)`, então hoje todo item precisa existir no
+tracker. Passa a haver trabalho injetado, por pasta ou por comando, que não
+tem ticket e não precisa.
+
+**E o erro passa a melhorar os meus repos.** Qualquer falha, ponto de atrito
+ou limitação que aparecer no fluxo entra como PR de `plans/` no repo certo:
+software-factory, automate-my-work ou logion. Não usa Linear; usa a `plans/`
+que os três já têm, com `next-steps.md` já ordenado nos três. Quem trabalha
+nesses planos é um agente em outra máquina.
+
+**O que impede isso de virar spam já existe, e é o próprio sf.** Um plano
+precisa de exit condition e de uma linha no `next-steps.md` ordenado, senão o
+`L4.PLAN_DECLARES_EXIT_CONDITION` fica vermelho. Isso é barra de qualidade e
+limitador de vazão de graça. A lógica do teto de reviewer vale aqui também,
+com número diferente.
+
+Três memórias que se complementam, e nenhuma delas é um markdown que alguém
+tem que lembrar de atualizar:
+
+| Repo | Que memória é | Como expira |
+| :-- | :-- | :-- |
+| logion | o que funciona e o que não funciona | receipt contra contrato pinado |
+| software-factory | o que o agente tem que provar | digest que expira quando o path muda |
+| amy | a ordem das tarefas e o que já custou | log append-only, agregado por janela |
+
+## Fase 11: o reporter do logion, opcional e fora do default
+
+Vai para o fim porque é o único que não desbloqueia nada, e porque **logion é
+opcional**. Quem instala o amy hoje não precisa saber que o logion existe. O
+tracking acontece porque eu tenho o logion instalado, não porque o amy quer.
+
+`@amy/plugin-logion-reporter`, **fora do conjunto default**, projetando o log
+no envelope `UsageObservation`. Modos do próprio logion e default `off`.
+`DO_NOT_TRACK=1` força `off` e não se contorna. Ligar mostra o diff e
+pergunta.
+
+Reportável não é reportando: o log é a costura, e o reporter é um consumidor
+entre outros. Isso vira duas regras locais do sf:
+
+- nenhum pacote `@amy/*` importa logion, exceto o próprio reporter, na forma
+  da `CORE_STAYS_IGNORANT`
+- nada em `packages/plugin-logion-reporter/src/**` cita nome de repo, padrão
+  de ID de ticket, e-mail ou caminho de checkout
+
+As quatro dimensões saem de dado que o amy já tem, não de opinião:
+`reliability` das trocas de agente, `token-efficiency` do budget,
+`usefulness` de chegar a QA ou escalar, `tool-safety` do gate ficar verde sem
+intervenção.
+
+## Fase 12: o sf gerencia plano de harness
+
+Tem um exemplo vivo agora: a `L4.PLAN_DECLARES_EXIT_CONDITION` tem escopo
+`plans/*.md` **dentro do repo**, e o plano que dirige todo este trabalho está
+em `~/.claude/plans/kind-strolling-castle.md`, fora de qualquer repo, sem exit
+condition validada e sem estar em nenhum `next-steps.md`. O sf não vê o plano
+que dirige o sf.
+
+Então o sf passa a reconciliar o diretório de planos do harness, qualquer
+harness, com o `plans/` do repo, e a gerenciar isso sozinho. Vai upstream no
+software-factory, porque não é específico do amy.
+
+## Fase 13: CodeForge, e depois o ARC-AGI
+
+`@amy/plugin-codeforge`, pinado no meu fork enquanto os PRs #4 a #7 não
+mergeiam. A ação `implement` passa por spec, `plan generate` e `run`, que faz
+sentido justamente onde uma chamada só é fraca: ticket grande.
+
+**E aí o ARC-AGI-1, pelo motivo certo.** O que transfere é forte: o gate
+determinístico é literalmente o que o ARC pede, porque um candidato tem que
+reproduzir todos os pares de treino e isso é verificável sem opinião. O relay
+dá diversidade de modelo. O logion dá "essa heurística se provou em N
+tarefas", que é a memória que solver de ARC precisa e quase nenhum tem.
+
+O que não transfere é o workflow: PR, review e QA não significam nada ali.
+Precisa de um segundo workflow que não compartilha ação nenhuma com o
+primeiro.
+
+E é aí que está o valor: **um segundo workflow que reusa fila, gate, relay,
+budget e report e não reusa nenhuma ação é a prova mais forte que o modelo de
+plugin pode receber.** O argumento do logion deixa de ser "funciona no meu
+trabalho" e passa a ser "funciona em dois domínios sem código em comum".
+
+Sobre placar, e sem prometer número: o score vem do solver, não do arcabouço.
+
+## Riscos, ditos na cara
+
+**Dez fases é muito.** As fases 1, 2 e 4 são o que destrava o resto: guardrail,
+log e um agente que sabe se reportar. Sem a 4, as fases 5, 6 e 7 são chute.
+
+**A tabela de preço envelhece, e um preço errado é uma decisão de parada
+errada.** Mitigação: o teto de token não depende da tabela, então o amy
+continua parando na hora certa mesmo com preço velho. É o teto em USD que
+sofre, e o `costSource` no log deixa visível qual linha foi calculada em vez
+de reportada.
+
+**A forma do envelope do codex varia por versão.** O CodexBar lê o uso dele
+com fallback entre vários nomes de chave, o que é sinal de que mudou mais de
+uma vez. O parser do codex nasce tolerante, e um envelope que ele não entende
+vira `tokens` ausente em vez de zero, porque zero é um número e ausente é a
+verdade.
+
+**O envelope do logion pode mudar.** Ele está em beta. Mitigação: o
+`integration_version` já está no envelope, e o reporter é um pacote só, então
+é um lugar pra ajustar.
+
+**`amy stop` não pode ser cooperativo demais.** Se um agente estiver rodando
+em subprocesso, escrever `.amy/STOP` não mata o filho por si. A fase 2 tem que
+matar o processo, não só recusar trabalho novo, senão o freio de mão não freia.
+
+---
+
+## Verificação
+
+Gate, sobre todos os workspaces:
+
+```sh
+npm run build && npm test && npm run lint && sf check && sf verify
+```
+
+Por fase:
+
+1. A regra `L0.CORE_STAYS_IGNORANT` tem que **falhar** quando eu adicionar um
+   `import ... from "@amy/workflow-ticket-to-qa"` no core, e passar depois de
+   tirar. `sf verify` provando o fixture de mutação de cada regra nova. Regra
+   habilitada que não consegue produzir finding cai em `L5.NO_INERT_RULE`.
+2. `amy stop` com um `amy run` em voo: o processo filho morre e a fila não
+   avança. `amy start` volta a andar, e o ticket continua de onde estava.
+3. Config de plugin inválida faz o `amy doctor` falhar nomeando o plugin e o
+   campo. Plugin sem config nenhuma continua montando.
+4. Um `implement` **real** grava uma linha `agent.run` cujos tokens e custo
+   batem com o `usage` e o `total_cost_usd` do envelope daquela invocação, com
+   `costSource: "reported"`. Exit não-zero classifica `failed`; um
+   `api_error_status` de 429, simulado, classifica `rate-limited` e não
+   `failed`. O `costOf` contra a tabela vendorada reproduz um número calculado
+   à mão, incluindo um caso acima do `thresholdTokens`. Um `modelUsage` com
+   sufixo de janela, tipo `claude-opus-5[1m]`, encontra o spec em vez de cair
+   em `unknown`. E editar o `specs.json` à mão sem `sf lock` **falha** o gate,
+   que é o `L2.GENERATED_FILES_ARE_LOCKED` fazendo o refresh ser deliberado.
+5. Forçar rate-limit (ou simular pelo `api_error_status`) faz trocar de harness
+   e não de modelo; forçar exit 1 faz subir de modelo e não de harness. Os dois
+   com asserção na linha `agent.handoff` do log, incluindo o campo que diz qual
+   eixo andou. Um `abandoned` **não** produz handoff nenhum, que é o freio de
+   mão continuando a frear. Uma ladder que nomeia um agente inexistente falha
+   no boot em vez de rodar mais curta. E o e2e roda contra o `dist`, de outro
+   processo, com binário de mentira no `PATH`: exit 429, exit 1, e um que
+   fecha. Sem credencial, repetível por qualquer um.
+6. `amy` **instalado** fecha um ticket sem que este repo esteja no PATH, e a
+   linha do log diz qual build fez. Rodar de dentro do checkout e rodar
+   instalado dão o mesmo resultado, senão a separação é decorativa.
+7. Budget com teto baixo de propósito: o engine para de começar ação e
+   reenfileira, sem perder o ticket. Com `maxOpenReviewsPerReviewer: 0`, o PR
+   é aberto e fica **sem ninguém atribuído**, e o ticket espera em vez de
+   falhar. Uma linha com `costSource: "unknown"` move o teto de token e não
+   move o de USD.
+8. Uma escada de skill que nomeia `/nao-existe` **falha no boot**, nomeando o
+   que havia para escolher. Com duas skills instaladas, a primeira responde e
+   a segunda não é chamada; matando a primeira, a segunda responde. Ambos com
+   asserção no log.
+9. Derrubar a API do GitHub no meio de um tick: **um** aviso na queda, silêncio
+   nas tentativas do meio, **um** aviso na volta, e o ticket continua de onde
+   estava. Um canal de notificação quebrado não impede o tick de terminar.
+   Renomear um `EventKind` sem `sf lock` **falha** o gate.
+10. Um item injetado que não existe no Linear atravessa a fila e é trabalhado
+    sem tracker nenhum. E uma falha real produz um PR de `plans/` no repo
+    certo, que o `sf check` daquele repo aceita: com exit condition e uma
+    linha no `next-steps.md`. Um plano sem isso **falha**, o que é o
+    limitador de vazão funcionando.
+11. `DO_NOT_TRACK=1` faz o reporter não mandar nada. Sem modo configurado,
+    também não manda. O reporter **não está** no conjunto default: um install
+    limpo não fala com o logion. A regra local **falha** se eu meter um nome
+    de repo no reporter, e a outra **falha** se qualquer pacote que não seja
+    o reporter importar logion.
+12. Um plano em `~/.claude/plans/` sem exit condition **falha** o `sf check`
+    do repo a que ele pertence, o que hoje não acontece.
+13. Um ticket grande fechado via CodeForge. E o ARC-AGI-1 rodando com um
+    segundo workflow que reusa fila, gate, relay e budget e **não reusa
+    nenhuma ação** do primeiro. Sem prometer score.
+
+E a que fecha tudo: **um ticket real, ponta a ponta, com `amy tick`.** O
+`TBO-1239` está em In Progress.


### PR DESCRIPTION
The roadmap lived in `~/.claude/plans/`, outside any repository, with no validated exit condition and no place in an execution order — the exact problem phase 12 describes: the software factory could not see the plan that drives the software factory.

It can now, and it had something to say immediately: `sf check` refused the file until it carried an `Exit condition:` and a line in `next-steps.md`.

**What changed on the way in**

- **The employer's name came out.** The roadmap named them three times, once to say amy works on their repositories with real ticket ids and real colleague names. The sentences are about what the risk *is*, and they say as much without naming anybody. This is the README's own open item ("taking the last of one employer out of it"), and it matters more now that this repository is public.
- **A status table went on the front.** A roadmap written before the work reads as if none of it happened. Each phase now names the gate or the plan that answers for it — and says plainly that the table is what ages while the digest is what expires.
- **The phase 9 design went to `docs/design/`, not `plans/`.** It describes shipped work, so it is documentation; `plans/the-engine-fails-out-loud.md` stays the plan of record. Its one relative link was repointed.
- It stays in Portuguese, as written. Translating 800 lines is not this PR.

**Checks:** `sf check` and `sf verify` clean, against the `sf` version this repository pins.

<sub>An earlier push of this branch also regenerated `docs/rules.md`. That was wrong and is reverted: the locally installed `sf` reported `0.3.0` while carrying a different catalog than `cargo install --tag v0.3.0` produces, so the regeneration was the local tool's prose, not a drift in this repository. The lesson is worth keeping — the docs are generated from the tool's built-in catalog, so a developer running a different build of `sf` will regenerate different prose and CI is the arbiter.</sub>