### PR TITLE
Call the changesets action by the names it has

### DIFF
--- a/.changeset/the-release-workflow-inputs.md
+++ b/.changeset/the-release-workflow-inputs.md
@@ -1,0 +1,8 @@
+---
+"@amy/cli": patch
+---
+
+The release workflow calls the changesets action by the names it actually
+has. Its inputs were renamed in v2 and the old ones are a hard error, so the
+first run on main stopped before doing anything — which is the failure mode
+to want.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,20 +35,16 @@ jobs:
       # exist, which is the quiet failure worth spelling out.
       id-token: write
     steps:
-      # persist-credentials stays on, unlike every other job in this
-      # repository: this is the one that pushes, and `changesets/action`
-      # pushes the version branch and its tags with the checkout's
-      # credential. There is no arrangement that removes it — a token in a
-      # remote URL is the same credential in the same file, spelled worse.
-      #
-      # The suppression below names `artipacked`, and the reason is that the
-      # audit is about that credential reaching an uploaded artifact: this job
-      # uploads none. It runs `npm ci`, the suite, and the changesets action,
-      # and ends.
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0 # zizmor: ignore[artipacked]
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           # The changelog reads history, and a shallow clone has none.
           fetch-depth: 0
+          # Off, like every other job here. `changesets/action` pushes the
+          # version branch, the commit and the tags through the GitHub API
+          # rather than through git — that is what `push-with-git-cli: false`,
+          # its default, means — so the credential this would leave in
+          # `.git/config` is one nothing here uses.
+          persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
@@ -65,10 +61,13 @@ jobs:
       - run: npm test
       - uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1
         with:
-          version: npm run release:version
-          publish: npm run release:publish
-          title: "Version packages"
-          commit: "chore(release): version packages"
+          # These four were renamed in v2 and the old names are a hard error
+          # rather than a warning, which is the right call and is how this
+          # was found: the first run on main said so and stopped.
+          version-script: npm run release:version
+          publish-script: npm run release:publish
+          pr-title: "Version packages"
+          commit-message: "chore(release): version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The first release run on main failed immediately, and correctly: `changesets/action` renamed four inputs in v2 and passing the v1 names is a hard error.

```
Error: The following inputs have been renamed:
- "publish" -> "publish-script"
- "version" -> "version-script"
- "commit"  -> "commit-message"
- "title"   -> "pr-title"
```

Worth saying why that is the behaviour to want: a warning would have produced a run that reported success and released nothing, and nobody reads the log of a green workflow.

**The checkout also stops keeping its credential.** Reading the pinned `action.yml` is what turned this up — `push-with-git-cli` defaults to `false`, and in that mode the action pushes the branch, the commit and the tags through the GitHub API, not through git. So the credential this job kept is one nothing in it uses: `persist-credentials: false` like every other job here, and the `artipacked` suppression I added in #2 is deleted rather than justified. A suppression that turns out to be unnecessary should not survive.

**Checks:** zizmor locally — no findings, nothing ignored (9 suppressed by config, as before). `npm run gate` exit 0, 617 tests, `sf verify` 33/33.

---

**Two things still yours, and the release stops without them:**

1. **`amy` on npmjs** — the scope is still unclaimed (`registry.npmjs.org/-/org/amy` → 404).
2. **`NPM_TOKEN` secret** — an *Automation* token, which is the kind that bypasses 2FA. There is no secret in this repository yet, so `NODE_AUTH_TOKEN` arrived empty in the run above.
3. **Actions has to be allowed to open pull requests.** This repository reports `can_approve_pull_request_reviews: false`, and the version PR is opened by the action with `GITHUB_TOKEN`. Flip it in Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests", or:

```sh
gh api -X PUT /repos/nicolasmelo1/amy/actions/permissions/workflow \
  -F default_workflow_permissions=read -F can_approve_pull_request_reviews=true
```

I did not flip it myself: it widens what Actions may do on your account, which is your call rather than mine.