### PR TITLE
fix(release): the version bump regenerates the documentation

### DIFF
--- a/.changeset/the-version-bump-regenerates-the-docs.md
+++ b/.changeset/the-version-bump-regenerates-the-docs.md
@@ -1,0 +1,25 @@
+---
+"@amykit/cli": patch
+---
+
+The version bump regenerates the documentation, so the release can pass its
+own gate.
+
+A release moves two things the generated documentation is derived from: every
+package's version, which `docs/manifest.json` carries, and the pending
+changesets, which `changeset version` consumes into changelogs.
+
+So the "Version packages" pull request was the one pull request in this
+repository that could never be green — the drift check would report
+`docs/manifest.json` and `docs/changelog/index.md` as stale, correctly, and
+there was no way to fix it by hand that the next bump would not undo.
+
+`release:version` now ends in `npm run docs:generate`. Beyond the gate, it
+means the news page ships *with* the release rather than after it: by the time
+the version pull request is reviewed, "Coming next" is empty and the changelogs
+it describes exist.
+
+The released half still cannot write itself, because a GitHub release does not
+exist until the publish has happened. `npm run docs:changelog` after a release
+is what fills it, and until it runs the page says so rather than showing
+nothing.

--- a/.software-factory/locks/dependencies.lock.json
+++ b/.software-factory/locks/dependencies.lock.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "files": {
     ".software-factory/evidence/installed-plugins/workflow-oncall/package.json": "1f704509661427d7ff41b0387187879d02f61fb5a01da5e1db115581a013f1f0",
-    "package.json": "a2ed3b411660e372481ce961923241dedac488f848fdacc20e680fe678496b2c",
+    "package.json": "2dbb1cf99290b2f37f071208f9281f7a7a1a1e7275c0612313780f0a67dcd88e",
     "packages/agent-kit/package.json": "60afb3e01ae1d142541bec5a189eb1e2895ac9057ff3b1de86965961ecceea1f",
     "packages/cli/package.json": "8f094f4309795aa280dbb000e9f76092a93fd9e420f655a77c5b8f3b99bc22f8",
     "packages/core/package.json": "0e1b42059419052ad22b8caee3a32031b95d842241d65af9ac6b75271e92622b",

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -358,6 +358,29 @@ It found 45 errors on the first run. Most were harmless drift, three were not:
   rather than the ticket fixture's, so every option they accepted was one the
   type said could not be passed.
 
+### The version bump regenerates the documentation, so the release can pass its own gate.
+
+`patch` · `@amykit/cli`
+
+A release moves two things the generated documentation is derived from: every
+package's version, which `docs/manifest.json` carries, and the pending
+changesets, which `changeset version` consumes into changelogs.
+
+So the "Version packages" pull request was the one pull request in this
+repository that could never be green — the drift check would report
+`docs/manifest.json` and `docs/changelog/index.md` as stale, correctly, and
+there was no way to fix it by hand that the next bump would not undo.
+
+`release:version` now ends in `npm run docs:generate`. Beyond the gate, it
+means the news page ships *with* the release rather than after it: by the time
+the version pull request is reviewed, "Coming next" is empty and the changelogs
+it describes exist.
+
+The released half still cannot write itself, because a GitHub release does not
+exist until the publish has happened. `npm run docs:changelog` after a release
+is what fills it, and until it runs the page says so rather than showing
+nothing.
+
 ### amy says what it is, rather than what its first workflow does.
 
 `patch` · `@amykit/cli`

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -69,12 +69,44 @@ npm run check:release
 Part of `npm run gate`. It checks the release configuration is coherent — the
 kind of thing that is otherwise discovered by a publish that half-worked.
 
+## The version bump regenerates the documentation
+
+```json
+"release:version": "changeset version && npm install --package-lock-only && npm run docs:generate"
+```
+
+The third command is not tidiness. A release moves two things the generated
+documentation is derived from — every package's version, which the manifest
+carries, and the pending changesets, which `changeset version` consumes into
+changelogs. Without regenerating, the version pull request is the one pull
+request in this repository that **could never pass its own gate**:
+
+```
+docs: the code moved and the documentation did not. These are out of date:
+  docs/changelog/index.md
+  docs/manifest.json
+```
+
+It also means the news page ships *with* the release rather than after it: by
+the time the version pull request is reviewed, "Coming next" is empty and the
+changelogs it describes exist.
+
+It needs `dist` to be built, because the generator asks each plugin what it
+mounts by registering it. The release job builds before the changesets action
+runs, and locally the generator says so rather than guessing.
+
 ## The news page
 
 ```sh
 npm run docs:changelog     # fetch releases from GitHub into the cache
 npm run docs:generate      # render /changelog from the cache and the changesets
 ```
+
+The released half is the one thing the release cannot write for itself: the
+GitHub release does not exist until the publish has happened. So after a
+release lands, run those two and commit — the page tells the truth about what
+the cache knows either way, which is why it says "No release has been cut yet"
+rather than showing nothing.
 
 The fetch is a separate command from generating on purpose: generating has to be
 reproducible on any machine at any time, and something that reaches the network

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -699,6 +699,11 @@
         },
         {
           "depth": 3,
+          "title": "The version bump regenerates the documentation, so the release can pass its own gate.",
+          "slug": "the-version-bump-regenerates-the-documentation-so-the-release-can-pass-its-own-gate"
+        },
+        {
+          "depth": 3,
           "title": "amy says what it is, rather than what its first workflow does.",
           "slug": "amy-says-what-it-is-rather-than-what-its-first-workflow-does"
         },
@@ -1504,6 +1509,11 @@
           "depth": 2,
           "title": "Checked before it can go wrong",
           "slug": "checked-before-it-can-go-wrong"
+        },
+        {
+          "depth": 2,
+          "title": "The version bump regenerates the documentation",
+          "slug": "the-version-bump-regenerates-the-documentation"
         },
         {
           "depth": 2,
@@ -5561,6 +5571,18 @@
           }
         ],
         "level": "minor"
+      },
+      {
+        "id": "the-version-bump-regenerates-the-docs",
+        "title": "The version bump regenerates the documentation, so the release can pass its own gate.",
+        "body": "A release moves two things the generated documentation is derived from: every\npackage's version, which `docs/manifest.json` carries, and the pending\nchangesets, which `changeset version` consumes into changelogs.\n\nSo the \"Version packages\" pull request was the one pull request in this\nrepository that could never be green — the drift check would report\n`docs/manifest.json` and `docs/changelog/index.md` as stale, correctly, and\nthere was no way to fix it by hand that the next bump would not undo.\n\n`release:version` now ends in `npm run docs:generate`. Beyond the gate, it\nmeans the news page ships *with* the release rather than after it: by the time\nthe version pull request is reviewed, \"Coming next\" is empty and the changelogs\nit describes exist.\n\nThe released half still cannot write itself, because a GitHub release does not\nexist until the publish has happened. `npm run docs:changelog` after a release\nis what fills it, and until it runs the page says so rather than showing\nnothing.",
+        "bumps": [
+          {
+            "package": "@amykit/cli",
+            "level": "patch"
+          }
+        ],
+        "level": "patch"
       },
       {
         "id": "what-amy-says-it-is",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "gate": "npm run build && npm run typecheck && npm run check:release && npm run docs:check && npm run test:coverage && npm run lint && npm run knip && npm run audit && sf check --allow-commands && sf verify",
     "e2e": "./.software-factory/evidence/plugin-file-queue-scenario.sh && ./.software-factory/evidence/plugin-agent-relay-scenario.sh && ./.software-factory/evidence/plugin-serial-engine-scenario.sh && ./.software-factory/evidence/installed-binary-scenario.sh && ./.software-factory/evidence/installed-plugins-scenario.sh && ./.software-factory/evidence/ticket-to-qa-scenario.sh && ./.software-factory/evidence/note-to-plan-scenario.sh",
     "changeset": "changeset",
-    "release:version": "changeset version && npm install --package-lock-only",
+    "release:version": "changeset version && npm install --package-lock-only && npm run docs:generate",
     "release:publish": "npm run build && changeset publish",
     "install:local": "./scripts/install.sh",
     "knip": "knip",


### PR DESCRIPTION
Found by opening PR #12. **The "Version packages" pull request is the one pull
request in this repository that could never pass its own gate.**

## Why

A release moves two things the generated documentation is derived from:

- **every package's version**, which `docs/manifest.json` carries for the
  catalogue, and
- **the pending changesets**, which `changeset version` consumes into
  changelogs — so `docs/changelog/index.md` "Coming next" empties out.

So the moment `changeset version` runs, the drift check is correctly red:

```
docs: the code moved and the documentation did not. These are out of date:
  docs/changelog/index.md
  docs/manifest.json
```

And there was nothing to fix by hand that the next bump would not immediately
undo. This is a defect in the documentation generator I added in #10, not in
changesets.

## The fix

```diff
-"release:version": "changeset version && npm install --package-lock-only"
+"release:version": "changeset version && npm install --package-lock-only && npm run docs:generate"
```

Beyond making the gate honest, it means **the news page ships with the release
rather than after it**: by the time the version pull request is reviewed,
"Coming next" is empty and the changelogs it describes exist.

It needs `dist` to be built, because the generator asks each plugin what it
mounts by *registering* it. The release job runs `npm run build` before the
changesets action, and locally the generator refuses with a message rather than
guessing.

## Proven, not assumed

Ran the whole bump on this branch and checked the state it leaves:

```
$ npx changeset version && npm install --package-lock-only && npm run docs:generate
  wrote docs/changelog/index.md
  wrote docs/manifest.json

$ npm run docs:check
docs are in step with the code (41 generated files)

$ grep "Nothing is pending" docs/changelog/index.md
Nothing is pending. `.changeset/` is empty, which between releases is not a mistake.
```

Then reverted the simulation — this PR carries only the one-line script change,
the documentation for it, and its changeset.

## What still cannot write itself

The **released** half of the news page. A GitHub release does not exist until
the publish has happened, so `npm run docs:changelog` after a release is what
fills it. Until it runs the page says "No release has been cut yet", which is
the truth about what the cache knows rather than an empty section.

Documented in `docs/development/releasing.md`.

## After this merges

`changesets/action` re-runs `release:version` on the next push to main and
force-updates `changeset-release/main`, so **PR #12 will pick up the
regenerated docs on its own** — no need to close it.

`npm run gate` — 0.
