### PR TITLE
Phase 10, written before it is built

### DIFF
--- a/plans/friction-becomes-a-plan.md
+++ b/plans/friction-becomes-a-plan.md
@@ -1,0 +1,136 @@
+# Friction becomes a plan, and the queue stops needing a ticket
+
+Phase 10, and it is two things that turn out to be one.
+
+**The queue should accept work that is not a ticket.** `EnqueueRequest` is
+already `{ workId, reason }` and knows nothing about trackers. The single
+thing in the way is `observe()`: it resolves the work id against the tracker
+and throws `PROJ-1 is not in the tracker any more` for anything else. So
+every item on the queue has to exist in Linear, and nothing can be injected
+by hand.
+
+**And the failures should improve the repositories.** Every friction point
+this machine hits — an adapter that lied, a step that needed three tries, a
+limitation somebody worked around — is worth a plan in one of three
+repositories: software factory, amy, or logion. Not a ticket in a tracker:
+those three already have a `plans/` directory and an ordered
+`next-steps.md`, which is where work is decided here.
+
+The second is an instance of the first. A friction note has no ticket, needs
+none, and has to reach a pull request anyway. Build the general thing and the
+particular one is a workflow over it.
+
+## The decision this rests on
+
+**A second workflow, not more states in the first.** `ticket-to-qa` is
+sixteen states about a ticket reaching QA; a note becoming a plan shares none
+of them and would only ever be a branch inside every predicate. The engine
+stopped knowing what a ticket is in
+[the engine drives a workflow it does not know](the-engine-drives-a-workflow-it-does-not-know.md),
+so a second workflow now costs a `plan()` and a runtime rather than a fork.
+
+This is also what settles that plan's one open criterion. It stays open there
+until it is a second workflow really going through the seam, and this is that
+workflow — which is the right way round: the proof arrives because something
+needed it, not because a checkbox wanted closing.
+
+The lifecycle is short on purpose, because nothing in it waits on a person:
+
+```text
+NOTED ──► DRAFTED ──► CHECKED ──► PR_OPEN ──► DONE
+             ▲            │
+             └────────────┘
+              sf check is red
+```
+
+`DRAFTED` is an agent writing `plans/<slug>.md` and its line in
+`next-steps.md`. `CHECKED` is `sf check` in that repository, which is the
+whole quality bar: a plan with no exit condition, or one missing from the
+ordered list, is red by `L4.PLAN_DECLARES_EXIT_CONDITION` and goes back to the
+agent with the finding. Nobody had to invent a rubric — the repository being
+written into already has one, and it is the same one a human contributor
+meets.
+
+## Three things have to move, and they are small
+
+**The forge port belongs to nobody in particular.** `CodeHost` is already
+domain-free: `findPullRequest`, `openPullRequest`, `requestReview` and
+`reviewLoad` mention a repository, a branch and a login, and not one of them
+mentions a ticket. It only *lives* in the ticket workflow's package. It moves
+to the core, where `Queue`, `Store`, `Notifier` and `EventLog` already are,
+and both workflows mount the same `@amy/plugin-github` behind it. `Gate` does
+not move: `run(ticket)` is ticket-shaped, and a plan workflow's check is
+`sf check` in a directory rather than a gate over a ticket.
+
+**The harnesses have to be contributed as harnesses.** `contributeTiers`
+builds a `HarnessAgent` — the ticket prompts, the branch handling, the commit
+— and contributes that. The domain-free unit underneath is
+`Harness.ask(prompt, cwd)`, which is what a second workflow wants: its own
+prompts over the same ladder, the same budget and the same accounting. So the
+harness plugins contribute the harness as well, the relay's ladder moves to
+where both can use it, and `@amy/plugin-claude` stops being a plugin only one
+workflow can use.
+
+**Work has to be injectable.** Two ways in, and both write the same queue:
+`amy note "..."` for the one-liner, and a directory amy watches for the
+longer ones, so a note can be written by an editor, by a hook, or by this
+machine itself when a tick fails. The record carries the note and the
+repository it is about; nothing resolves it against anything.
+
+## What stops this becoming spam
+
+The reviewer ceiling's argument applies with a different number: past
+`maxOpenPlansPerRepo`, the workflow holds rather than opening another pull
+request nobody has read. A machine that files twelve plans a day into three
+repositories is not improving them, it is producing a backlog with a robot's
+name on it.
+
+And `sf` is the other half, for free: a plan that does not carry an exit
+condition and a place in the execution order cannot go green, so the floor on
+quality is the floor the repository already enforces on people.
+
+## Acceptance criteria
+
+- [ ] A work item injected by command reaches the queue and is advanced
+      without existing in any tracker
+      (proof: deferred:the second workflow does not exist yet)
+- [ ] A note dropped in the watched directory is picked up by `amy discover`
+      alongside anything else that is due
+      (proof: deferred:the watched directory does not exist yet)
+- [ ] The two workflows run on the same engine, the same queue, the same
+      store, the same log and the same budget, with no engine change between
+      them (proof: deferred:this is the criterion the other plan is waiting
+      on, and it closes here)
+- [ ] The forge port is mounted once and used by both workflows
+      (proof: deferred:`CodeHost` has not moved to the core yet)
+- [ ] A second workflow's agent uses the same harness ladder and the same
+      budget as the first, with its own prompts
+      (proof: deferred:the harnesses contribute no harness yet)
+- [ ] A drafted plan that `sf check` refuses goes back to the agent with the
+      finding, rather than reaching a pull request
+      (proof: deferred:the workflow does not exist yet)
+- [ ] A plan that passes reaches a pull request in the repository it is about,
+      naming the friction it came from
+      (proof: deferred:the workflow does not exist yet)
+- [ ] Past `maxOpenPlansPerRepo`, nothing new is opened and the machine says
+      so once (proof: deferred:the ceiling does not exist yet)
+- [ ] A tick that fails in the ticket workflow leaves a note behind, so the
+      thing that broke becomes the thing that gets fixed
+      (proof: deferred:notes cannot be written yet)
+
+**Exit condition:** a friction note, written by hand or by a failing tick,
+becomes a pull request adding a plan to software factory, amy or logion —
+with an exit condition and a line in that repository's `next-steps.md`,
+because anything less is refused by that repository's own `sf check` — and
+the machine that did it never touched a tracker, never changed the engine,
+and stopped opening pull requests once the ceiling was reached.
+
+## What this deliberately does not do
+
+It does not decide what is worth a plan. The agent proposes and a human
+merges, which is the same arrangement every other thing here has: the
+machine's judgement is a pull request, not a commit.
+
+It does not write into a fourth repository. Three are the ones this work
+already lives in, and a note about anything else is a note the operator gets
+told about instead.

--- a/plans/next-steps.md
+++ b/plans/next-steps.md
@@ -17,8 +17,9 @@ O roadmap inteiro, com as treze fases e o estado de cada uma, está em
 | 4 | [The engine fails out loud](the-engine-fails-out-loud.md) | A dependency that goes down produces one warning on the way down, silence while it is down, and one warning when it comes back, and no broken notification channel ever costs a ticket a move |
 | 5 | [The lifecycle is proven end to end](the-lifecycle-is-proven-end-to-end.md) | The installed executable walks one ticket from the working status to a QA handoff against a world of stand-ins, twice, with no credential and no network |
 | 6 | [The engine drives a workflow it does not know](the-engine-drives-a-workflow-it-does-not-know.md) | `plugins/serial-engine/src/**` names no workflow package, and a second workflow runs on the same engine by contributing a plan and a runtime |
-| 7 | [What runs is a released version](what-runs-is-a-released-version.md) | A machine with no checkout installs `@amy/cli` from GitHub Packages, `amy --version` names a version changesets published, and a dirty tree only ever says `dev` |
-| 8 | [Plugins are installed, not compiled in](plugins-are-installed-not-compiled-in.md) | A second machine runs a ticket with only the plugins it needs installed, and one it never installed is refused by name at boot |
+| 7 | [Friction becomes a plan, and the queue stops needing a ticket](friction-becomes-a-plan.md) | A friction note becomes a pull request adding a plan to the right repository, with no tracker involved and no change to the engine |
+| 8 | [What runs is a released version](what-runs-is-a-released-version.md) | A machine with no checkout installs `@amy/cli` from GitHub Packages, `amy --version` names a version changesets published, and a dirty tree only ever says `dev` |
+| 9 | [Plugins are installed, not compiled in](plugins-are-installed-not-compiled-in.md) | A second machine runs a ticket with only the plugins it needs installed, and one it never installed is refused by name at boot |
 
 ## Parked
 

--- a/plans/the-roadmap.md
+++ b/plans/the-roadmap.md
@@ -17,7 +17,7 @@ trabalho de hoje. O resto do repositório é em inglês.
 | 7 | entregue | o budget e o teto de reviewer, provados pelo gate `plugin-agent-relay` |
 | 8 | entregue pela metade | a escada de skills por passo existe no `@amy/plugin-agent-relay`; o scaffolder não |
 | 9 | entregue | [the engine fails out loud](the-engine-fails-out-loud.md), gate `plugin-serial-engine`, e o desenho em [docs/design](../docs/design/the-engine-fails-out-loud.md) |
-| 10 | próxima | ainda sem plano próprio neste diretório |
+| 10 | próxima | [friction becomes a plan](friction-becomes-a-plan.md), escrito e ainda não construído |
 | 11 | depois da 10 | ainda sem plano próprio |
 | 12 | depois da 11 | ainda sem plano próprio; sobe para o software-factory |
 | 13 | parada | esperando as três anteriores |


### PR DESCRIPTION
The plan only. No code, and every criterion is `deferred:` — which is what a plan written before the work honestly looks like.

Phase 10 is two things that turn out to be one. The queue should take work that is not a ticket: `EnqueueRequest` is already `{workId, reason}` and the single thing in the way is `observe()` resolving the id against the tracker. And the failures should improve the repositories: friction becomes a plan in software factory, amy or logion, which is where work is decided here — not a ticket in a tracker.

The second is an instance of the first. A friction note has no ticket, needs none, and has to reach a pull request anyway.

## The four things worth arguing about now

**A second workflow, not more states in the first.** Sixteen states about a ticket reaching QA share nothing with a note becoming a plan, and #4 means this costs a `plan()` and a runtime rather than a fork of the engine. It also settles the one open criterion in `the-engine-drives-a-workflow-it-does-not-know.md` — in the right direction, because the proof arrives from something that needed it rather than from a checkbox that wanted closing.

**`CodeHost` moves to the core.** I checked rather than assumed: `findPullRequest`, `openPullRequest`, `requestReview`, `reviewLoad` — repository, branch, login, and not one mention of a ticket. It is domain-free already and only *lives* in the ticket workflow's package. `Gate` does **not** move: `run(ticket)` is ticket-shaped, and a plan's check is `sf check` in a directory.

**The harnesses get contributed as harnesses.** `contributeTiers` builds a `HarnessAgent` — ticket prompts, branch handling, commit — and contributes that. The domain-free unit underneath is `Harness.ask(prompt, cwd)`, which is what a second workflow needs: its own prompts over the same ladder, the same budget, the same accounting.

**The quality bar is already written, and it is not ours.** A drafted plan has to pass the *target* repository's `sf check`: no exit condition, or missing from the ordered `next-steps.md`, is red by `L4.PLAN_DECLARES_EXIT_CONDITION` and goes back to the agent with the finding. The same bar a human contributor meets. Plus `maxOpenPlansPerRepo`, because a machine filing twelve plans a day into three repositories is not improving them, it is producing a backlog with a robot's name on it.

## The shape

```
NOTED ──► DRAFTED ──► CHECKED ──► PR_OPEN ──► DONE
             ▲            │
             └────────────┘
              sf check is red
```

Short on purpose: nothing in it waits on a person. The agent proposes, `sf` refuses or lets it through, and a human merges — the same arrangement as everything else here.

**Checks:** `sf check` clean, so the plan carries its exit condition and sits in the execution order. Read the plan rather than this description if you only read one.