### PR TITLE
fix(release): the version pull request can pass its own CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,10 +68,28 @@ jobs:
           # into an .npmrc for this registry only.
           registry-url: https://registry.npmjs.org
       - run: npm ci
+      # `sf`, for one command only: the version bump rewrites twenty-five
+      # package.json files, so the dependency lock has to move with them or
+      # the version pull request can never be green.
+      #
+      # A prebuilt binary rather than `cargo install`, because a Rust
+      # toolchain in the one job nobody can take back is a cost with no
+      # return. The digest is checked because a downloaded binary that
+      # nothing verifies is a supply chain nobody is watching.
+      - name: Install sf
+        env:
+          SF_VERSION: v0.3.0
+        run: |
+          base="https://github.com/nicolasmelo1/software-factory/releases/download/$SF_VERSION"
+          curl -fsSL "$base/sf-x86_64-unknown-linux-gnu" -o sf
+          curl -fsSL "$base/sf-x86_64-unknown-linux-gnu.sha256" -o sf.sha256
+          printf '%s  sf\n' "$(cut -d' ' -f1 sf.sha256)" | sha256sum -c -
+          chmod +x sf && sudo mv sf /usr/local/bin/sf
+          sf --version
       # The suite before the publish, because a release is the one build
       # nobody can take back. `npm run gate` is not used here on purpose: it
-      # runs `sf`, which this job has no reason to install, and the pull
-      # request that produced this commit already ran it.
+      # runs every rule, and the pull request that produced this commit
+      # already did.
       - run: npm run build
       - run: npm test
       - uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1

--- a/.github/workflows/software-factory.yml
+++ b/.github/workflows/software-factory.yml
@@ -79,8 +79,14 @@ jobs:
       # A change to a published package without a changeset is a release that
       # would leave the version standing still. `--since` scopes it to what
       # this pull request adds, so a branch is judged on its own diff.
+      #
+      # Except on the release branch, where it asks for the opposite of what
+      # is there: the version pull request is what *consumes* every changeset,
+      # and it touches all of them, so this could never be satisfied on it.
       - name: Every published change carries a changeset
-        if: github.event_name == 'pull_request'
+        if: >-
+          github.event_name == 'pull_request'
+          && github.head_ref != 'changeset-release/main'
         env:
           BASE_REF: ${{ github.base_ref }}
         run: |

--- a/.software-factory/evidence/installed-binary.json
+++ b/.software-factory/evidence/installed-binary.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "gate": "installed-binary",
-  "implementation_sha256": "287c9ca670186033b3e347014d7e86575d51523f5d16db902420541e17d99824",
+  "implementation_sha256": "72b2651e50fd83a2921395bc5d13ab386ccc9301c79ab73752c2435dc889631d",
   "runs": [
     {
       "scenario": "installed-binary",

--- a/.software-factory/locks/dependencies.lock.json
+++ b/.software-factory/locks/dependencies.lock.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "files": {
     ".software-factory/evidence/installed-plugins/workflow-oncall/package.json": "1f704509661427d7ff41b0387187879d02f61fb5a01da5e1db115581a013f1f0",
-    "package.json": "2dbb1cf99290b2f37f071208f9281f7a7a1a1e7275c0612313780f0a67dcd88e",
+    "package.json": "7aede54f5d5858c3481433df8d65407ce3eef5ab6d6ce515b0f7b070360cc5d8",
     "packages/agent-kit/package.json": "60afb3e01ae1d142541bec5a189eb1e2895ac9057ff3b1de86965961ecceea1f",
     "packages/cli/package.json": "8f094f4309795aa280dbb000e9f76092a93fd9e420f655a77c5b8f3b99bc22f8",
     "packages/core/package.json": "0e1b42059419052ad22b8caee3a32031b95d842241d65af9ac6b75271e92622b",

--- a/.software-factory/locks/factory.lock.json
+++ b/.software-factory/locks/factory.lock.json
@@ -3,7 +3,7 @@
   "files": {
     ".allowed-root-files": "6b96c6cde21f0a325b44a460c9d46632b09ea60876b9ac0f05e78f0254104a10",
     ".githooks/pre-commit": "72074487050ecb19ece275b8946bd8c4d343c92dd0cd85fc73b00b6fcd7b55e8",
-    ".github/workflows/software-factory.yml": "ffa6bd0a3872a5c7ba8ecc4a78d7be000a2d66e42db1043dbf032bea4f675abe",
+    ".github/workflows/software-factory.yml": "557a11ae97e0716723b0b542fd3512d680ffb224d468b269174b955e21fa9aa6",
     ".software-factory/policy.yaml": "0805ce6e9d3dbc15f1388789b11c1a570f0f740861e2aa5e2247e96e6b595013",
     ".software-factory/ratchet.yaml": "e0be45ffb042d35cb29274e8ad70a8ab1f82cb94ac21c1203e183a929158b8e2",
     ".software-factory/rules/core-stays-ignorant.yaml": "f49946b95bd97b7e075ef73d3241c3530d323607abb5b9b9a5558f8f216f2942",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "gate": "npm run build && npm run typecheck && npm run check:release && npm run docs:check && npm run test:coverage && npm run lint && npm run knip && npm run audit && sf check --allow-commands && sf verify",
     "e2e": "./.software-factory/evidence/plugin-file-queue-scenario.sh && ./.software-factory/evidence/plugin-agent-relay-scenario.sh && ./.software-factory/evidence/plugin-serial-engine-scenario.sh && ./.software-factory/evidence/installed-binary-scenario.sh && ./.software-factory/evidence/installed-plugins-scenario.sh && ./.software-factory/evidence/ticket-to-qa-scenario.sh && ./.software-factory/evidence/note-to-plan-scenario.sh",
     "changeset": "changeset",
-    "release:version": "changeset version && npm install --package-lock-only && npm run docs:generate",
+    "release:version": "changeset version && npm install --package-lock-only && npm run docs:generate && sf lock && node scripts/check-lock-scope.mjs",
     "release:publish": "npm run build && changeset publish",
     "install:local": "./scripts/install.sh",
     "knip": "knip",

--- a/scripts/check-lock-scope.mjs
+++ b/scripts/check-lock-scope.mjs
@@ -1,0 +1,46 @@
+// Checks that a version bump re-locked the dependency manifests and nothing
+// else.
+//
+// Usage: node scripts/check-lock-scope.mjs
+//
+// `release:version` runs `sf lock`, because bumping twenty-five package.json
+// files is a deliberate dependency change and the lock has to move with them
+// or the release pull request can never be green.
+//
+// But `sf lock` takes no scope: it rewrites every lock from whatever is on
+// disk. Left alone, that hands a release the power to bless a changed
+// `events.json`, `policy.yaml` or `docs/rules.md` in silence — which is the
+// one thing those locks exist to prevent, since their whole value is that a
+// reviewer sees the diff.
+//
+// So: run it, then refuse if it touched anything but the dependency lock.
+import { execFileSync } from "node:child_process";
+
+const ALLOWED = ".software-factory/locks/dependencies.lock.json";
+
+const changed = execFileSync("git", ["diff", "--name-only", "--", ".software-factory/"], {
+  encoding: "utf-8",
+})
+  .split("\n")
+  .map((line) => line.trim())
+  .filter(Boolean);
+
+const unexpected = changed.filter((file) => file !== ALLOWED);
+
+if (unexpected.length > 0) {
+  process.stderr.write("the version bump re-locked more than the dependency manifests:\n");
+  for (const file of unexpected) process.stderr.write(`  ${file}\n`);
+  process.stderr.write(
+    "\nA release may move the dependency lock, because it moves every package.json.\n" +
+      "It may not move the others: those hold the event contract, the policy and the\n" +
+      "generated artifacts, and their value is that a reviewer sees the diff.\n" +
+      "\nLand that change in its own pull request first.\n",
+  );
+  process.exit(1);
+}
+
+process.stdout.write(
+  changed.length > 0
+    ? "the dependency lock moved with the manifests, and nothing else did\n"
+    : "no lock needed moving\n",
+);


### PR DESCRIPTION
PR #12 is red for two reasons, and **both are structural** — the checks ask the
release for the opposite of what it is. Neither was visible by reading the
workflow; both were found by opening the pull request.

| Job | Failure |
| :-- | :-- |
| `build` | `Some packages have been changed but no changesets were found` |
| `factory` | 25 × `L2.DEPENDENCIES_CHANGE_DELIBERATELY` |

## 1. The changeset check

It refuses a change to a published package that carries no changeset. The
version pull request **consumes** every changeset and touches all twenty-five
packages, so it can never satisfy it.

```yaml
if: >-
  github.event_name == 'pull_request'
  && github.head_ref != 'changeset-release/main'
```

Skipped on the release branch, and only there.

## 2. The dependency lock

The bump rewrites twenty-five `package.json` files — versions, and the internal
ranges the `fixed` group moves together. That is a **real** dependency change
and the lock should move with it, so it is not a rule to skip:

```diff
-"release:version": "changeset version && npm install --package-lock-only && npm run docs:generate"
+"release:version": "… && npm run docs:generate && sf lock && node scripts/check-lock-scope.mjs"
```

Which needs `sf` in the release job. There are prebuilt binaries, so it is a
download with its digest checked rather than `cargo install` — a Rust toolchain
in the one job nobody can take back is a cost with no return.

### The guard, and why it is not ceremony

`sf lock` takes no scope. It rewrites **every** lock from whatever is on disk,
which would hand a release the power to bless a changed `events.json`,
`policy.yaml` or `docs/rules.md` in silence — precisely the thing those locks
exist to prevent, since their whole value is that a reviewer sees the diff.

`scripts/check-lock-scope.mjs` refuses anything but the dependency lock. **It
earned its place immediately**: it fired on this very branch, because editing
the two workflow files moves `factory.lock.json` too.

```
the version bump re-locked more than the dependency manifests:
  .software-factory/locks/factory.lock.json

A release may move the dependency lock, because it moves every package.json.
It may not move the others: those hold the event contract, the policy and the
generated artifacts, and their value is that a reviewer sees the diff.
```

## Proven by running it

Ran the real `npm run release:version` on this branch, from a clean commit, and
checked the state it leaves:

```
$ npm run release:version
  wrote docs/changelog/index.md
  wrote docs/manifest.json
the dependency lock moved with the manifests, and nothing else did

$ npm run docs:check
docs are in step with the code (41 generated files)

$ sf check --allow-commands
✓ 33 rules, no findings (2 frozen by the ratchet)

$ node -e "…packages/core/package.json…"
0.2.0
```

Then `git reset --hard` — this PR carries only the workflow conditions, the
script, the guard and the sf install step.

## This publishes nothing

Merging it re-runs the release workflow, which force-updates
`changeset-release/main` and turns **PR #12 green while it waits**. Nothing
reaches npm until #12 itself is merged.

## Noticed, not fixed here

`CONTRIBUTING.md` says to install `sf` at `v0.4.0`; the `factory` job pins
`v0.3.0`. This PR uses `v0.3.0`, to match what actually validates the
repository rather than to quietly change which rules run. Worth reconciling in
its own change.

`npm run gate` — 0.
