### PR TITLE
The engine drives a workflow it does not know

### DIFF
--- a/.changeset/the-engine-drives-any-workflow.md
+++ b/.changeset/the-engine-drives-any-workflow.md
@@ -1,0 +1,16 @@
+---
+"@amy/core": minor
+---
+
+The engine drives a workflow it does not know.
+
+`WorkflowRuntime` is new in the core: what a workflow contributes so that
+something else can run it — how to find work, what the world looks like, one
+handler per action, and the fold only the workflow can do. The serial engine
+takes one and keeps the half that names nothing: the queue, the attempt
+counts, the budget and the handbrake.
+
+For anyone driving this from a config: `repos`, `qaStatusName` and `policy`
+moved from the engine's settings slice to the workflow's, and the engine
+gained `retryDelayMs` of its own. `amy` maps both for you; a hand-written
+`plugins:` slice needs the two keys moved.

--- a/.software-factory/evidence/installed-binary-run.json
+++ b/.software-factory/evidence/installed-binary-run.json
@@ -6,8 +6,8 @@
   "observed": {
     "assertions_run": 12,
     "assertions_failed": 0,
-    "version": "0.1.0 (1d89185-dirty, built 2026-09-04T21:10:37Z)",
-    "build_on_log_line": "0.1.0+1d89185-dirty"
+    "version": "0.1.0 (6c0a1ee-dirty, built 2026-09-04T21:56:59Z)",
+    "build_on_log_line": "0.1.0+6c0a1ee-dirty"
   },
   "assertions": [{"type":"installed.reports_a_real_build","status":"passed"},{"type":"installed.stamp_names_version_and_commit","status":"passed"},{"type":"installed.plugins_are_inside_the_binary","status":"passed"},{"type":"installed.every_plugin_resolves","status":"passed"},{"type":"installed.carries_the_whole_default_set","status":"passed"},{"type":"installed.runs_without_a_checkout","status":"passed"},{"type":"installed.keeps_state_beside_the_caller","status":"passed"},{"type":"installed.does_not_write_into_the_source_tree","status":"passed"},{"type":"installed.log_line_names_the_build","status":"passed"},{"type":"installed.log_build_matches_the_binary","status":"passed"},{"type":"installed.stamp_carries_a_commit","status":"passed"},{"type":"installed.is_one_file","status":"passed"}]
 }

--- a/.software-factory/evidence/installed-binary.json
+++ b/.software-factory/evidence/installed-binary.json
@@ -1,14 +1,14 @@
 {
   "schema_version": 1,
   "gate": "installed-binary",
-  "implementation_sha256": "e1e19ab390ca633450874d970b3f0edfdb6204031a2ede0c721c2f83b164a439",
+  "implementation_sha256": "7b14d33a56c0eb6b5d1d48157931e490bddcbf8209a99537fdfbc3d5c103d49a",
   "runs": [
     {
       "scenario": "installed-binary",
       "status": "passed",
       "actor": "Claude (agent), running .software-factory/evidence/installed-binary-scenario.sh against a freshly installed binary on macOS, for Nicolas Melo",
       "report": ".software-factory/evidence/installed-binary-run.json",
-      "report_sha256": "04b5e21c72ebca9f0a6b8985f5295ae7a418f337c59224ce512394c98a920adb",
+      "report_sha256": "45a8133a594755118827351814d82f05e4b38362ee7dc15a24196d67e0917a5d",
       "required_assertions": []
     }
   ]

--- a/.software-factory/evidence/plugin-serial-engine-scenario.sh
+++ b/.software-factory/evidence/plugin-serial-engine-scenario.sh
@@ -67,6 +67,11 @@ const { plugin: store } = await import(dist("plugins", "file-store"));
 const { FileEventLog } = await import(dist("plugins", "file-log"));
 const { plugin: github } = await import(dist("plugins", "github"));
 const { plugin: engine } = await import(dist("plugins", "serial-engine"));
+// The workflow arrives as a plugin now: it registers the order its states
+// happen in and contributes how each of its actions runs. The engine holds
+// neither, which is what lets this scenario drive the real one rather than a
+// copy of it.
+const { plugin: workflow } = await import(dist("packages", "workflow-ticket-to-qa"));
 const { plugin: fanout, CHANNEL_COLLECTION } = await import(dist("plugins", "notify-fanout"));
 
 const assertions = [];
@@ -204,13 +209,10 @@ function refusingBudgetPlugin() {
  */
 async function host({ channels = [channelPlugin("recorder")], extra = [], log } = {}) {
   const outcome = await mount(
-    [queue, store, github, fanout, ...channels, worldPlugin(), ...extra, engine],
+    [queue, store, github, fanout, ...channels, worldPlugin(), workflow, ...extra, engine],
     {
-      "@amy/plugin-serial-engine": {
-        repos: ["acme/widgets"],
-        qaStatusName: "In QA",
-        maxItemAttempts: 5,
-      },
+      "@amy/plugin-serial-engine": { maxItemAttempts: 5 },
+      "@amy/workflow-ticket-to-qa": { repos: ["acme/widgets"], qaStatusName: "In QA" },
     },
     {
       runner: new NodeCommandRunner(),

--- a/.software-factory/evidence/plugin-serial-engine.json
+++ b/.software-factory/evidence/plugin-serial-engine.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "gate": "plugin-serial-engine",
-  "implementation_sha256": "98e8990d17f6ed0e75ad425f99f11d352f51f6079c8625b622732f0e5a4512f9",
+  "implementation_sha256": "73dd6ef47121219aa1457070e718b7df81f6ff559a97a747b7fa3c61a382e3ed",
   "runs": [
     {
       "scenario": "plugin-serial-engine",

--- a/.software-factory/evidence/ticket-to-qa-run.json
+++ b/.software-factory/evidence/ticket-to-qa-run.json
@@ -10,7 +10,7 @@
   "observed": {
     "assertions_run": 30,
     "assertions_failed": 0,
-    "version": "0.1.0 (1d89185-dirty, built 2026-09-04T21:10:39Z)",
+    "version": "0.1.0 (6c0a1ee-dirty, built 2026-09-04T21:57:00Z)",
     "looks": 38,
     "transitions": [
       "DISCOVERED>CLARIFYING",
@@ -56,12 +56,12 @@
     ],
     "what_the_world_did": [
       "a colleague answered the question on the ticket",
-      "the automated reviewer looked at 2b5ac79 and left one comment",
-      "the automated reviewer looked at daa079d and had nothing to say",
+      "the automated reviewer looked at 770c897 and left one comment",
+      "the automated reviewer looked at 254ac8c and had nothing to say",
       "one of ada's other reviews was merged, so she is carrying one",
-      "ada asked for changes on daa079d",
+      "ada asked for changes on 254ac8c",
       "the owner settled the disagreement on the ticket",
-      "ada approved 8665126"
+      "ada approved abcbf16"
     ],
     "agent_calls": [
       "triage",

--- a/.software-factory/evidence/ticket-to-qa.json
+++ b/.software-factory/evidence/ticket-to-qa.json
@@ -1,14 +1,14 @@
 {
   "schema_version": 1,
   "gate": "ticket-to-qa",
-  "implementation_sha256": "b4263fd6a230e886065dd711a1f4e33066a4c0c1f3f9198161b8722e4c4ded5c",
+  "implementation_sha256": "3c19a2dfa72bd7cbe42e21565054dbde4e697f070a3f8b262d8aa3ae338b64f7",
   "runs": [
     {
       "scenario": "ticket-to-qa",
       "status": "passed",
       "actor": "Claude (agent), driving the installed executable through one ticket against stand-in services on macOS, for Nicolas Melo",
       "report": ".software-factory/evidence/ticket-to-qa-run.json",
-      "report_sha256": "4acf2efd7da9f09cc0c6dc0c63af89ff3e6a96c88f34880a654d92fe08cb29a4",
+      "report_sha256": "bad26274c3e47d06d2b10400a71b7d334cbf88e03f310c63294917313e010070",
       "required_assertions": []
     }
   ]

--- a/README.md
+++ b/README.md
@@ -162,28 +162,39 @@ taken, how each one is dispatched, the generic work record, the plan, and the
 registry that mounts everything else. A state is a string to it and an action
 is a name.
 
-**A workflow is only the order in which actions happen.** It does not define
-actions: a second workflow that needs `implement` reuses the one the core
-ships rather than dragging a whole domain along with it. A new action goes
-into the core.
+**A workflow is only the order in which actions happen, plus how they run.**
+It does not define actions: a second workflow that needs `implement` reuses
+the one the core ships rather than dragging a whole domain along with it. A
+new action goes into the core.
 
 ```text
 @amy/core
   actions:  triage, implement, run-gate, open-pull-request, address-threads,
             assign-reviewer, request-rereview, escalate, hand-off-to-qa,
             announce                    each declares the port it needs
+  contract: Workflow + WorkflowRuntime  what an engine drives, generically
       ▲                                          ▲
       │ composes actions                         │ implements ports
       │                                          │
 @amy/workflow-ticket-to-qa              @amy/plugin-linear       tracker
-  the sixteen states, its typed         @amy/plugin-github       code-host
-  port contracts, and a pure plan()     @amy/plugin-claude       agent
-                                        @amy/plugin-command-gate gate
-                                        @amy/plugin-notify-* notifier
-                                        @amy/plugin-file-queue   queue
-                                        @amy/plugin-file-store   store
-                                        @amy/plugin-serial-engine engine
+  the sixteen states, a pure plan(),    @amy/plugin-github       code-host
+  its typed port contracts, and the     @amy/plugin-claude       agent
+  runtime that runs its actions         @amy/plugin-command-gate gate
+      │                                 @amy/plugin-notify-* notifier
+      │ contributes a runtime           @amy/plugin-file-queue   queue
+      ▼                                 @amy/plugin-file-store   store
+@amy/plugin-serial-engine
+  a queue, a budget, a retry count and a stop switch — and no idea what a
+  ticket is
 ```
+
+**The engine drives a workflow it does not know.** It asks the workflow what
+to do next, asks the *runtime* the workflow contributed to do it, and holds
+the queue, the attempt counts, the budget and the handbrake in between. Every
+noun in `Worker.ts` is one of those; a ticket, a pull request and a reviewer
+appear nowhere in it. So a second workflow over a different domain — the one
+[the roadmap](plans/the-roadmap.md) wants for ARC — costs a `plan()` and a
+runtime, not a fork of the engine.
 
 Plugins are **loaded from the config and assembled**, not constructed by the
 CLI. `mount()` refuses, at boot and by name, a plugin that will not import, a
@@ -356,7 +367,7 @@ agent:
 
 ## State of the build
 
-613 tests. The core, the workflow, the plugins, the CLI and the gate all
+624 tests. The core, the workflow, the plugins, the CLI and the gate all
 pass, and `sf verify` proves all 33 of this repository's own rules fire.
 
 <!-- claim: WALKS_A_TICKET_TO_QA proven-by: ticket-to-qa -->
@@ -444,7 +455,7 @@ catches it.
 
 ### The tests exercise classes. The gates exercise the artifact.
 
-613 tests all import a source file and call a method. That is worth having and
+624 tests all import a source file and call a method. That is worth having and
 it is not the same claim as "the published package works": a barrel that
 forgets an export, or a `dist` nobody built, passes the whole suite and is
 broken on the machine that installs it.

--- a/packages/cli/src/hostPlugin.ts
+++ b/packages/cli/src/hostPlugin.ts
@@ -1,6 +1,5 @@
 import { Plugin } from "@amy/core";
-import { WORKFLOW_DATA } from "@amy/plugin-serial-engine";
-import { Roster } from "@amy/workflow-ticket-to-qa";
+import { Roster, WORKFLOW_DATA } from "@amy/workflow-ticket-to-qa";
 
 /**
  * The host's own glue, mounted like anything else.

--- a/packages/cli/src/loader.ts
+++ b/packages/cli/src/loader.ts
@@ -25,6 +25,10 @@ import { Plugin } from "@amy/core";
  * mounting problem naming a package that was never meant to mount.
  */
 const BUILT_INS = {
+  // The workflow is a plugin like anything else: it registers the order its
+  // states happen in, and contributes how each of its actions runs. An
+  // install that drops it has an engine with nothing to drive, and says so.
+  "@amy/workflow-ticket-to-qa": () => import("@amy/workflow-ticket-to-qa"),
   "@amy/plugin-file-queue": () => import("@amy/plugin-file-queue"),
   "@amy/plugin-file-store": () => import("@amy/plugin-file-store"),
   "@amy/plugin-linear": () => import("@amy/plugin-linear"),
@@ -44,6 +48,7 @@ const BUILT_INS = {
 export const COMPILED_IN: readonly string[] = Object.keys(BUILT_INS);
 
 export const DEFAULT_PLUGINS: readonly (keyof typeof BUILT_INS)[] = [
+  "@amy/workflow-ticket-to-qa",
   "@amy/plugin-file-queue",
   "@amy/plugin-file-store",
   "@amy/plugin-linear",

--- a/packages/cli/src/schemas.ts
+++ b/packages/cli/src/schemas.ts
@@ -1,4 +1,5 @@
 import { ConfigSchema } from "@amy/core";
+import { configSchema as ticketToQa } from "@amy/workflow-ticket-to-qa";
 import { configSchema as claude } from "@amy/plugin-claude";
 import { configSchema as commandGate } from "@amy/plugin-command-gate";
 import { configSchema as fileQueue } from "@amy/plugin-file-queue";
@@ -15,6 +16,7 @@ import { configSchema as serialEngine } from "@amy/plugin-serial-engine";
  * that silently never applied.
  */
 export const PLUGIN_SCHEMAS: Readonly<Record<string, ConfigSchema>> = {
+  "@amy/workflow-ticket-to-qa": ticketToQa,
   "@amy/plugin-claude": claude,
   "@amy/plugin-command-gate": commandGate,
   "@amy/plugin-file-queue": fileQueue,

--- a/packages/cli/src/slices.ts
+++ b/packages/cli/src/slices.ts
@@ -32,13 +32,20 @@ export function pluginSlices(config: AmyConfig): Record<string, unknown> {
       retentionDays: config.retentionDays,
       staleClaimMs: config.staleClaimMs,
     },
-    "@amy/plugin-serial-engine": {
+    // The workflow's own vocabulary: which repositories it counts review
+    // load across, where it hands work over, and the ceilings its decision
+    // function reads.
+    "@amy/workflow-ticket-to-qa": {
       repos: config.repos,
-      policy: config.policy,
       qaStatusName: config.qaStatusName,
+      policy: config.policy,
+    },
+    // The engine's, and none of it names a domain.
+    "@amy/plugin-serial-engine": {
       staleClaimMs: config.staleClaimMs,
       retentionDays: config.retentionDays,
       maxItemAttempts: config.maxItemAttempts,
+      retryDelayMs: config.policy.pollBackoffMs,
     },
   };
 

--- a/packages/cli/tests/slices.test.ts
+++ b/packages/cli/tests/slices.test.ts
@@ -36,13 +36,16 @@ describe("pluginSlices", () => {
     expect(slices["@amy/plugin-command-gate"]?.commands).toEqual({ "acme/widgets": ["npm test"] });
   });
 
-  it("gives the engine the policy, so a configured ceiling reaches the machine", () => {
+  it("gives the workflow the policy, so a configured ceiling reaches the machine", () => {
     const slices = pluginSlices({
       ...CONFIG,
       policy: { ...CONFIG.policy, maxOpenReviewsPerReviewer: 0 },
     }) as Record<string, Record<string, unknown>>;
 
-    expect(slices["@amy/plugin-serial-engine"]?.policy).toMatchObject({
+    // The policy is written in the workflow's vocabulary — attempt ceilings,
+    // backoffs, how many open reviews one person may be handed — so it goes
+    // to the workflow rather than to whatever is driving it.
+    expect(slices["@amy/workflow-ticket-to-qa"]?.policy).toMatchObject({
       maxOpenReviewsPerReviewer: 0,
     });
   });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,6 +4,9 @@ export type { ActionSpec, PortKind } from "./actions.js";
 export { actionsOf, applyPlan } from "./work.js";
 export type { Action, Plan, Transition, WorkRecord } from "./work.js";
 
+export { WORKFLOW_RUNTIME } from "./runtime.js";
+export type { ActionContext, ActionHandler, WorkflowRuntime } from "./runtime.js";
+
 export type {
   Engine,
   HostPaths,

--- a/packages/core/src/mount.ts
+++ b/packages/core/src/mount.ts
@@ -148,6 +148,7 @@ function contextFor(
     paths: host.paths,
     contributions: (collection) => mounted.contributions.get(collection) ?? new Map(),
     port: (kind) => mounted.ports.get(kind),
+    workflow: () => mounted.workflow,
   };
 }
 

--- a/packages/core/src/plugin.ts
+++ b/packages/core/src/plugin.ts
@@ -70,6 +70,14 @@ export interface PluginContext {
   contributions(collection: string): ReadonlyMap<string, object>;
   /** A mounted port, read when asked. */
   port(kind: PortKind): object | undefined;
+  /**
+   * The mounted workflow, read when asked.
+   *
+   * Live for the same reason the two above are: an engine is mounted by a
+   * plugin that may be listed before the workflow's, and mounting order
+   * should not be something an operator has to get right.
+   */
+  workflow(): Workflow<never, never> | undefined;
 }
 
 export interface Registry {

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1,0 +1,78 @@
+import { Action, Plan, WorkRecord } from "./work.js";
+
+/**
+ * The collection a workflow contributes its runtime to.
+ *
+ * Named here rather than by the engine that reads it, because a workflow
+ * should not have to know which engine will drive it — and an engine should
+ * not have to name the workflow. The same reasoning as the notification
+ * channels, one level up.
+ */
+export const WORKFLOW_RUNTIME = "workflow-runtime";
+
+/**
+ * What one action needs to do its work, and where it writes what happened.
+ *
+ * `outcomes` is a bag the workflow owns at both ends: its handlers fill it
+ * and its `apply` reads it. The engine only carries it between the two,
+ * which is why it is typed as loosely here as it is.
+ */
+export interface ActionContext<R extends WorkRecord = WorkRecord, O = unknown> {
+  readonly record: R;
+  readonly observation: O;
+  readonly outcomes: Record<string, unknown>;
+}
+
+export type ActionHandler<R extends WorkRecord = WorkRecord, O = unknown> = (
+  action: Action,
+  context: ActionContext<R, O>,
+) => Promise<void>;
+
+/**
+ * How a workflow's actions actually run.
+ *
+ * The decision — `Workflow.plan` — is pure and says *what* should happen. This
+ * is the other half: what the outside world looks like before deciding, what
+ * each action does, and how what it produced folds back into the record. All
+ * three are domain knowledge, and none of them belongs in an engine.
+ *
+ * An engine that takes this drives any workflow. One that reaches for a
+ * tracker or a pull request itself drives exactly one, whatever its types
+ * say.
+ */
+export interface WorkflowRuntime<R extends WorkRecord = WorkRecord, O = unknown> {
+  /**
+   * What the decision function is given as its policy.
+   *
+   * Carried here because a policy is written in the workflow's own
+   * vocabulary — attempt ceilings, backoffs, how many open reviews one person
+   * may be handed — and an engine that held it would be an engine that has an
+   * opinion about all three.
+   */
+  readonly policy: unknown;
+  /** Work that exists and is not on the queue yet, by id. */
+  found(): Promise<string[]>;
+  /** The record a work id starts with, before anything has happened to it. */
+  newRecord(workId: string, now: Date): R;
+  /** A snapshot of the outside world for one record, gathered before deciding. */
+  observe(record: R): Promise<O>;
+  /** One handler per action this workflow can emit, keyed by action name. */
+  handlers(): Readonly<Record<string, ActionHandler<R, O>>>;
+  /**
+   * Folds what the actions produced, and what was observed, into the record.
+   *
+   * The engine has already folded the state, the attempt count and the
+   * history through `applyPlan`; it cannot fold the rest, because it does not
+   * know what a triage or a gate result is. The observation is here because
+   * not everything a record learns comes from an action — an answer somebody
+   * left elsewhere arrives as an observation, and a fold that could not see
+   * one would leave the record waiting on it forever.
+   */
+  apply(
+    record: R,
+    plan: Plan,
+    outcomes: Record<string, unknown>,
+    observation: O,
+    now: Date,
+  ): R;
+}

--- a/packages/test-fixtures/src/fakes.ts
+++ b/packages/test-fixtures/src/fakes.ts
@@ -2,7 +2,17 @@ import { vi } from "vitest";
 import { ticket } from "./builders.js";
 import { AgentResult, AgentRun, Event, EventLog, Notifier, StopSwitch, Store, checkEvent } from "@amy/core";
 import { WorkerConfig } from "@amy/plugin-serial-engine";
-import { Agent, CodeHost, DEFAULT_POLICY, Gate, PullRequestView, Ticket, TicketRecord, Tracker } from "@amy/workflow-ticket-to-qa";
+import {
+  Agent,
+  CodeHost,
+  DEFAULT_POLICY,
+  Gate,
+  PullRequestView,
+  Ticket,
+  TicketRecord,
+  TicketRuntimeConfig,
+  Tracker,
+} from "@amy/workflow-ticket-to-qa";
 export class InMemoryStore implements Store {
   public readonly records = new Map<string, TicketRecord>();
 
@@ -113,12 +123,16 @@ export class ThrowingEventLog implements EventLog {
 }
 
 export const workerConfig: WorkerConfig = {
-  repos: ["Northwind/northwind-backend"],
-  qaStatusName: "In QA",
-  policy: DEFAULT_POLICY,
   staleClaimMs: 30 * 60 * 1000,
   retentionDays: 7,
   maxItemAttempts: 5,
+  retryDelayMs: DEFAULT_POLICY.pollBackoffMs,
+};
+
+/** What the ticket runtime needs told to it, for a test. */
+export const runtimeConfig: TicketRuntimeConfig = {
+  repos: ["Northwind/northwind-backend"],
+  qaStatusName: "In QA",
 };
 
 export function ticketFor(overrides: Partial<Ticket> = {}): Ticket {

--- a/packages/test-fixtures/src/index.ts
+++ b/packages/test-fixtures/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./builders.js";
 export * from "./fakes.js";
 export * from "./scripted.js";
+export * from "./worker.js";

--- a/packages/test-fixtures/src/worker.ts
+++ b/packages/test-fixtures/src/worker.ts
@@ -1,0 +1,98 @@
+import { Budget, EventLog, Notifier, Plan, StopSwitch, Workflow, WorkflowRuntime } from "@amy/core";
+import {
+  Agent,
+  CodeHost,
+  DEFAULT_POLICY,
+  Gate,
+  Policy,
+  Roster,
+  ticketRuntime,
+  ticketToQa,
+  Tracker,
+} from "@amy/workflow-ticket-to-qa";
+import { fakeAgent, fakeGate, fakeHost, fakeTracker, runtimeConfig, workerConfig } from "./fakes.js";
+import { roster } from "./builders.js";
+
+/**
+ * What a test wants to vary about an engine driving the ticket workflow.
+ *
+ * The ports are here rather than on the engine because that is where they
+ * live now: the engine holds a queue, a record store and a notifier, and
+ * everything that knows what a ticket is arrives through the runtime.
+ */
+export interface TicketWorkerOverrides {
+  tracker?: Tracker;
+  host?: CodeHost;
+  agent?: Agent;
+  gate?: Gate;
+  notifier?: Notifier;
+  roster?: () => Roster;
+  now?: () => Date;
+  log?: EventLog;
+  stop?: StopSwitch;
+  budget?: Budget;
+  policy?: Policy;
+  config?: Partial<EngineConfig>;
+  /** A decision this workflow would never make, for a test that needs one. */
+  plan?: Workflow["plan"];
+}
+
+interface EngineConfig {
+  staleClaimMs: number;
+  retentionDays: number;
+  maxItemAttempts: number;
+  retryDelayMs: number;
+}
+
+/**
+ * Everything a `Worker` needs except the queue and the store, which a test
+ * builds itself because it reads them afterwards.
+ *
+ * Structurally typed rather than importing the engine's own types: the engine
+ * depends on these fixtures, and a fixture that depended back would be a
+ * cycle.
+ */
+export interface TicketWorkerDeps {
+  workflow: Workflow;
+  runtime: WorkflowRuntime;
+  notifier: Notifier;
+  now: () => Date;
+  config: EngineConfig;
+  log?: EventLog;
+  stop?: StopSwitch;
+  budget?: Budget;
+}
+
+export function ticketWorkerDeps(overrides: TicketWorkerOverrides = {}): TicketWorkerDeps {
+  const now = overrides.now ?? ((): Date => new Date());
+  const notifier = overrides.notifier ?? { announce: async (): Promise<void> => {} };
+
+  const workflow: Workflow = overrides.plan
+    ? { ...ticketToQa, plan: overrides.plan as (r: never, o: never, p: never) => Plan }
+    : (ticketToQa as Workflow);
+
+  return {
+    workflow,
+    runtime: ticketRuntime({
+      tracker: overrides.tracker ?? fakeTracker(),
+      host: overrides.host ?? fakeHost(),
+      agent: overrides.agent ?? fakeAgent(),
+      gate: overrides.gate ?? fakeGate(),
+      notifier,
+      roster: overrides.roster ?? ((): Roster => roster()),
+      now,
+      log: overrides.log,
+      config: runtimeConfig,
+      policy: overrides.policy ?? DEFAULT_POLICY,
+      // The same boundary `ticketToQa` casts at, for the same reason: this
+      // workflow's record and observation are typed, the engine's are not,
+      // and the cast lives at the one place they meet.
+    }) as unknown as WorkflowRuntime,
+    notifier,
+    now,
+    config: { ...workerConfig, ...overrides.config },
+    log: overrides.log,
+    stop: overrides.stop,
+    budget: overrides.budget,
+  };
+}

--- a/packages/workflow-ticket-to-qa/src/index.ts
+++ b/packages/workflow-ticket-to-qa/src/index.ts
@@ -41,6 +41,12 @@ export type { EffectOutcomes } from "./outcomes.js";
 
 export { plan, ticketToQa } from "./machine.js";
 
+export { ticketRuntime } from "./runtime.js";
+export type { TicketRuntimeConfig, TicketRuntimeDeps } from "./runtime.js";
+
+export { WORKFLOW_DATA, configSchema, plugin } from "./plugin.js";
+export type { Provider } from "./plugin.js";
+
 export type { FollowUpRequest, Tracker } from "./ports/Tracker.js";
 export type { CodeHost, OpenPullRequestRequest } from "./ports/CodeHost.js";
 export type { Agent } from "./ports/Agent.js";

--- a/packages/workflow-ticket-to-qa/src/plugin.ts
+++ b/packages/workflow-ticket-to-qa/src/plugin.ts
@@ -1,0 +1,156 @@
+import {
+  ConfigSchema,
+  Notifier,
+  Plan,
+  Plugin,
+  PluginContext,
+  WORKFLOW_RUNTIME,
+  WorkflowRuntime,
+} from "@amy/core";
+import { Observation, DEFAULT_POLICY, Policy } from "./observation.js";
+import { Agent } from "./ports/Agent.js";
+import { CodeHost } from "./ports/CodeHost.js";
+import { Gate } from "./ports/Gate.js";
+import { Tracker } from "./ports/Tracker.js";
+import { Roster } from "./roster.js";
+import { TicketRecord } from "./record.js";
+import { ticketRuntime } from "./runtime.js";
+import { ticketToQa } from "./machine.js";
+
+/**
+ * The collection the host puts this workflow's data in.
+ *
+ * Today's roster is neither a port nor a setting: it changes daily, lives in
+ * its own file, and reading it is something the host knows how to do. It is
+ * contributed and read when a tick needs it, so confirming the roster takes
+ * effect without a restart.
+ */
+export const WORKFLOW_DATA = "workflow-data";
+
+/** Something one plugin contributes for another to read when it is needed. */
+export interface Provider<T> {
+  read(): T;
+}
+
+export const configSchema: ConfigSchema = {
+  repos: {
+    type: "string[]",
+    required: true,
+    description: "every repository review load is counted across",
+  },
+  qaStatusName: {
+    type: "string",
+    required: true,
+    description: "the status a ticket moves to when it is handed to QA",
+  },
+  policy: {
+    type: "record",
+    description:
+      "maxImplementAttempts, maxGateAttempts, pollBackoffMs, rosterBackoffMs and maxOpenReviewsPerReviewer. Anything left out keeps its default",
+    default: {},
+  },
+};
+
+/**
+ * The runtime built for one mount, keyed by that mount's context.
+ *
+ * The exported plugin is a module singleton, so a field on it would be shared
+ * by every host in the process and the second mount would answer with the
+ * first one's ports.
+ */
+const runtimes = new WeakMap<PluginContext, WorkflowRuntime<TicketRecord, Observation>>();
+
+function runtimeFor(ctx: PluginContext): WorkflowRuntime<TicketRecord, Observation> {
+  const existing = runtimes.get(ctx);
+  if (existing) return existing;
+
+  const built = ticketRuntime({
+    tracker: required<Tracker>(ctx, "tracker"),
+    host: required<CodeHost>(ctx, "code-host"),
+    agent: required<Agent>(ctx, "agent"),
+    gate: required<Gate>(ctx, "gate"),
+    notifier: required<Notifier>(ctx, "notifier"),
+    roster: () => provided<Roster>(ctx, "roster"),
+    now: ctx.now,
+    log: ctx.log,
+    config: {
+      repos: ctx.config.repos as string[],
+      qaStatusName: ctx.config.qaStatusName as string,
+    },
+    policy: { ...DEFAULT_POLICY, ...(ctx.config.policy as Partial<Policy>) },
+  });
+
+  runtimes.set(ctx, built);
+  return built;
+}
+
+/**
+ * This workflow, as a plugin: the order its states happen in, and how each of
+ * its actions runs.
+ *
+ * Both halves are here on purpose. The decision is pure and the runtime is
+ * not, and neither is an engine's business — an engine that reached for a
+ * tracker itself would drive this workflow and no other, whatever its types
+ * said.
+ */
+export const plugin: Plugin = {
+  name: "@amy/workflow-ticket-to-qa",
+  version: "0.1.0",
+  configSchema,
+  register(registry, ctx) {
+    registry.workflow(ticketToQa);
+
+    // Not built now: the ports it needs are mounted by plugins that may be
+    // listed after this one, and mounting order should not be something an
+    // operator has to get right. `ready` builds it while boot can still
+    // refuse, and this is the fallback for a host that mounts without that
+    // second pass.
+    const lazily = (): WorkflowRuntime<TicketRecord, Observation> => runtimeFor(ctx);
+
+    registry.contribute(WORKFLOW_RUNTIME, ticketToQa.name, {
+      get policy(): unknown {
+        return lazily().policy;
+      },
+      found: (): Promise<string[]> => lazily().found(),
+      newRecord: (workId: string, now: Date): TicketRecord => lazily().newRecord(workId, now),
+      observe: (record: TicketRecord): Promise<Observation> => lazily().observe(record),
+      handlers: () => lazily().handlers(),
+      apply: (
+        record: TicketRecord,
+        plan: Plan,
+        outcomes: Record<string, unknown>,
+        observation: Observation,
+        now: Date,
+      ): TicketRecord => lazily().apply(record, plan, outcomes, observation, now),
+    } satisfies WorkflowRuntime<TicketRecord, Observation>);
+  },
+
+  /**
+   * Builds the runtime while boot can still refuse.
+   *
+   * A missing port is an install that cannot run a ticket, and it costs a
+   * boot naming the port rather than somebody's ticket halfway through.
+   */
+  ready(ctx) {
+    runtimeFor(ctx);
+  },
+};
+
+/** A port this workflow cannot work without. */
+function required<T>(ctx: PluginContext, kind: string): T {
+  const port = ctx.port(kind);
+  if (!port) {
+    throw new Error(`the ticket-to-qa workflow needs the \`${kind}\` port, and nothing mounted it`);
+  }
+  return port as T;
+}
+
+function provided<T>(ctx: PluginContext, name: string): T {
+  const entry = ctx.contributions(WORKFLOW_DATA).get(name);
+  if (!entry) {
+    throw new Error(
+      `the ticket-to-qa workflow needs \`${name}\` in the \`${WORKFLOW_DATA}\` collection`,
+    );
+  }
+  return (entry as Provider<T>).read();
+}

--- a/packages/workflow-ticket-to-qa/src/runtime.ts
+++ b/packages/workflow-ticket-to-qa/src/runtime.ts
@@ -1,0 +1,318 @@
+import {
+  ActionContext,
+  ActionHandler,
+  AgentRun,
+  Event,
+  EventKind,
+  EventLog,
+  Notifier,
+  Plan,
+  WorkflowRuntime,
+} from "@amy/core";
+import { Agent } from "./ports/Agent.js";
+import { CodeHost } from "./ports/CodeHost.js";
+import { Gate } from "./ports/Gate.js";
+import { Tracker } from "./ports/Tracker.js";
+import { Effect } from "./effects.js";
+import { Observation, Policy } from "./observation.js";
+import { EffectOutcomes, applyTicketPlan } from "./outcomes.js";
+import { Roster } from "./roster.js";
+import { TicketRecord, newRecord } from "./record.js";
+import { Ticket, pullRequestTitle } from "./ticket.js";
+
+export interface TicketRuntimeConfig {
+  /** Every repository review load is counted across. */
+  repos: readonly string[];
+  /** The status a ticket moves to when it is handed to QA. */
+  qaStatusName: string;
+}
+
+export interface TicketRuntimeDeps {
+  tracker: Tracker;
+  host: CodeHost;
+  agent: Agent;
+  gate: Gate;
+  notifier: Notifier;
+  roster: () => Roster;
+  now: () => Date;
+  config: TicketRuntimeConfig;
+  policy: Policy;
+  /** Optional, so a runtime with no log still runs. */
+  log?: EventLog;
+}
+
+type Context = ActionContext<TicketRecord, Observation>;
+
+/** Exhaustive over this workflow's actions, checked at compile time. */
+type TicketHandlers = {
+  [K in Effect["type"]]: (effect: Extract<Effect, { type: K }>, ctx: Context) => Promise<void>;
+};
+
+/**
+ * How this workflow's actions run: what the world looks like before a
+ * decision, what each action does, and how the result folds back in.
+ *
+ * It lived inside the engine, and that is what made the engine drive exactly
+ * one workflow. Everything here names a ticket, a pull request or a reviewer,
+ * so it belongs on this side of the boundary; what stayed behind is a queue,
+ * a budget, a retry count and a stop switch, which name nothing.
+ */
+export function ticketRuntime(
+  deps: TicketRuntimeDeps,
+): WorkflowRuntime<TicketRecord, Observation> {
+  /**
+   * Appends to the log if there is one, and shrugs if it throws.
+   *
+   * A full disk under `.amy/log` must not cost a ticket a move, which is the
+   * engine's promise as much as this one's. It says nothing when it fails, on
+   * purpose: the engine writes several lines per tick through its own
+   * forgiving path and complains once. Complaining here too would be two
+   * voices for one outage.
+   */
+  const record = (kind: EventKind, rest: Omit<Event, "at" | "kind"> = {}): void => {
+    try {
+      deps.log?.append({ at: deps.now().toISOString(), kind, ...rest });
+    } catch {
+      // See above: the engine is what tells the operator.
+    }
+  };
+
+  /**
+   * Says something to the operator, and never lets that cost a ticket.
+   *
+   * Swallowed for the same reason the engine swallows it: nothing downstream
+   * reads a notification, so its failure cannot make a saved record a lie.
+   * The tracker, the code host, the agent and the gate are deliberately not
+   * wrapped — see `plans/the-engine-fails-out-loud.md`.
+   */
+  const announce = async (text: string, ctx: Context): Promise<void> => {
+    try {
+      await deps.notifier.announce({ text, workId: ctx.record.id, state: ctx.record.state });
+    } catch (error) {
+      record("notify.failed", {
+        workId: ctx.record.id,
+        state: ctx.record.state,
+        detail: { error: error instanceof Error ? error.message : String(error), text },
+      });
+    }
+  };
+
+  /**
+   * Writes down what an agent run took.
+   *
+   * Every field the relay and the budget will need is here, and `costSource`
+   * says whether the money figure was measured or worked out, so nothing
+   * downstream has to guess which.
+   */
+  const recordAgentRun = (ctx: Context, run: AgentRun): void => {
+    record("agent.run", {
+      workId: ctx.record.id,
+      state: ctx.record.state,
+      detail: {
+        harness: run.harness,
+        model: run.model,
+        outcome: run.outcome,
+        durationMs: run.durationMs,
+        costSource: run.costSource,
+        ...(run.costUsd === undefined ? {} : { costUsd: run.costUsd }),
+        ...(run.tokens === undefined ? {} : { tokens: { ...run.tokens } }),
+      },
+    });
+  };
+
+  const requireTicket = async (workId: string): Promise<Ticket> => {
+    const found = await deps.tracker.get(workId);
+    if (!found) {
+      throw new Error(`${workId} is not in the tracker any more`);
+    }
+    return found;
+  };
+
+  const requestReview = async (ctx: Context, host: string): Promise<void> => {
+    const number = ctx.observation.pullRequest?.number ?? ctx.record.pullRequestNumber;
+    if (number === undefined) {
+      throw new Error(`${ctx.record.id} has no pull request to request a review on`);
+    }
+    await deps.host.requestReview(ctx.observation.ticket.repo, number, host);
+  };
+
+  /** The outcomes bag, typed at the one boundary that knows what is in it. */
+  const outcomesOf = (ctx: Context): EffectOutcomes => ctx.outcomes as EffectOutcomes;
+
+  const handlers: TicketHandlers = {
+    "triage": async (_effect, ctx) => {
+      const { value, run } = await deps.agent.triage(ctx.observation.ticket);
+      recordAgentRun(ctx, run);
+      refuseAnIncompleteRun("triage", run);
+      outcomesOf(ctx).triage = value;
+    },
+
+    "ask-question": async (effect, ctx) => {
+      await deps.tracker.comment(
+        ctx.observation.ticket.id,
+        effect.questions.map((question) => `- ${question}`).join("\n"),
+      );
+      await announce(`${ctx.record.id} needs an answer before I can start.`, ctx);
+    },
+
+    "implement": async (effect, ctx) => {
+      const { value, run } = await deps.agent.implement(
+        ctx.observation.ticket,
+        effect.retryContext,
+      );
+      recordAgentRun(ctx, run);
+      outcomesOf(ctx).implementation = value;
+    },
+
+    "run-gate": async (_effect, ctx) => {
+      outcomesOf(ctx).gate = await deps.gate.run(ctx.observation.ticket);
+    },
+
+    "open-pull-request": async (_effect, ctx) => {
+      outcomesOf(ctx).pullRequestNumber = await deps.host.openPullRequest({
+        repo: ctx.observation.ticket.repo,
+        branch: ctx.observation.ticket.branchName,
+        title: pullRequestTitle(ctx.observation.ticket),
+        // Empty by convention. The ticket is the description.
+        body: "",
+      });
+    },
+
+    "address-threads": async (effect, ctx) => {
+      const threads = (ctx.observation.pullRequest?.threads ?? []).filter((thread) =>
+        effect.threadIds.includes(thread.id),
+      );
+      const { value, run } = await deps.agent.addressThreads(
+        ctx.observation.ticket,
+        threads,
+        effect.from,
+      );
+      recordAgentRun(ctx, run);
+      refuseAnIncompleteRun("address-threads", run);
+      outcomesOf(ctx).verdicts = value;
+    },
+
+    "assign-reviewer": async (effect, ctx) => {
+      await requestReview(ctx, effect.host);
+      outcomesOf(ctx).reviewer = effect.host;
+    },
+
+    "request-rereview": async (effect, ctx) => {
+      await requestReview(ctx, effect.host);
+    },
+
+    "escalate": async (effect, ctx) => {
+      const followUpTicketId = await deps.tracker.createFollowUp({
+        parentTicketId: ctx.observation.ticket.id,
+        title: `FUP ${ctx.observation.ticket.id}: review comments need a decision`,
+        body: effect.reason,
+      });
+
+      outcomesOf(ctx).escalation = {
+        reason: effect.reason,
+        askedAt: deps.now().toISOString(),
+        followUpTicketId,
+      };
+
+      await announce(`${ctx.record.id} is parked, ${followUpTicketId} has the details.`, ctx);
+    },
+
+    "hand-off-to-qa": async (effect, ctx) => {
+      await deps.tracker.setStatus(ctx.observation.ticket.id, deps.config.qaStatusName);
+      await deps.tracker.assign(ctx.observation.ticket.id, effect.tracker);
+    },
+
+    "announce": async (effect, ctx) => {
+      await announce(effect.text, ctx);
+    },
+  };
+
+  return {
+    policy: deps.policy,
+
+    async found() {
+      return (await deps.tracker.inProgress()).map((ticket) => ticket.id);
+    },
+
+    newRecord,
+
+    async observe(current) {
+      const ticket = await requireTicket(current.id);
+      const pullRequest = await deps.host.findPullRequest(ticket.repo, ticket.branchName);
+
+      // Only fetched where it is used, so a poll that is only waiting for a
+      // review does not hammer the code host counting everybody's workload.
+      const reviewLoad =
+        current.state === "REVIEWER_ASSIGNED"
+          ? await deps.host.reviewLoad(deps.config.repos)
+          : {};
+
+      const awaitingAnswer = current.triage && !current.triage.clear;
+      const awaitingOwner = current.escalation && !current.escalation.resolvedAt;
+
+      return {
+        ticket,
+        pullRequest,
+        reviewLoad,
+        roster: deps.roster(),
+        questionAnswered: awaitingAnswer
+          ? await deps.tracker.hasReplyAfter(ticket.id, current.triage!.at)
+          : false,
+        escalationAnswered: awaitingOwner
+          ? await deps.tracker.hasReplyAfter(ticket.id, current.escalation!.askedAt)
+          : false,
+        now: deps.now(),
+      };
+    },
+
+    handlers() {
+      // The cast is the boundary. Inside this file the map is exhaustive over
+      // `Effect` and each handler takes exactly its own payload, which is
+      // what makes a new action fail to compile until something runs it. The
+      // engine cannot know that union, and only ever hands back an action it
+      // was given by the very plan that typed it.
+      return Object.fromEntries(
+        Object.entries(handlers).map(([name, handler]) => [
+          name,
+          handler as ActionHandler<TicketRecord, Observation>,
+        ]),
+      );
+    },
+
+    apply(current, plan: Plan, outcomes, observation, now) {
+      const folded = outcomes as EffectOutcomes;
+
+      // The owner's answer to an escalation arrives as an observation rather
+      // than as the result of an action — the move it unblocks carries no
+      // action at all — so it is folded here rather than by a handler.
+      const settled =
+        current.escalation && !current.escalation.resolvedAt && observation.escalationAnswered
+          ? { ...folded, escalationResolvedAt: now.toISOString() }
+          : folded;
+
+      return applyTicketPlan(current, plan, settled, now);
+    },
+  };
+}
+
+/**
+ * Fails an action whose agent run did not complete.
+ *
+ * By the time this is reached, a relay has already tried every harness and
+ * model it was given, so there is nowhere left to go and the action has to
+ * fail rather than store an answer nobody gave.
+ *
+ * `implement` is deliberately not one of these: an attempt that did not hold
+ * is a first-class outcome there, and the machine retries it with the reason
+ * attached. `triage` and `address-threads` have no such outcome, and taking
+ * their empty value as an answer would park a ticket waiting on a question
+ * that was never asked, or drop a review comment nobody replied to.
+ */
+function refuseAnIncompleteRun(action: string, run: AgentRun): void {
+  if (run.outcome === "completed") return;
+
+  throw new Error(
+    `${action} did not complete: ${run.outcome} on ${run.harness}` +
+      `${run.model ? ` (${run.model})` : ""}${run.output ? `\n\n${run.output}` : ""}`,
+  );
+}

--- a/packages/workflow-ticket-to-qa/tests/plugin.test.ts
+++ b/packages/workflow-ticket-to-qa/tests/plugin.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import { HostServices, Plugin, WORKFLOW_RUNTIME, WorkflowRuntime, mount } from "@amy/core";
+import { fakeAgent, fakeGate, fakeHost, fakeTracker, roster } from "@amy/test-fixtures";
+import { WORKFLOW_DATA, plugin } from "../src/plugin.js";
+
+const HOST: HostServices = {
+  runner: { run: async () => ({ ok: true, exitCode: 0, stdout: "", stderr: "" }) },
+  now: () => new Date("2026-09-03T12:00:00.000Z"),
+  paths: { workspace: "/w", state: "/w/.amy" },
+};
+
+const SETTINGS = {
+  "@amy/workflow-ticket-to-qa": { repos: ["acme/widgets"], qaStatusName: "In QA" },
+};
+
+/** Everything this workflow reaches for, mounted by somebody else. */
+const world: Plugin = {
+  name: "@amy/plugin-world",
+  version: "0.1.0",
+  register: (registry) => {
+    registry.port("tracker", fakeTracker());
+    registry.port("code-host", fakeHost());
+    registry.port("agent", fakeAgent());
+    registry.port("gate", fakeGate());
+    registry.port("notifier", { announce: async () => {} });
+    registry.contribute(WORKFLOW_DATA, "roster", { read: () => roster() });
+  },
+};
+
+const mountWith = (plugins: Plugin[]) => mount(plugins, SETTINGS, HOST);
+
+describe("the ticket-to-qa workflow, as a plugin", () => {
+  it("registers the workflow and contributes a runtime under its name", async () => {
+    const outcome = await mountWith([plugin, world]);
+    if (!outcome.ok) throw new Error(outcome.problems.join("; "));
+
+    expect(outcome.mounted.workflow?.name).toBe("ticket-to-qa");
+
+    // Keyed by the workflow's own name, which is how an engine finds the
+    // runtime for the workflow it was given rather than for some other one.
+    const runtime = outcome.mounted.contributions.get(WORKFLOW_RUNTIME)?.get("ticket-to-qa");
+    expect(runtime).toBeDefined();
+  });
+
+  it("brings a handler for every action the workflow says it emits", async () => {
+    const outcome = await mountWith([plugin, world]);
+    if (!outcome.ok) throw new Error(outcome.problems.join("; "));
+
+    const runtime = outcome.mounted.contributions
+      .get(WORKFLOW_RUNTIME)
+      ?.get("ticket-to-qa") as WorkflowRuntime;
+    const handled = Object.keys(runtime.handlers());
+
+    expect([...(outcome.mounted.workflow?.usesActions ?? [])].sort()).toEqual(handled.sort());
+  });
+
+  // The point of doing this at boot: a machine missing a plugin finds out
+  // before it touches a ticket, and finds out which port is missing.
+  it("refuses at boot when a port it needs was never mounted, naming it", async () => {
+    const outcome = await mountWith([plugin]);
+
+    expect(outcome.ok).toBe(false);
+    if (outcome.ok) return;
+    expect(outcome.problems.join("; ")).toMatch(/needs the `tracker` port/);
+  });
+
+  it("refuses at boot when nothing contributed today's roster", async () => {
+    const withoutRoster: Plugin = {
+      ...world,
+      register: (registry) => {
+        registry.port("tracker", fakeTracker());
+        registry.port("code-host", fakeHost());
+        registry.port("agent", fakeAgent());
+        registry.port("gate", fakeGate());
+        registry.port("notifier", { announce: async () => {} });
+      },
+    };
+
+    const outcome = await mountWith([plugin, withoutRoster]);
+    if (!outcome.ok) throw new Error(outcome.problems.join("; "));
+
+    const runtime = outcome.mounted.contributions
+      .get(WORKFLOW_RUNTIME)
+      ?.get("ticket-to-qa") as WorkflowRuntime;
+
+    // The roster is read when a tick needs it, not at mount, so confirming it
+    // takes effect without a restart. The refusal moves with it.
+    await expect(
+      runtime.observe({
+        id: "PROJ-1239",
+        state: "DISCOVERED",
+        updatedAt: HOST.now().toISOString(),
+        attempts: {},
+        history: [],
+      }),
+    ).rejects.toThrow(/needs `roster` in the `workflow-data` collection/);
+  });
+
+  it("hands the decision the policy it was configured with", async () => {
+    const outcome = await mountWith([
+      plugin,
+      world,
+    ]);
+    if (!outcome.ok) throw new Error(outcome.problems.join("; "));
+
+    const runtime = outcome.mounted.contributions
+      .get(WORKFLOW_RUNTIME)
+      ?.get("ticket-to-qa") as WorkflowRuntime;
+
+    // Defaults, because the settings above name no policy — and a policy that
+    // silently arrived empty would turn every ceiling into zero.
+    expect(runtime.policy).toMatchObject({ maxImplementAttempts: 3, maxGateAttempts: 3 });
+  });
+});

--- a/plans/next-steps.md
+++ b/plans/next-steps.md
@@ -16,8 +16,9 @@ O roadmap inteiro, com as treze fases e o estado de cada uma, está em
 | 3 | [The relay is proven end to end](the-relay-is-proven-end-to-end.md) | A quota refusal, a killed child and a mistyped ladder are each proven against the built artifacts, with no credential involved |
 | 4 | [The engine fails out loud](the-engine-fails-out-loud.md) | A dependency that goes down produces one warning on the way down, silence while it is down, and one warning when it comes back, and no broken notification channel ever costs a ticket a move |
 | 5 | [The lifecycle is proven end to end](the-lifecycle-is-proven-end-to-end.md) | The installed executable walks one ticket from the working status to a QA handoff against a world of stand-ins, twice, with no credential and no network |
-| 6 | [What runs is a released version](what-runs-is-a-released-version.md) | A machine with no checkout installs `@amy/cli` from GitHub Packages, `amy --version` names a version changesets published, and a dirty tree only ever says `dev` |
-| 7 | [Plugins are installed, not compiled in](plugins-are-installed-not-compiled-in.md) | A second machine runs a ticket with only the plugins it needs installed, and one it never installed is refused by name at boot |
+| 6 | [The engine drives a workflow it does not know](the-engine-drives-a-workflow-it-does-not-know.md) | `plugins/serial-engine/src/**` names no workflow package, and a second workflow runs on the same engine by contributing a plan and a runtime |
+| 7 | [What runs is a released version](what-runs-is-a-released-version.md) | A machine with no checkout installs `@amy/cli` from GitHub Packages, `amy --version` names a version changesets published, and a dirty tree only ever says `dev` |
+| 8 | [Plugins are installed, not compiled in](plugins-are-installed-not-compiled-in.md) | A second machine runs a ticket with only the plugins it needs installed, and one it never installed is refused by name at boot |
 
 ## Parked
 

--- a/plans/the-engine-drives-a-workflow-it-does-not-know.md
+++ b/plans/the-engine-drives-a-workflow-it-does-not-know.md
@@ -1,0 +1,98 @@
+# The engine drives a workflow it does not know
+
+The question was whether a second workflow can reuse the plugins or has to
+duplicate them. The answer was: the plugins, yes; the engine, no.
+
+`Worker.ts` was 748 lines with 36 references to the ticket domain. It built
+the observation out of a tracker, held a handler per ticket action, folded a
+gate result it had to understand, registered `ticketToQa` itself, and read
+`repos` and `qaStatusName` out of its own settings. `decide` was injectable,
+so the *decision* could be swapped — and nothing else could.
+
+That made the roadmap's own strongest claim untestable. Phase 13 says a
+second workflow that reuses queue, gate, relay, budget and report while
+sharing no action is the strongest proof the plugin model can receive. With
+the engine as it was, that proof would have failed at the engine rather than
+at the model, and it would have failed by needing a second copy of 748 lines.
+
+## The seam, and why it is this one
+
+The mechanism already existed here twice: a **collection** is how the
+notification channels reach the fan-out without the core learning the word
+"channel", and how today's roster reaches a tick without being a port. The
+same shape, one level up.
+
+`WorkflowRuntime` is what a workflow contributes:
+
+- `found()` — work that exists and is not queued yet
+- `newRecord()` — what a work id starts as
+- `observe(record)` — the snapshot the decision reads
+- `handlers()` — one per action it can emit
+- `apply(record, plan, outcomes, observation, now)` — the fold only it can do
+- `policy` — the ceilings its own decision function reads
+
+What stayed in the engine is the half that names nothing: claim an item,
+recover an abandoned one, ask the budget before spending an agent, park
+rather than lose, count attempts across processes, warn once on the way down
+and once on the way back, stop between actions, prune, and chain the next
+look. Those are true of any workflow, and none of them mentions a ticket.
+
+The observation is in `apply` for a reason worth keeping: not everything a
+record learns comes from an action. The owner's answer to an escalation
+arrives as an observation, and the move it unblocks carries no action at all,
+so a fold that could not see one would leave the record waiting forever.
+
+## What this is not
+
+It is not two workflows at once. `mount()` still claims a single workflow, so
+an install drives one; two means two configs and two state directories, which
+is the right shape for now and is not what phase 13 needs.
+
+It is not a domain-free `Agent`, `Tracker`, `CodeHost` or `Gate` either. Those
+four contracts are declared by this workflow and typed on its `Ticket`, which
+is deliberate — type safety comes from the workflow's side. So a second
+workflow over the *same* domain reuses every adapter and costs a `plan()`; a
+second workflow over a different domain reuses the harnesses, the queue, the
+store, the log, the notifiers, the relay's ladder and the budget, and brings
+its own adapters. That is the honest boundary, and it is the one an ARC
+workflow would meet.
+
+## Acceptance criteria
+
+- [x] The engine imports nothing from any workflow package, and no noun in it
+      names a domain
+      (proof: test:plugins/serial-engine/tests/plugin.test.ts)
+- [x] The workflow contributes both halves — the order of its states and how
+      its actions run — as a plugin
+      (proof: test:packages/workflow-ticket-to-qa/tests/plugin.test.ts)
+- [x] A workflow that registers itself and contributes no runtime is refused
+      by name, with what there was to choose from
+      (proof: test:plugins/serial-engine/tests/plugin.test.ts)
+- [x] A port the workflow needs and nobody mounted is refused at boot, naming
+      the port
+      (proof: test:packages/workflow-ticket-to-qa/tests/plugin.test.ts)
+- [x] The engine reports an action the runtime brought no handler for, and a
+      hand-written runtime with one handler proves it
+      (proof: test:plugins/serial-engine/tests/Worker.test.ts)
+- [x] The workflow's vocabulary — its repositories, its QA status, its policy
+      — is in the workflow's own settings slice, not the engine's
+      (proof: test:packages/cli/tests/slices.test.ts)
+- [x] Everything the engine promised about a bad day still holds: one warning
+      on the way down, one on the way back, a broken channel or log costing no
+      move (proof: assertion:engine.warns_once_on_the_first_failure)
+- [x] The lifecycle still walks end to end, unchanged, through the installed
+      executable
+      (proof: assertion:lifecycle.the_ticket_walks_the_lifecycle_in_order)
+- [ ] A second workflow, over a domain sharing no action with this one, runs
+      on this engine unmodified
+      (proof: deferred:that workflow is phase 13, and it is the run that
+      settles this rather than an argument about it)
+
+**Exit condition:** `plugins/serial-engine/src/**` contains no reference to
+any `@amy/workflow-*` package, the five end-to-end scenarios pass unchanged
+against the built artifacts, and a second workflow can be driven by handing
+the same engine a `Workflow` and a `WorkflowRuntime`.
+
+The last criterion is the one that matters and it stays open on purpose. The
+seam is only proven by a second thing going through it, and inventing a
+throwaway second workflow to close a checkbox would prove the checkbox.

--- a/plugins/serial-engine/src/Worker.ts
+++ b/plugins/serial-engine/src/Worker.ts
@@ -1,5 +1,6 @@
 import {
-  AgentRun,
+  Action,
+  ActionContext,
   Budget,
   Event,
   EventKind,
@@ -10,52 +11,42 @@ import {
   QueueItem,
   StopSwitch,
   Store,
+  WorkRecord,
+  Workflow,
+  WorkflowRuntime,
   actionsOf,
+  applyPlan,
   dispatchesTo,
-  CORE_ACTIONS,
 } from "@amy/core";
-import {
-  Agent,
-  CodeHost,
-  Effect,
-  EffectOutcomes,
-  Gate,
-  Observation,
-  Policy,
-  Roster,
-  Ticket,
-  TicketRecord,
-  TicketState,
-  Tracker,
-  applyTicketPlan,
-  newRecord,
-  plan,
-  pullRequestTitle,
-} from "@amy/workflow-ticket-to-qa";
 
 export interface WorkerConfig {
-  /** Every repository the team reviews in, for counting review load. */
-  repos: readonly string[];
-  /** The status a ticket moves to when it is handed to QA. */
-  qaStatusName: string;
-  policy: Policy;
   /** How long a claimed item may sit before it is treated as abandoned. */
   staleClaimMs: number;
   /** How long finished queue items are kept before being pruned. */
   retentionDays: number;
-  /** How many times one ticket may fail before the machine gives up on it. */
+  /** How many times one item may fail before the machine gives up on it. */
   maxItemAttempts: number;
+  /** How long to hold a failed item before looking at it again. */
+  retryDelayMs: number;
 }
 
 export interface WorkerDeps {
   queue: Queue;
-  records: Store<TicketRecord>;
-  tracker: Tracker;
-  host: CodeHost;
-  agent: Agent;
-  gate: Gate;
+  records: Store;
+  /** The order the states happen in, and what the workflow says it emits. */
+  workflow: Workflow;
+  /**
+   * How that workflow's actions actually run.
+   *
+   * This is the whole reason this engine is not welded to one domain. What
+   * used to be here — an observation built out of a tracker, a handler per
+   * ticket action, a fold that knew what a gate result is — is on the other
+   * side of this interface now, in the package that knows what those words
+   * mean.
+   */
+  runtime: WorkflowRuntime;
+  /** Core's own port, and the only one left here: a failure has to be sayable. */
   notifier: Notifier;
-  roster: () => Roster;
   now: () => Date;
   config: WorkerConfig;
   /** Optional, so an engine with no log still runs. */
@@ -64,28 +55,7 @@ export interface WorkerDeps {
   stop?: StopSwitch;
   /** Optional, so an engine with no ceiling on spending still runs. */
   budget?: Budget;
-  /**
-   * The workflow to drive. Defaults to the one this engine was written for,
-   * but taking it here is what lets another workflow be mounted instead of
-   * forked, and what lets a test drive a plan this one never emits.
-   */
-  decide?: typeof plan;
 }
-
-interface ActionContext {
-  ticket: Ticket;
-  observation: Observation;
-  record: TicketRecord;
-  outcomes: EffectOutcomes;
-}
-
-/** Exhaustive over the workflow's actions, checked at compile time. */
-type ActionHandlers = {
-  [K in Effect["type"]]: (
-    effect: Extract<Effect, { type: K }>,
-    ctx: ActionContext,
-  ) => Promise<void>;
-};
 
 /** The one result the budget produces, named so the check can return it. */
 export type Parked = Extract<TickResult, { kind: "parked" }>;
@@ -96,45 +66,51 @@ export type TickResult =
   | {
       kind: "worked";
       workId: string;
-      from: TicketState;
-      to: TicketState;
+      from: string;
+      to: string;
       plan: Plan["kind"];
       why: string;
       /** Set when the plan asked to be looked at again later. */
       retryAfterMs?: number;
     }
-  | { kind: "failed"; workId: string; state: TicketState; error: string }
+  | { kind: "failed"; workId: string; state: string; error: string }
   /** The move would have spent an agent, and the budget said not yet. */
   | {
       kind: "parked";
       workId: string;
-      state: TicketState;
+      state: string;
       reason: string;
       retryAfterMs: number;
     };
 
 /**
- * Advances at most one ticket by at most one move, then chains the next look.
+ * Advances at most one piece of work by at most one move, then chains the
+ * next look.
  *
  * Nothing here decides *when* the next step runs. A step that takes a minute
  * and a step that takes an hour both enqueue their successor the moment they
  * finish, so the queue is the schedule.
+ *
+ * Nothing here decides *what* a step is, either. Every noun in this file is
+ * queue, record, attempt, budget or stop; a ticket, a pull request and a
+ * reviewer are all on the far side of `runtime`.
  */
 export class Worker {
   constructor(private readonly deps: WorkerDeps) {}
 
-  /** Puts every ticket in the working status onto the queue. */
+  /** Puts every piece of work the runtime can find onto the queue. */
   async discover(): Promise<string[]> {
     const now = this.deps.now();
     const enqueued: string[] = [];
+    const terminal = this.deps.workflow.terminalStates;
 
-    for (const ticket of await this.deps.tracker.inProgress()) {
-      const existing = this.deps.records.load(ticket.id);
-      if (existing && existing.state === "DONE") continue;
-      if (this.deps.queue.pending().some((i) => i.workId === ticket.id)) continue;
+    for (const workId of await this.deps.runtime.found()) {
+      const existing = this.deps.records.load(workId);
+      if (existing && terminal.includes(existing.state)) continue;
+      if (this.deps.queue.pending().some((item) => item.workId === workId)) continue;
 
-      this.deps.queue.enqueue({ workId: ticket.id, reason: "found in the working status" }, now);
-      enqueued.push(ticket.id);
+      this.deps.queue.enqueue({ workId, reason: "found by the workflow" }, now);
+      enqueued.push(workId);
     }
 
     return enqueued;
@@ -158,7 +134,8 @@ export class Worker {
 
     this.record("run.claimed", { workId: item.workId, detail: { reason: item.reason } });
 
-    const record = this.deps.records.load(item.workId) ?? newRecord(item.workId, now);
+    const record =
+      this.deps.records.load(item.workId) ?? this.deps.runtime.newRecord(item.workId, now);
 
     try {
       return await this.advance(item, record, now);
@@ -167,14 +144,9 @@ export class Worker {
     }
   }
 
-  private async advance(
-    item: QueueItem,
-    record: TicketRecord,
-    now: Date,
-  ): Promise<TickResult> {
-    const observation = await this.observe(record);
-    const decide = this.deps.decide ?? plan;
-    const decision = decide(record, observation, this.deps.config.policy);
+  private async advance(item: QueueItem, record: WorkRecord, now: Date): Promise<TickResult> {
+    const observation = await this.deps.runtime.observe(record);
+    const decision = this.deps.workflow.plan(record, observation, this.deps.runtime.policy);
 
     this.record("work.planned", {
       workId: item.workId,
@@ -199,9 +171,9 @@ export class Worker {
       };
     }
 
-    const effects = actionsOf(decision) as Effect[];
+    const actions = actionsOf(decision);
 
-    const parked = this.parked(record, effects, now);
+    const parked = this.parked(record, actions, now);
     if (parked) {
       this.deps.queue.enqueue(
         {
@@ -219,8 +191,19 @@ export class Worker {
       return parked;
     }
 
-    const outcomes = await this.execute(observation, record, effects);
-    const next = applyTicketPlan(record, decision, outcomes, now);
+    const outcomes = await this.execute(observation, record, actions);
+
+    // The core folds the state, the attempt count and the history; the
+    // runtime folds what only it can read. Two calls rather than one because
+    // the second cannot be written without knowing the domain, and this
+    // engine is the half that does not.
+    const next = this.deps.runtime.apply(
+      applyPlan(record, decision, now),
+      decision,
+      outcomes,
+      observation,
+      now,
+    );
     this.deps.records.save(next);
 
     this.deps.queue.enqueue(
@@ -258,15 +241,17 @@ export class Worker {
    * A budget refusal, when this move would spend an agent and the ceiling is
    * already reached.
    *
-   * The record is deliberately not saved: the ticket keeps its state and its
+   * The record is deliberately not saved: the work keeps its state and its
    * per-state attempt count, and only its next look moves. Parked, not lost.
    * The queue item's own attempt count is carried by the caller, which is a
    * different counter and has to be said, not assumed.
    */
-  private parked(record: TicketRecord, effects: readonly Effect[], now: Date): Parked | null {
+  private parked(record: WorkRecord, actions: readonly Action[], now: Date): Parked | null {
     if (!this.deps.budget) return null;
 
-    const spending = effects.filter((e) => dispatchesTo(e.type, "agent")).map((e) => e.type);
+    const spending = actions
+      .filter((action) => dispatchesTo(action.type, "agent"))
+      .map((action) => action.type);
     if (spending.length === 0) return null;
 
     const decision = this.deps.budget.mayStart(now);
@@ -297,7 +282,7 @@ export class Worker {
 
   private async recordFailure(
     item: QueueItem,
-    record: TicketRecord,
+    record: WorkRecord,
     error: unknown,
   ): Promise<TickResult> {
     const message = error instanceof Error ? error.message : String(error);
@@ -314,7 +299,7 @@ export class Worker {
 
     // Routed through `announce`, not straight at the port. The item is
     // already completed by this point, so a single broken channel used to
-    // throw past `tick()` and the ticket left the queue with no record of why.
+    // throw past `tick()` and the work left the queue with no record of why.
     const notice = this.failureNotice(item, record, attempt, message);
     if (notice) await this.announce(notice, item.workId, record.state);
 
@@ -323,7 +308,7 @@ export class Worker {
         {
           workId: item.workId,
           reason: `retrying after an error: ${message}`,
-          delayMs: this.deps.config.policy.pollBackoffMs,
+          delayMs: this.deps.config.retryDelayMs,
           attempt,
         },
         now,
@@ -349,7 +334,7 @@ export class Worker {
    */
   private failureNotice(
     item: QueueItem,
-    record: TicketRecord,
+    record: WorkRecord,
     attempt: number,
     message: string,
   ): string | null {
@@ -378,7 +363,7 @@ export class Worker {
    * "I have stopped, come and look", and announcing a recovery there would
    * give the machine credit for a person's repair.
    */
-  private async announceRecovery(item: QueueItem, state: TicketState): Promise<void> {
+  private async announceRecovery(item: QueueItem, state: string): Promise<void> {
     if (item.attempt === 0) return;
 
     this.record("work.recovered", {
@@ -394,189 +379,32 @@ export class Worker {
     );
   }
 
-  private async observe(record: TicketRecord): Promise<Observation> {
-    const ticket = await this.requireTicket(record.id);
-
-    const pullRequest = await this.deps.host.findPullRequest(ticket.repo, ticket.branchName);
-
-    // Only fetched where it is used, so a poll that is only waiting for a
-    // review does not hammer the code host counting everybody's workload.
-    const reviewLoad =
-      record.state === "REVIEWER_ASSIGNED"
-        ? await this.deps.host.reviewLoad(this.deps.config.repos)
-        : {};
-
-    const awaitingAnswer = record.triage && !record.triage.clear;
-    const awaitingOwner = record.escalation && !record.escalation.resolvedAt;
-
-    return {
-      ticket,
-      pullRequest,
-      reviewLoad,
-      roster: this.deps.roster(),
-      questionAnswered: awaitingAnswer
-        ? await this.deps.tracker.hasReplyAfter(ticket.id, record.triage!.at)
-        : false,
-      escalationAnswered: awaitingOwner
-        ? await this.deps.tracker.hasReplyAfter(ticket.id, record.escalation!.askedAt)
-        : false,
-      now: this.deps.now(),
-    };
-  }
-
-  private async requireTicket(workId: string): Promise<Ticket> {
-    const ticket = await this.deps.tracker.get(workId);
-    if (!ticket) {
-      throw new Error(`${workId} is not in the tracker any more`);
-    }
-    return ticket;
-  }
-
   /**
-   * What one action needs to do its work, and where it records what happened.
-   */
-  private context(observation: Observation, record: TicketRecord, outcomes: EffectOutcomes) {
-    return { ticket: observation.ticket, observation, record, outcomes };
-  }
-
-  /**
-   * One handler per action, rather than one branch per action.
+   * Actions the workflow says it emits that nothing here could run.
    *
-   * Keyed on the action name and exhaustive over it, so a new action the
-   * workflow can emit will not compile until something here runs it. That is
-   * the same guarantee the switch this replaced gave, without putting every
-   * action's argument shaping in one function.
-   */
-  private handlers(): ActionHandlers {
-    const deps = this.deps;
-
-    return {
-      "triage": async (_effect, ctx) => {
-        const { value, run } = await deps.agent.triage(ctx.ticket);
-        this.recordAgentRun(ctx, run);
-        refuseAnIncompleteRun("triage", run);
-        ctx.outcomes.triage = value;
-      },
-
-      "ask-question": async (effect, ctx) => {
-        await deps.tracker.comment(
-          ctx.ticket.id,
-          effect.questions.map((q) => `- ${q}`).join("\n"),
-        );
-        await this.announce(
-          `${ctx.ticket.id} needs an answer before I can start.`,
-          ctx.ticket.id,
-          ctx.record.state,
-        );
-      },
-
-      "implement": async (effect, ctx) => {
-        const { value, run } = await deps.agent.implement(ctx.ticket, effect.retryContext);
-        this.recordAgentRun(ctx, run);
-        ctx.outcomes.implementation = value;
-      },
-
-      "run-gate": async (_effect, ctx) => {
-        ctx.outcomes.gate = await deps.gate.run(ctx.ticket);
-      },
-
-      "open-pull-request": async (_effect, ctx) => {
-        ctx.outcomes.pullRequestNumber = await deps.host.openPullRequest({
-          repo: ctx.ticket.repo,
-          branch: ctx.ticket.branchName,
-          title: pullRequestTitle(ctx.ticket),
-          // Empty by convention. The ticket is the description.
-          body: "",
-        });
-      },
-
-      "address-threads": async (effect, ctx) => {
-        const threads = (ctx.observation.pullRequest?.threads ?? []).filter((t) =>
-          effect.threadIds.includes(t.id),
-        );
-        const { value, run } = await deps.agent.addressThreads(ctx.ticket, threads, effect.from);
-        this.recordAgentRun(ctx, run);
-        refuseAnIncompleteRun("address-threads", run);
-        ctx.outcomes.verdicts = value;
-      },
-
-      "assign-reviewer": async (effect, ctx) => {
-        await this.requestReview(ctx.observation, ctx.record, effect.host);
-        ctx.outcomes.reviewer = effect.host;
-      },
-
-      "request-rereview": async (effect, ctx) => {
-        await this.requestReview(ctx.observation, ctx.record, effect.host);
-      },
-
-      "escalate": async (effect, ctx) => {
-        const followUpTicketId = await deps.tracker.createFollowUp({
-          parentTicketId: ctx.ticket.id,
-          title: `FUP ${ctx.ticket.id}: review comments need a decision`,
-          body: effect.reason,
-        });
-
-        ctx.outcomes.escalation = {
-          reason: effect.reason,
-          askedAt: deps.now().toISOString(),
-          followUpTicketId,
-        };
-
-        await this.announce(
-          `${ctx.ticket.id} is parked, ${followUpTicketId} has the details.`,
-          ctx.ticket.id,
-          ctx.record.state,
-        );
-      },
-
-      "hand-off-to-qa": async (effect, ctx) => {
-        await deps.tracker.setStatus(ctx.ticket.id, deps.config.qaStatusName);
-        await deps.tracker.assign(ctx.ticket.id, effect.tracker);
-      },
-
-      "announce": async (effect, ctx) => {
-        await this.announce(effect.text, ctx.ticket.id, ctx.record.state);
-      },
-    };
-  }
-
-  /**
-   * Actions the workflow says it emits that this engine could not run.
-   *
-   * Either nothing handles the name, or the core says the action needs a port
-   * this engine has not been given. Asked before a ticket is touched rather
-   * than discovered halfway through one.
+   * The port half of this question is `unmetNeeds` in the core, which reads
+   * the mount. This is the other half: whether the runtime brought a handler
+   * for each name. Asked before any work is touched rather than discovered
+   * halfway through a piece of it.
    */
   missingActions(usesActions: readonly string[]): string[] {
-    const handlers = this.handlers() as Record<string, unknown>;
-    const mounted: Record<string, boolean> = {
-      agent: Boolean(this.deps.agent),
-      tracker: Boolean(this.deps.tracker),
-      "code-host": Boolean(this.deps.host),
-      gate: Boolean(this.deps.gate),
-      notifier: Boolean(this.deps.notifier),
-    };
-
-    return usesActions.filter((name) => {
-      if (!handlers[name]) return true;
-      const spec = CORE_ACTIONS[name];
-      return spec !== undefined && !mounted[spec.port];
-    });
+    const handlers = this.deps.runtime.handlers();
+    return usesActions.filter((name) => !handlers[name]);
   }
 
   private async execute(
-    observation: Observation,
-    record: TicketRecord,
-    effects: readonly Effect[],
-  ): Promise<EffectOutcomes> {
-    const outcomes: EffectOutcomes = {};
-    const ctx = this.context(observation, record, outcomes);
-    const handlers = this.handlers();
+    observation: unknown,
+    record: WorkRecord,
+    actions: readonly Action[],
+  ): Promise<Record<string, unknown>> {
+    const outcomes: Record<string, unknown> = {};
+    const ctx: ActionContext = { record, observation, outcomes };
+    const handlers = this.deps.runtime.handlers();
 
-    for (const effect of effects) {
-      const handler = handlers[effect.type] as (e: Effect, c: typeof ctx) => Promise<void>;
+    for (const action of actions) {
+      const handler = handlers[action.type];
       if (!handler) {
-        throw new Error(`no handler is mounted for the action "${effect.type}"`);
+        throw new Error(`no handler is mounted for the action "${action.type}"`);
       }
 
       // Between actions as well as between ticks, because a plan can carry
@@ -585,20 +413,20 @@ export class Worker {
         this.record("stop.enforced", {
           workId: record.id,
           state: record.state,
-          detail: { pending: effect.type, reason: this.deps.stop.reason() },
+          detail: { pending: action.type, reason: this.deps.stop.reason() },
         });
         break;
       }
 
-      this.record("action.started", { workId: record.id, detail: { action: effect.type } });
+      this.record("action.started", { workId: record.id, detail: { action: action.type } });
       try {
-        await handler(effect, ctx);
-        this.record("action.finished", { workId: record.id, detail: { action: effect.type } });
+        await handler(action, ctx);
+        this.record("action.finished", { workId: record.id, detail: { action: action.type } });
       } catch (error) {
         this.record("action.failed", {
           workId: record.id,
           detail: {
-            action: effect.type,
+            action: action.type,
             error: error instanceof Error ? error.message : String(error),
           },
         });
@@ -606,39 +434,23 @@ export class Worker {
       }
     }
 
-    if (record.escalation && !record.escalation.resolvedAt && observation.escalationAnswered) {
-      outcomes.escalationResolvedAt = this.deps.now().toISOString();
-    }
-
     return outcomes;
   }
 
-  private async requestReview(
-    observation: Observation,
-    record: TicketRecord,
-    host: string,
-  ): Promise<void> {
-    const number = observation.pullRequest?.number ?? record.pullRequestNumber;
-    if (number === undefined) {
-      throw new Error(`${record.id} has no pull request to request a review on`);
-    }
-    await this.deps.host.requestReview(observation.ticket.repo, number, host);
-  }
-
   /**
-   * Says something to the operator, and never lets that cost a ticket.
+   * Says something to the operator, and never lets that cost a piece of work.
    *
    * A port call may only be swallowed when its failure does not make the
    * saved record a lie, and this is the one that qualifies: nothing
-   * downstream reads a notification. The tracker, the code host, the agent
-   * and the gate are all deliberately not wrapped — see
+   * downstream reads a notification. Every other port is reached through the
+   * runtime and is deliberately not wrapped — see
    * `plans/the-engine-fails-out-loud.md`.
    *
    * It lives here rather than only in the fan-out because `notifier` is a
    * port and an install may mount something else behind it. The promise is
    * the engine's, not the mounted plugin's.
    */
-  private async announce(text: string, workId: string, state: TicketState): Promise<void> {
+  private async announce(text: string, workId: string, state: string): Promise<void> {
     try {
       await this.deps.notifier.announce({ text, workId, state });
     } catch (error) {
@@ -651,37 +463,11 @@ export class Worker {
   }
 
   /**
-   * Writes down what an agent run took.
-   *
-   * Every field the relay and the budget will need is here, and `costSource`
-   * says whether the money figure was measured or worked out, so nothing
-   * downstream has to guess which.
-   */
-  private recordAgentRun(ctx: { record: TicketRecord }, run: AgentRun): void {
-    this.record("agent.run", {
-      // The record's id, like every other line, rather than the ticket's.
-      // They agree in production and a log that keys on two different things
-      // cannot be joined.
-      workId: ctx.record.id,
-      state: ctx.record.state,
-      detail: {
-        harness: run.harness,
-        model: run.model,
-        outcome: run.outcome,
-        durationMs: run.durationMs,
-        costSource: run.costSource,
-        ...(run.costUsd === undefined ? {} : { costUsd: run.costUsd }),
-        ...(run.tokens === undefined ? {} : { tokens: { ...run.tokens } }),
-      },
-    });
-  }
-
-  /**
    * Appends to the log if there is one, and shrugs if there is not.
    *
-   * A full disk or a bad permission under `.amy/log` must not cost a ticket a
-   * move, and must not be silent either, or the machine looks healthy while
-   * keeping no record of anything.
+   * A full disk or a bad permission under `.amy/log` must not cost a piece of
+   * work a move, and must not be silent either, or the machine looks healthy
+   * while keeping no record of anything.
    *
    * Once per worker: a broken log throws on every one of the eight or so
    * calls in a tick, and a flood in stderr is its own outage. It does not
@@ -723,26 +509,4 @@ export class Worker {
   private maybePrune(now: Date): void {
     this.deps.queue.prune(this.deps.config.retentionDays, now);
   }
-}
-
-/**
- * Fails an action whose agent run did not complete.
- *
- * By the time this is reached, a relay has already tried every harness and
- * model it was given, so there is nowhere left to go and the action has to
- * fail rather than store an answer nobody gave.
- *
- * `implement` is deliberately not one of these: an attempt that did not hold
- * is a first-class outcome there, and the machine retries it with the reason
- * attached. `triage` and `address-threads` have no such outcome, and taking
- * their empty value as an answer would park a ticket waiting on a question
- * that was never asked, or drop a review comment nobody replied to.
- */
-function refuseAnIncompleteRun(action: string, run: AgentRun): void {
-  if (run.outcome === "completed") return;
-
-  throw new Error(
-    `${action} did not complete: ${run.outcome} on ${run.harness}` +
-      `${run.model ? ` (${run.model})` : ""}${run.output ? `\n\n${run.output}` : ""}`,
-  );
 }

--- a/plugins/serial-engine/src/config.ts
+++ b/plugins/serial-engine/src/config.ts
@@ -1,17 +1,13 @@
 import { ConfigSchema } from "@amy/core";
 
-/** What this plugin needs told to it, and nothing more. */
+/**
+ * What this plugin needs told to it, and nothing more.
+ *
+ * `repos`, `qaStatusName` and `policy` used to be here. They are the
+ * workflow's vocabulary, not an engine's, and they moved to the workflow's
+ * own slice when the engine stopped knowing what a ticket is.
+ */
 export const configSchema: ConfigSchema = {
-  repos: {
-    type: "string[]",
-    required: true,
-    description: "every repository review load is counted across",
-  },
-  qaStatusName: {
-    type: "string",
-    required: true,
-    description: "the status a ticket moves to when it is handed to QA",
-  },
   staleClaimMs: {
     type: "number",
     description: "how long a claimed item may sit before it counts as abandoned",
@@ -22,15 +18,14 @@ export const configSchema: ConfigSchema = {
     description: "how long a finished queue item is kept before it is pruned",
     default: 7,
   },
-  policy: {
-    type: "record",
-    description:
-      "the workflow's policy: maxImplementAttempts, maxGateAttempts, pollBackoffMs, rosterBackoffMs and maxOpenReviewsPerReviewer. Anything left out keeps its default",
-    default: {},
-  },
   maxItemAttempts: {
     type: "number",
-    description: "how many times one ticket may fail before the operator is told",
+    description: "how many times one item may fail before the operator is told and it is dropped",
     default: 5,
+  },
+  retryDelayMs: {
+    type: "number",
+    description: "how long a failed item is held before it is looked at again",
+    default: 5 * 60 * 1000,
   },
 };

--- a/plugins/serial-engine/src/index.ts
+++ b/plugins/serial-engine/src/index.ts
@@ -1,5 +1,4 @@
 export { Worker } from "./Worker.js";
 export type { TickResult, WorkerConfig, WorkerDeps } from "./Worker.js";
 export { configSchema } from "./config.js";
-export { WORKFLOW_DATA, plugin } from "./plugin.js";
-export type { Provider } from "./plugin.js";
+export { plugin } from "./plugin.js";

--- a/plugins/serial-engine/src/plugin.ts
+++ b/plugins/serial-engine/src/plugin.ts
@@ -1,33 +1,26 @@
-import { Budget, Engine, Notifier, Plugin, PluginContext, Queue, Store } from "@amy/core";
 import {
-  Agent,
-  CodeHost,
-  Gate,
-  Policy,
-  Roster,
-  TicketRecord,
-  Tracker,
-  DEFAULT_POLICY,
-  ticketToQa,
-} from "@amy/workflow-ticket-to-qa";
+  Budget,
+  Engine,
+  Notifier,
+  Plugin,
+  PluginContext,
+  Queue,
+  Store,
+  WORKFLOW_RUNTIME,
+  Workflow,
+  WorkflowRuntime,
+} from "@amy/core";
 import { Worker } from "./Worker.js";
 import { configSchema } from "./config.js";
-
-/** Something one plugin contributes for another to read when it is needed. */
-export interface Provider<T> {
-  read(): T;
-}
-
-/** The collection the host puts workflow data in, such as today's roster. */
-export const WORKFLOW_DATA = "workflow-data";
 
 export const plugin: Plugin = {
   name: "@amy/plugin-serial-engine",
   version: "0.1.0",
   configSchema,
   register(registry, ctx) {
-    // Built on the first tick rather than now, because the ports it needs are
-    // mounted by plugins that may be listed after this one.
+    // Built on the first tick rather than now, because the workflow and the
+    // ports it needs are registered by plugins that may be listed after this
+    // one.
     let worker: Worker | null = null;
     const lazily = (): Worker => (worker ??= build(ctx));
 
@@ -40,42 +33,69 @@ export const plugin: Plugin = {
     };
 
     registry.engine(engine);
-    registry.workflow(ticketToQa);
   },
 };
 
 function build(ctx: PluginContext): Worker {
+  const workflow = ctx.workflow() as Workflow | undefined;
+  if (!workflow) {
+    throw new Error("the serial engine needs a workflow, and no plugin registered one");
+  }
+
+  // The pair first: a workflow with no runtime is an engine that cannot
+  // mean anything, and saying so beats reporting a missing queue to somebody
+  // whose real problem is a half-mounted workflow.
+  const runtime = runtimeFor(ctx, workflow);
+
   return new Worker({
     queue: required<Queue>(ctx, "queue"),
-    records: required<Store<TicketRecord>>(ctx, "store"),
-    tracker: required<Tracker>(ctx, "tracker"),
-    host: required<CodeHost>(ctx, "code-host"),
-    agent: required<Agent>(ctx, "agent"),
-    gate: required<Gate>(ctx, "gate"),
+    records: required<Store>(ctx, "store"),
+    workflow,
+    runtime,
     notifier: required<Notifier>(ctx, "notifier"),
-    roster: () => provided<Roster>(ctx, "roster"),
     now: ctx.now,
     log: ctx.log,
     // Optional: an install that set no ceiling mounts no budget, and this
     // engine then never asks one.
     budget: ctx.port("budget") as Budget | undefined,
     config: {
-      repos: ctx.config.repos as string[],
-      qaStatusName: ctx.config.qaStatusName as string,
-      policy: { ...DEFAULT_POLICY, ...(ctx.config.policy as Partial<Policy>) },
       staleClaimMs: ctx.config.staleClaimMs as number,
       retentionDays: ctx.config.retentionDays as number,
       maxItemAttempts: ctx.config.maxItemAttempts as number,
+      retryDelayMs: ctx.config.retryDelayMs as number,
     },
   });
 }
 
 /**
- * A port this engine cannot work without.
+ * The runtime the mounted workflow contributed.
+ *
+ * Looked up by the workflow's own name, so an install that mounts two
+ * workflows and one runtime is refused here rather than driving the wrong
+ * half of itself. Naming what there was to choose from, because a
+ * mismatched pair is a config mistake and the fix is a name.
+ */
+function runtimeFor(ctx: PluginContext, workflow: Workflow): WorkflowRuntime {
+  const contributed = ctx.contributions(WORKFLOW_RUNTIME);
+  const runtime = contributed.get(workflow.name);
+
+  if (!runtime) {
+    const offered = [...contributed.keys()].join(", ") || "nothing";
+    throw new Error(
+      `the workflow \`${workflow.name}\` contributed no runtime to \`${WORKFLOW_RUNTIME}\`, ` +
+        `so nothing here knows how to run its actions. Contributed: ${offered}`,
+    );
+  }
+
+  return runtime as WorkflowRuntime;
+}
+
+/**
+ * Something this engine cannot work without.
  *
  * The loader already refuses a mount where an action has no port, so reaching
  * here means something registered an engine without the rest. Saying which
- * port beats a property access on undefined.
+ * one beats a property access on undefined.
  */
 function required<T>(ctx: PluginContext, kind: string): T {
   const port = ctx.port(kind);
@@ -83,12 +103,4 @@ function required<T>(ctx: PluginContext, kind: string): T {
     throw new Error(`the serial engine needs the \`${kind}\` port, and nothing mounted it`);
   }
   return port as T;
-}
-
-function provided<T>(ctx: PluginContext, name: string): T {
-  const entry = ctx.contributions(WORKFLOW_DATA).get(name);
-  if (!entry) {
-    throw new Error(`the serial engine needs \`${name}\` in the \`${WORKFLOW_DATA}\` collection`);
-  }
-  return (entry as Provider<T>).read();
 }

--- a/plugins/serial-engine/tests/Worker.failures.test.ts
+++ b/plugins/serial-engine/tests/Worker.failures.test.ts
@@ -5,14 +5,13 @@ import path from "node:path";
 import { Worker, WorkerDeps } from "../src/Worker.js";
 import { FileQueue } from "@amy/plugin-file-queue";
 import { LogBudget } from "@amy/core";
-import { WORKDAY, roster } from "@amy/test-fixtures";
+import { WORKDAY } from "@amy/test-fixtures";
 import {
+  ticketWorkerDeps,
   InMemoryStore,
   RecordingEventLog,
   RecordingNotifier,
   fakeAgent,
-  fakeGate,
-  fakeHost,
   fakeTracker,
   workerConfig,
 } from "@amy/test-fixtures";
@@ -47,16 +46,12 @@ describe("a dependency that goes down and comes back", () => {
     return new Worker({
       queue,
       records,
-      tracker: fakeTracker(),
-      host: fakeHost(),
-      agent: fakeAgent(),
-      gate: fakeGate(),
-      notifier,
-      roster: () => roster(),
-      now: () => clock,
-      config: workerConfig,
-      log,
-      ...overrides,
+      ...ticketWorkerDeps({
+        notifier,
+        now: () => clock,
+        log,
+        ...overrides,
+      }),
     });
   }
 
@@ -66,7 +61,7 @@ describe("a dependency that goes down and comes back", () => {
 
   /** Past the backoff, because the retried item is held behind it. */
   function later(): void {
-    clock = new Date(clock.getTime() + workerConfig.policy.pollBackoffMs + 1000);
+    clock = new Date(clock.getTime() + workerConfig.retryDelayMs + 1000);
   }
 
   it("warns once on the first failure", async () => {

--- a/plugins/serial-engine/tests/Worker.isolation.test.ts
+++ b/plugins/serial-engine/tests/Worker.isolation.test.ts
@@ -4,17 +4,15 @@ import os from "node:os";
 import path from "node:path";
 import { Worker, WorkerDeps } from "../src/Worker.js";
 import { FileQueue } from "@amy/plugin-file-queue";
-import { WORKDAY, roster } from "@amy/test-fixtures";
+import { WORKDAY } from "@amy/test-fixtures";
 import {
+  ticketWorkerDeps,
   InMemoryStore,
   RecordingEventLog,
   RecordingNotifier,
   ThrowingEventLog,
   ThrowingNotifier,
   fakeAgent,
-  fakeGate,
-  fakeHost,
-  fakeTracker,
   workerConfig,
 } from "@amy/test-fixtures";
 
@@ -47,16 +45,11 @@ describe("a broken notifier and a broken log", () => {
     return new Worker({
       queue,
       records,
-      tracker: fakeTracker(),
-      host: fakeHost(),
-      agent: fakeAgent(),
-      gate: fakeGate(),
-      notifier: new RecordingNotifier(),
-      roster: () => roster(),
-      now: () => clock,
-      config: workerConfig,
-      log,
-      ...overrides,
+      ...ticketWorkerDeps({
+        now: () => clock,
+        log,
+        ...overrides,
+      }),
     });
   }
 
@@ -72,7 +65,7 @@ describe("a broken notifier and a broken log", () => {
 
     const result = await build({
       notifier: new ThrowingNotifier(),
-      decide: announcing,
+      plan: announcing,
     }).tick();
 
     expect(result).toMatchObject({ kind: "worked" });
@@ -81,7 +74,7 @@ describe("a broken notifier and a broken log", () => {
   it("records the notification it could not send", async () => {
     queue.enqueue({ workId: "PROJ-1239", reason: "discovered" }, clock);
 
-    await build({ notifier: new ThrowingNotifier(), decide: announcing }).tick();
+    await build({ notifier: new ThrowingNotifier(), plan: announcing }).tick();
 
     const [failed] = log.of("notify.failed");
     expect(failed?.workId).toBe("PROJ-1239");
@@ -92,7 +85,7 @@ describe("a broken notifier and a broken log", () => {
   it("still saves the move the announcement was about", async () => {
     queue.enqueue({ workId: "PROJ-1239", reason: "discovered" }, clock);
 
-    await build({ notifier: new ThrowingNotifier(), decide: announcing }).tick();
+    await build({ notifier: new ThrowingNotifier(), plan: announcing }).tick();
 
     expect(records.load("PROJ-1239")).not.toBeNull();
   });

--- a/plugins/serial-engine/tests/Worker.stop.test.ts
+++ b/plugins/serial-engine/tests/Worker.stop.test.ts
@@ -4,18 +4,15 @@ import os from "node:os";
 import path from "node:path";
 import { Worker, WorkerDeps } from "../src/Worker.js";
 import { FileQueue } from "@amy/plugin-file-queue";
-import { WORKDAY, roster } from "@amy/test-fixtures";
+import { WORKDAY } from "@amy/test-fixtures";
 import {
+  ticketWorkerDeps,
   FakeStopSwitch,
   agentResult,
   InMemoryStore,
   RecordingEventLog,
-  RecordingNotifier,
   fakeAgent,
-  fakeGate,
-  fakeHost,
   fakeTracker,
-  workerConfig,
 } from "@amy/test-fixtures";
 
 describe("the handbrake", () => {
@@ -41,17 +38,12 @@ describe("the handbrake", () => {
     return new Worker({
       queue,
       records,
-      tracker: fakeTracker(),
-      host: fakeHost(),
-      agent: fakeAgent(),
-      gate: fakeGate(),
-      notifier: new RecordingNotifier(),
-      roster: () => roster(),
-      now: () => WORKDAY,
-      config: workerConfig,
-      log,
-      stop,
-      ...overrides,
+      ...ticketWorkerDeps({
+        now: () => WORKDAY,
+        log,
+        stop,
+        ...overrides,
+      }),
     });
   }
 
@@ -101,7 +93,7 @@ describe("the handbrake", () => {
 
     await build({
       tracker,
-      decide: () => ({
+      plan: () => ({
         kind: "act",
         why: "two actions, and the brake comes down after the first",
         effects: [{ type: "ask-question", questions: ["first"] }, { type: "run-gate" }],
@@ -145,16 +137,11 @@ describe("what the engine writes down", () => {
     return new Worker({
       queue,
       records: new InMemoryStore(),
-      tracker: fakeTracker(),
-      host: fakeHost(),
-      agent: fakeAgent(),
-      gate: fakeGate(),
-      notifier: new RecordingNotifier(),
-      roster: () => roster(),
-      now: () => WORKDAY,
-      config: workerConfig,
-      log,
-      ...overrides,
+      ...ticketWorkerDeps({
+        now: () => WORKDAY,
+        log,
+        ...overrides,
+      }),
     });
   }
 

--- a/plugins/serial-engine/tests/Worker.test.ts
+++ b/plugins/serial-engine/tests/Worker.test.ts
@@ -2,16 +2,17 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { WorkflowRuntime } from "@amy/core";
 import { Worker, WorkerDeps } from "../src/Worker.js";
 import { FileQueue } from "@amy/plugin-file-queue";
 import { DEFAULT_POLICY } from "@amy/workflow-ticket-to-qa";
 import { USES_ACTIONS, newRecord } from "@amy/workflow-ticket-to-qa";
-import { HEAD, WORKDAY, botReview, pullRequest, roster, thread, ticket } from "@amy/test-fixtures";
+import { HEAD, WORKDAY, botReview, pullRequest, thread, ticket } from "@amy/test-fixtures";
 import {
+  ticketWorkerDeps,
   InMemoryStore,
   RecordingNotifier,
   fakeAgent,
-  fakeGate,
   fakeHost,
   fakeTracker,
   workerConfig,
@@ -40,15 +41,11 @@ describe("Worker", () => {
     return new Worker({
       queue,
       records,
-      tracker: fakeTracker(),
-      host: fakeHost(),
-      agent: fakeAgent(),
-      gate: fakeGate(),
-      notifier,
-      roster: () => roster(),
-      now: () => clock,
-      config: workerConfig,
-      ...overrides,
+      ...ticketWorkerDeps({
+        notifier,
+        now: () => clock,
+        ...overrides,
+      }),
     });
   }
 
@@ -314,14 +311,7 @@ describe("Worker.discover", () => {
     return new Worker({
       queue,
       records,
-      tracker,
-      host: fakeHost(),
-      agent: fakeAgent(),
-      gate: fakeGate(),
-      notifier: new RecordingNotifier(),
-      roster: () => roster(),
-      now: () => WORKDAY,
-      config: workerConfig,
+      ...ticketWorkerDeps({ tracker, now: () => WORKDAY }),
     });
   }
 
@@ -364,15 +354,10 @@ describe("Worker.missingActions", () => {
     return new Worker({
       queue: new FileQueue(path.join(root, "queue")),
       records: new InMemoryStore(),
-      tracker: fakeTracker(),
-      host: fakeHost(),
-      agent: fakeAgent(),
-      gate: fakeGate(),
-      notifier: new RecordingNotifier(),
-      roster: () => roster(),
-      now: () => WORKDAY,
-      config: workerConfig,
-      ...overrides,
+      ...ticketWorkerDeps({
+        now: () => WORKDAY,
+        ...overrides,
+      }),
     });
   }
 
@@ -386,10 +371,35 @@ describe("Worker.missingActions", () => {
     expect(build().missingActions(["check-web-browser"])).toEqual(["check-web-browser"]);
   });
 
-  it("names a core action whose port was never mounted", () => {
-    const withoutGate = build({ gate: undefined as never });
+  // The other half of this question — whether the port an action dispatches
+  // to was mounted at all — is `unmetNeeds` in the core, which reads the
+  // mount. This engine cannot answer that any more, and that is the point: it
+  // does not hold the ports.
+  it("names what the runtime brought no handler for", () => {
+    // Written out in full because it is the extension point: driving a
+    // second workflow means handing the engine one of these, not forking it.
+    const thin: WorkflowRuntime = {
+      policy: {},
+      found: async () => [],
+      newRecord: (id, at) => ({
+        id,
+        state: "NEW",
+        updatedAt: at.toISOString(),
+        attempts: {},
+        history: [],
+      }),
+      observe: async () => ({}),
+      handlers: () => ({ triage: async () => {} }),
+      apply: (record) => record,
+    };
 
-    expect(withoutGate.missingActions(["run-gate"])).toEqual(["run-gate"]);
-    expect(withoutGate.missingActions(["triage"])).toEqual([]);
+    const worker = new Worker({
+      queue: new FileQueue(path.join(root, "queue")),
+      records: new InMemoryStore(),
+      ...ticketWorkerDeps({ now: () => WORKDAY }),
+      runtime: thin,
+    });
+
+    expect(worker.missingActions(["triage", "run-gate"])).toEqual(["run-gate"]);
   });
 });

--- a/plugins/serial-engine/tests/budget.test.ts
+++ b/plugins/serial-engine/tests/budget.test.ts
@@ -4,16 +4,12 @@ import os from "node:os";
 import path from "node:path";
 import { Budget, BudgetDecision, LogBudget } from "@amy/core";
 import { FileQueue } from "@amy/plugin-file-queue";
-import { WORKDAY, record as recordIn, roster } from "@amy/test-fixtures";
+import { WORKDAY, record as recordIn } from "@amy/test-fixtures";
 import {
+  ticketWorkerDeps,
   InMemoryStore,
   RecordingEventLog,
-  RecordingNotifier,
   fakeAgent,
-  fakeGate,
-  fakeHost,
-  fakeTracker,
-  workerConfig,
 } from "@amy/test-fixtures";
 import { Worker, WorkerDeps } from "../src/Worker.js";
 
@@ -53,16 +49,11 @@ describe("Worker, against a budget", () => {
     return new Worker({
       queue,
       records,
-      tracker: fakeTracker(),
-      host: fakeHost(),
-      agent: fakeAgent(),
-      gate: fakeGate(),
-      notifier: new RecordingNotifier(),
-      roster: () => roster(),
-      now: () => clock,
-      log,
-      config: workerConfig,
-      ...overrides,
+      ...ticketWorkerDeps({
+        now: () => clock,
+        log,
+        ...overrides,
+      }),
     });
   }
 

--- a/plugins/serial-engine/tests/plugin.test.ts
+++ b/plugins/serial-engine/tests/plugin.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from "vitest";
-import { Engine, HostServices, mount } from "@amy/core";
+import {
+  Engine,
+  HostServices,
+  Plugin,
+  WORKFLOW_RUNTIME,
+  WorkRecord,
+  WorkflowRuntime,
+  mount,
+} from "@amy/core";
 import { plugin } from "../src/plugin.js";
 
 const HOST: HostServices = {
@@ -8,28 +16,97 @@ const HOST: HostServices = {
   paths: { workspace: "/w", state: "/w/.amy" },
 };
 
+// The engine's own settings, and there is nothing about a ticket in them any
+// more: `repos` and `qaStatusName` are the workflow's vocabulary and live in
+// the workflow's slice.
 const SETTINGS = {
-  "@amy/plugin-serial-engine": { repos: ["acme/widgets"], qaStatusName: "In QA" },
+  "@amy/plugin-serial-engine": { maxItemAttempts: 3 },
 };
 
-async function mountAlone(extra: Parameters<typeof mount>[0] = []) {
+/** A workflow, and no way to run it. Half of the pair an engine needs. */
+const halfAWorkflow: Plugin = {
+  name: "@amy/workflow-half",
+  version: "0.1.0",
+  register: (registry) =>
+    registry.workflow({
+      name: "half",
+      states: ["NEW"],
+      waitingStates: [],
+      initialState: "NEW",
+      terminalStates: [],
+      usesActions: [],
+      usesObservers: [],
+      plan: () => ({ kind: "settled", why: "nothing to do" }),
+    }),
+};
+
+/**
+ * A whole pair that needs no ports at all.
+ *
+ * Which is the claim this engine now makes: what it drives is a workflow and
+ * a runtime, and it neither knows nor cares that this one reaches nothing.
+ */
+const stubWorkflow: Plugin = {
+  name: "@amy/workflow-stub",
+  version: "0.1.0",
+  register: (registry) => {
+    halfAWorkflow.register(registry, undefined as never);
+    registry.contribute(WORKFLOW_RUNTIME, "half", {
+      policy: {},
+      found: async () => [],
+      newRecord: (workId: string, at: Date) => ({
+        id: workId,
+        state: "NEW",
+        updatedAt: at.toISOString(),
+        attempts: {},
+        history: [],
+      }),
+      observe: async () => ({}),
+      handlers: () => ({}),
+      apply: (record: WorkRecord) => record,
+    } satisfies WorkflowRuntime);
+  },
+};
+
+async function mountAlone(extra: Plugin[] = []) {
   const outcome = await mount([plugin, ...extra], SETTINGS, HOST);
   if (!outcome.ok) throw new Error(outcome.problems.join("; "));
   return outcome.mounted;
 }
 
 describe("the serial engine plugin", () => {
-  it("mounts an engine and the workflow it drives", async () => {
+  it("mounts an engine and nothing else", async () => {
     const mounted = await mountAlone();
 
     expect(typeof mounted.engine?.tick).toBe("function");
-    expect(mounted.workflow?.name).toBe("ticket-to-qa");
+    // Deliberately not this plugin's job any more. An engine that registered
+    // the workflow was an engine that had decided which one it drives.
+    expect(mounted.workflow).toBeUndefined();
+  });
+
+  it("refuses to run without a workflow, rather than throwing on undefined", async () => {
+    const mounted = await mountAlone();
+
+    await expect((mounted.engine as Engine).tick()).rejects.toThrow(
+      /needs a workflow, and no plugin registered one/,
+    );
+  });
+
+  // The pair is what makes a workflow driveable: the order its states happen
+  // in, and how the actions in them run. Half of it is a config mistake, and
+  // it costs a boot rather than somebody's ticket.
+  it("refuses a workflow that contributed no runtime, and names what there was", async () => {
+    const mounted = await mountAlone([halfAWorkflow]);
+
+    await expect((mounted.engine as Engine).tick()).rejects.toThrow(
+      /`half` contributed no runtime/,
+    );
   });
 
   it("mounts without the ports it will need, and complains only when used", async () => {
     // Deliberate: the ports come from plugins that may be listed after this
     // one, so demanding them at mount would make the config order matter.
-    const mounted = await mountAlone();
+    const mounted = await mountAlone([stubWorkflow]);
 
     await expect((mounted.engine as Engine).tick()).rejects.toThrow(
       /needs the `queue` port, and nothing mounted it/,
@@ -38,6 +115,7 @@ describe("the serial engine plugin", () => {
 
   it("names the missing port, not a property of undefined", async () => {
     const withQueue = await mountAlone([
+      stubWorkflow,
       {
         name: "@amy/plugin-q",
         version: "0.1.0",
@@ -45,9 +123,6 @@ describe("the serial engine plugin", () => {
       },
     ]);
 
-    await expect((withQueue.engine as Engine).tick()).rejects.toThrow(
-      /needs the `store` port/,
-    );
+    await expect((withQueue.engine as Engine).tick()).rejects.toThrow(/needs the `store` port/);
   });
-
 });


### PR DESCRIPTION
Stacked on #3, and it retargets to `main` when that merges.

You asked how hard a second workflow would be. The plugins reuse cleanly; the engine did not, and it was worth fixing before phase 13 rather than after.

## What was wrong

`Worker.ts` was 748 lines with **36 references to the ticket domain**. It built the observation out of a tracker, held a handler per ticket action, folded a gate result it had to understand, registered `ticketToQa` itself, and read `repos` and `qaStatusName` out of its own settings. `decide` was injectable, so the *decision* could be swapped — and nothing else could.

So the roadmap's own strongest claim — phase 13's "a second workflow that reuses queue, gate, relay, budget and report while sharing no action" — would have failed at the engine rather than at the plugin model, by needing a second copy of 748 lines.

## The seam

`WorkflowRuntime`, in the core. What a workflow contributes so that something else can run it:

| | |
| :-- | :-- |
| `found()` | work that exists and is not queued yet |
| `newRecord()` | what a work id starts as |
| `observe(record)` | the snapshot the decision reads |
| `handlers()` | one per action it can emit |
| `apply(record, plan, outcomes, observation, now)` | the fold only it can do |
| `policy` | the ceilings its own decision reads |

Contributed to a **collection** — the same mechanism that already gets the notification channels to the fan-out, and today's roster to a tick, one level up. No new concept.

**The workflow is a plugin now.** It registers the order of its states *and* contributes how they run, and refuses at boot by name when a port it needs was never mounted. The engine registers neither half; handed a workflow that contributed no runtime, it says which one and what there was to choose from.

**What stayed in the engine is the half that names nothing:** claim, recover an abandoned item, ask the budget before spending an agent, park rather than lose, count attempts across processes, warn once down and once back, stop between actions, prune, chain the next look.

One design note worth reading: the observation is an argument to the fold. The owner's answer to an escalation arrives as an observation, and the move it unblocks carries no action at all — a fold that could not see one would leave the record waiting forever.

## What this does not do

- **Not two workflows at once.** `mount()` still claims a single workflow: one install drives one.
- **Not domain-free adapters.** `Agent`, `Tracker`, `CodeHost` and `Gate` are still declared by this workflow and typed on its `Ticket`, deliberately. So a second workflow over the *same* domain costs a `plan()`; over a *different* domain it reuses the harnesses, queue, store, log, notifiers, relay ladder and budget, and brings its own adapters. That is the honest boundary, and it is written down in the plan.
- The last acceptance criterion — a second workflow actually running on this engine — stays open and `deferred:` on purpose. The seam is proven by a second thing going through it, and inventing a throwaway workflow to close a checkbox would prove the checkbox.

## How I know nothing broke

Behaviour is unchanged, and the gates are the evidence rather than my word:

- `npm run e2e`: 12/12, 29/29, 16/16, 12/12, and the whole lifecycle **30/30 in the same 38 looks**.
- The engine's bad-day promises still hold line for line (`plugin-serial-engine`, 16 assertions).
- `npm run gate` exit 0: **624 tests**, lint, knip, audit, `check:release`, `sf check` clean, `sf verify` 33/33.
- Three gates re-run and resealed, because their activation paths moved: `ticket-to-qa`, `plugin-serial-engine`, `installed-binary`.

Two tests are new and are the ones worth reading: `packages/workflow-ticket-to-qa/tests/plugin.test.ts` (the pair, and both boot refusals) and the `missingActions` case in `Worker.test.ts`, which hand-writes a runtime with one handler — the extension point, spelled out.