### PR TITLE
The release stays dormant until somebody arms it

### DIFF
--- a/.changeset/the-release-stays-dormant.md
+++ b/.changeset/the-release-stays-dormant.md
@@ -1,0 +1,11 @@
+---
+"@amy/cli": patch
+---
+
+The release workflow stays dormant until `AMY_RELEASE` is set.
+
+The first release is deliberately later, and an unarmed release job failed on
+every push to main: GitHub refuses to let Actions open a pull request unless
+that is switched on, and there is no npm token behind it yet either. Both are
+real preconditions, and neither is a reason for main to be red in the
+meantime.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,21 @@ jobs:
   # means the tag is pushed by the same run that publishes.
   release:
     runs-on: ubuntu-latest
+    # Dormant until somebody arms it, and green while dormant.
+    #
+    # The first release is deliberately after phase 12, so there is no npm
+    # organisation and no token yet. Unarmed, this job fails on every push to
+    # main — `GitHub Actions is not permitted to create or approve pull
+    # requests` first, and a missing credential after that. A red build that
+    # means nothing trains everybody to ignore the one that does.
+    #
+    # Arm it with one command, once, when the organisation exists:
+    #
+    #     gh variable set AMY_RELEASE --body on
+    #
+    # A variable rather than a secret, because a job condition cannot read a
+    # secret, and because "is the release armed" is not itself a secret.
+    if: vars.AMY_RELEASE == 'on'
     permissions:
       # The action pushes the version branch and the tags it creates.
       contents: write


### PR DESCRIPTION
Main is red, and for nothing.

```
HttpError: GitHub Actions is not permitted to create or approve pull requests.
  - https://docs.github.com/rest/pulls/pulls#create-a-pull-request
```

The release job runs on every push to main and cannot do its job yet: opening the "Version packages" pull request needs that permission switched on for the account, and the publish behind it needs an npm organisation and a token. Those are real preconditions, and you have said the first release comes after phase 12 — so main would be red for weeks over something nobody is meant to do yet.

So the job asks first whether it was armed:

```sh
gh variable set AMY_RELEASE --body on
```

A **variable** rather than a secret, for two reasons: a job condition cannot read a secret, and "is the release armed" is not itself a secret. A skipped job is green, so main goes quiet until the day the release is meant to happen — and on that day nothing about this workflow changes except one variable.

The alternative was leaving it red and remembering why. A red build that means nothing is worse than no build: it trains everybody, me included, to skim past the one that means something.

**Checks:** zizmor clean (nothing ignored), `sf check` clean with the workflow re-locked. The rest of the gate is untouched by a job condition.

<sub>When you do arm it, the order is: create the `amy` organisation on npmjs → add the `NPM_TOKEN` automation token → `gh api -X PUT /repos/nicolasmelo1/amy/actions/permissions/workflow -F default_workflow_permissions=read -F can_approve_pull_request_reviews=true` → `gh variable set AMY_RELEASE --body on`. The pending changesets are already in the repository, so the first armed push opens the version pull request with all of them.</sub>