### PR TITLE
feat(core): the forge says if it can merge, if its checks passed, and what waits on you

### DIFF
--- a/.changeset/the-forge-says-if-it-can-merge.md
+++ b/.changeset/the-forge-says-if-it-can-merge.md
@@ -1,0 +1,41 @@
+---
+"@amykit/core": minor
+---
+
+The forge says whether it can merge, whether its checks passed, and what is
+waiting on you.
+
+Three things the forge always knew and nothing here could ask it. Each one is
+a `CodeHost` question, so any workflow gets them and none of them is the
+ticket workflow's private vocabulary.
+
+**`checks`** — what CI says about the head, and the commit it says it about.
+Carried with the sha for the same reason a review carries one: a green rollup
+from three pushes ago says nothing about what is there now. `none` is a
+separate answer from `failing`, because a repository that runs no checks
+reports exactly that, and a machine reading it as "not passing" would hold
+every pull request for a verdict nobody is coming to give. Seen in the wild on
+a release pull request whose workflows are all skipped.
+
+**`mergeState`** — `conflicting`, `behind`, `mergeable` or `unknown`. Only the
+states a workflow can act on itself, plus not-yet-known, because the forge
+works a merge out asynchronously and guessing either way is how a branch gets
+handed over as mergeable before anybody knows. Everything else a forge reports
+here is already carried by `reviewDecision` and `checks`, and a second name for
+it would be two fields free to disagree.
+
+**`reviewsRequestedOf(login, repos)`** — the open pull requests waiting on one
+person. `reviewLoad` counts; it does not say which, and the second cannot be
+derived from the first. Scoped to the repositories given, and an empty list is
+nothing to search rather than everything: a forge search runs across the
+account, so an unscoped one returns work from every repository the credential
+can see.
+
+**Nothing is offered to a reviewer that the forge already says is broken.**
+Red checks, a conflict, or a branch sitting on a base it has moved off now go
+back to the ticket's owner instead of onto somebody's pile. Review time is the
+one currency here nobody can top up — the reason the per-reviewer ceiling
+exists — and a reading of a branch about to change is a reading done twice.
+A verdict still running is waited for, bounded by the same ceiling the local
+gate answers to, because a check that is configured and never reports would
+otherwise be a ticket that stops with nobody told.

--- a/.software-factory/evidence/note-to-plan-run.json
+++ b/.software-factory/evidence/note-to-plan-run.json
@@ -42,8 +42,8 @@
     "notes_left": [
       "by-hand.md",
       "not-mine.md",
-      "note-2026-09-05T203542745.md",
-      "note-2026-09-05T203546400.md",
+      "note-2026-09-05T212124434.md",
+      "note-2026-09-05T212128071.md",
       "will-break.md"
     ],
     "budget": "new work: allowed"

--- a/.software-factory/evidence/note-to-plan.json
+++ b/.software-factory/evidence/note-to-plan.json
@@ -1,14 +1,14 @@
 {
   "schema_version": 1,
   "gate": "note-to-plan",
-  "implementation_sha256": "2247fefadee793fd8d2d8c8583e268b06f2a4ecb66ad94de48ce05731137214a",
+  "implementation_sha256": "fe3e1b782a43d1b3c7a77c5d10a8767882c2d4419dda1e331c98d6d1411a3941",
   "runs": [
     {
       "scenario": "note-to-plan",
       "status": "passed",
       "actor": "Claude (agent), driving the installed executable from a written-down piece of friction to a pull request against stand-in services on macOS, for Nicolas Melo",
       "report": ".software-factory/evidence/note-to-plan-run.json",
-      "report_sha256": "8962c7622380d25f73cc0fbf056006d3ed4cbe6e90478c6df539fe8c64cd6e4a",
+      "report_sha256": "e53316345a4d8ae130ed16b5967e7ec9e55c83f4732f828eed67e38a4c4505db",
       "required_assertions": []
     }
   ]

--- a/.software-factory/evidence/ticket-to-qa-run.json
+++ b/.software-factory/evidence/ticket-to-qa-run.json
@@ -56,12 +56,12 @@
     ],
     "what_the_world_did": [
       "a colleague answered the question on the ticket",
-      "the automated reviewer looked at 11c82ce and left one comment",
-      "the automated reviewer looked at 8b6657c and had nothing to say",
+      "the automated reviewer looked at f7885c8 and left one comment",
+      "the automated reviewer looked at 454c664 and had nothing to say",
       "one of ada's other reviews was merged, so she is carrying one",
-      "ada asked for changes on 8b6657c",
+      "ada asked for changes on 454c664",
       "the owner settled the disagreement on the ticket",
-      "ada approved ff8c5b3"
+      "ada approved 1a0e563"
     ],
     "agent_calls": [
       "triage",

--- a/.software-factory/evidence/ticket-to-qa.json
+++ b/.software-factory/evidence/ticket-to-qa.json
@@ -1,14 +1,14 @@
 {
   "schema_version": 1,
   "gate": "ticket-to-qa",
-  "implementation_sha256": "cb8ed1bc651d07bd1fdc532aa204620767d6d1a55dca84dffcdc62fbc8ea5f0c",
+  "implementation_sha256": "dee78a4661d081cca887bc61b7d38eb3c9d31306f07a6c226fb686f0a64215e3",
   "runs": [
     {
       "scenario": "ticket-to-qa",
       "status": "passed",
       "actor": "Claude (agent), driving the installed executable through one ticket against stand-in services on macOS, for Nicolas Melo",
       "report": ".software-factory/evidence/ticket-to-qa-run.json",
-      "report_sha256": "7ae4834d136522dedc8f996a6bf974f3911ad2fde1d9b7cf4b12ffb0f9cd8bc8",
+      "report_sha256": "9bf4bd817fd5a73299a9eff58a9cb17299aa5a529ce6316b6790026cd0dd9842",
       "required_assertions": []
     }
   ]

--- a/.software-factory/evidence/ticket-to-qa/bin/gh
+++ b/.software-factory/evidence/ticket-to-qa/bin/gh
@@ -74,6 +74,21 @@ function pullRequestNode(repo, pull) {
     isDraft: pull.isDraft,
     reviewDecision: pull.reviewDecision,
     headRefOid: headOf(repo, pull.head),
+    changedFiles: pull.changedFiles,
+    additions: pull.additions,
+    deletions: pull.deletions,
+    mergeable: pull.mergeable,
+    mergeStateStatus: pull.mergeStateStatus,
+    commits: {
+      nodes: [
+        {
+          commit: {
+            oid: headOf(repo, pull.head),
+            statusCheckRollup: pull.checks === null ? null : { state: pull.checks },
+          },
+        },
+      ],
+    },
     reviewRequests: {
       nodes: pull.requestedReviewers.map((login) => ({
         requestedReviewer: { __typename: "User", login },
@@ -129,6 +144,12 @@ function openPullRequest(state, repoPath, args) {
     state: "open",
     isDraft: false,
     reviewDecision: null,
+    changedFiles: 3,
+    additions: 40,
+    deletions: 12,
+    mergeable: "MERGEABLE",
+    mergeStateStatus: "CLEAN",
+    checks: "SUCCESS",
     requestedReviewers: [],
     reviews: [],
     threads: [],

--- a/.software-factory/evidence/ticket-to-qa/world.mjs
+++ b/.software-factory/evidence/ticket-to-qa/world.mjs
@@ -97,6 +97,15 @@ function openReview(number, head, reviewer) {
     state: "open",
     isDraft: false,
     reviewDecision: "REVIEW_REQUIRED",
+    // What the forge knows about the branch, in the shape the real one sends
+    // it. Small, green and clean, so the walk is about the lifecycle and a
+    // run that means to be about a broken branch has to say so.
+    changedFiles: 3,
+    additions: 40,
+    deletions: 12,
+    mergeable: "MERGEABLE",
+    mergeStateStatus: "CLEAN",
+    checks: "SUCCESS",
     requestedReviewers: [reviewer],
     reviews: [],
     threads: [],

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -417,6 +417,45 @@ moved from the engine's settings slice to the workflow's, and the engine
 gained `retryDelayMs` of its own. `amy` maps both for you; a hand-written
 `plugins:` slice needs the two keys moved.
 
+### The forge says whether it can merge, whether its checks passed, and what is waiting on you.
+
+`minor` · `@amykit/core`
+
+Three things the forge always knew and nothing here could ask it. Each one is
+a `CodeHost` question, so any workflow gets them and none of them is the
+ticket workflow's private vocabulary.
+
+**`checks`** — what CI says about the head, and the commit it says it about.
+Carried with the sha for the same reason a review carries one: a green rollup
+from three pushes ago says nothing about what is there now. `none` is a
+separate answer from `failing`, because a repository that runs no checks
+reports exactly that, and a machine reading it as "not passing" would hold
+every pull request for a verdict nobody is coming to give. Seen in the wild on
+a release pull request whose workflows are all skipped.
+
+**`mergeState`** — `conflicting`, `behind`, `mergeable` or `unknown`. Only the
+states a workflow can act on itself, plus not-yet-known, because the forge
+works a merge out asynchronously and guessing either way is how a branch gets
+handed over as mergeable before anybody knows. Everything else a forge reports
+here is already carried by `reviewDecision` and `checks`, and a second name for
+it would be two fields free to disagree.
+
+**`reviewsRequestedOf(login, repos)`** — the open pull requests waiting on one
+person. `reviewLoad` counts; it does not say which, and the second cannot be
+derived from the first. Scoped to the repositories given, and an empty list is
+nothing to search rather than everything: a forge search runs across the
+account, so an unscoped one returns work from every repository the credential
+can see.
+
+**Nothing is offered to a reviewer that the forge already says is broken.**
+Red checks, a conflict, or a branch sitting on a base it has moved off now go
+back to the ticket's owner instead of onto somebody's pile. Review time is the
+one currency here nobody can top up — the reason the per-reviewer ceiling
+exists — and a reading of a branch about to change is a reading done twice.
+A verdict still running is waited for, bounded by the same ceiling the local
+gate answers to, because a check that is configured and never reports would
+otherwise be a ticket that stops with nobody told.
+
 ### The version moves because a change said it should, and an installed package can say which one it is.
 
 `minor` · `@amykit/cli`

--- a/docs/concepts/ports.md
+++ b/docs/concepts/ports.md
@@ -77,6 +77,7 @@ Declared in `packages/core/src/ports/CodeHost.ts`.
 | `openPullRequest(request: OpenPullRequestRequest): Promise<number>` |  |
 | `requestReview(repo: string, pullRequestNumber: number, host: string): Promise<void>` |  |
 | `reviewLoad(repos: readonly string[]): Promise<Record<string, number>>` | Open reviews per login, counted across every given repository. |
+| `reviewsRequestedOf(login: string, repos: readonly string[]): Promise<ReviewRequest[]>` | The open pull requests waiting on one login's review, in these repositories and no others. |
 
 ### `CommandRunner`
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -699,6 +699,11 @@
         },
         {
           "depth": 3,
+          "title": "The forge says whether it can merge, whether its checks passed, and what is waiting on you.",
+          "slug": "the-forge-says-whether-it-can-merge-whether-its-checks-passed-and-what-is-waiting-on-you"
+        },
+        {
+          "depth": 3,
           "title": "The version moves because a change said it should, and an installed package can say which one it is.",
           "slug": "the-version-moves-because-a-change-said-it-should-and-an-installed-package-can-say-which-one-it-is"
         },
@@ -2778,6 +2783,11 @@
             "name": "reviewLoad",
             "signature": "reviewLoad(repos: readonly string[]): Promise<Record<string, number>>",
             "doc": "Open reviews per login, counted across every given repository."
+          },
+          {
+            "name": "reviewsRequestedOf",
+            "signature": "reviewsRequestedOf(login: string, repos: readonly string[]): Promise<ReviewRequest[]>",
+            "doc": "The open pull requests waiting on one login's review, in these repositories and no others."
           }
         ]
       },
@@ -5615,6 +5625,18 @@
         "id": "the-engine-drives-any-workflow",
         "title": "The engine drives a workflow it does not know.",
         "body": "`WorkflowRuntime` is new in the core: what a workflow contributes so that\nsomething else can run it — how to find work, what the world looks like, one\nhandler per action, and the fold only the workflow can do. The serial engine\ntakes one and keeps the half that names nothing: the queue, the attempt\ncounts, the budget and the handbrake.\n\nFor anyone driving this from a config: `repos`, `qaStatusName` and `policy`\nmoved from the engine's settings slice to the workflow's, and the engine\ngained `retryDelayMs` of its own. `amy` maps both for you; a hand-written\n`plugins:` slice needs the two keys moved.",
+        "bumps": [
+          {
+            "package": "@amykit/core",
+            "level": "minor"
+          }
+        ],
+        "level": "minor"
+      },
+      {
+        "id": "the-forge-says-if-it-can-merge",
+        "title": "The forge says whether it can merge, whether its checks passed, and what is waiting on you.",
+        "body": "Three things the forge always knew and nothing here could ask it. Each one is\na `CodeHost` question, so any workflow gets them and none of them is the\nticket workflow's private vocabulary.\n\n**`checks`** — what CI says about the head, and the commit it says it about.\nCarried with the sha for the same reason a review carries one: a green rollup\nfrom three pushes ago says nothing about what is there now. `none` is a\nseparate answer from `failing`, because a repository that runs no checks\nreports exactly that, and a machine reading it as \"not passing\" would hold\nevery pull request for a verdict nobody is coming to give. Seen in the wild on\na release pull request whose workflows are all skipped.\n\n**`mergeState`** — `conflicting`, `behind`, `mergeable` or `unknown`. Only the\nstates a workflow can act on itself, plus not-yet-known, because the forge\nworks a merge out asynchronously and guessing either way is how a branch gets\nhanded over as mergeable before anybody knows. Everything else a forge reports\nhere is already carried by `reviewDecision` and `checks`, and a second name for\nit would be two fields free to disagree.\n\n**`reviewsRequestedOf(login, repos)`** — the open pull requests waiting on one\nperson. `reviewLoad` counts; it does not say which, and the second cannot be\nderived from the first. Scoped to the repositories given, and an empty list is\nnothing to search rather than everything: a forge search runs across the\naccount, so an unscoped one returns work from every repository the credential\ncan see.\n\n**Nothing is offered to a reviewer that the forge already says is broken.**\nRed checks, a conflict, or a branch sitting on a base it has moved off now go\nback to the ticket's owner instead of onto somebody's pile. Review time is the\none currency here nobody can top up — the reason the per-reviewer ceiling\nexists — and a reading of a branch about to change is a reading done twice.\nA verdict still running is waited for, bounded by the same ceiling the local\ngate answers to, because a check that is configured and never reports would\notherwise be a ticket that stops with nobody told.",
         "bumps": [
           {
             "package": "@amykit/core",

--- a/docs/reference/contracts.md
+++ b/docs/reference/contracts.md
@@ -98,6 +98,7 @@ Declared in `packages/core/src/ports/CodeHost.ts`.
 | `openPullRequest(request: OpenPullRequestRequest): Promise<number>` |  |
 | `requestReview(repo: string, pullRequestNumber: number, host: string): Promise<void>` |  |
 | `reviewLoad(repos: readonly string[]): Promise<Record<string, number>>` | Open reviews per login, counted across every given repository. |
+| `reviewsRequestedOf(login: string, repos: readonly string[]): Promise<ReviewRequest[]>` | The open pull requests waiting on one login's review, in these repositories and no others. |
 
 ### `CommandRunner`
 

--- a/packages/cli/tests/two-workflows.test.ts
+++ b/packages/cli/tests/two-workflows.test.ts
@@ -119,6 +119,13 @@ class World {
                       isDraft: false,
                       reviewDecision: null,
                       headRefOid: "abc",
+                      mergeable: "MERGEABLE",
+                      mergeStateStatus: "CLEAN",
+                      commits: {
+                        nodes: [
+                          { commit: { oid: "abc", statusCheckRollup: { state: "SUCCESS" } } },
+                        ],
+                      },
                       reviewRequests: { nodes: [] },
                       reviews: { nodes: [] },
                       reviewThreads: { nodes: [] },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,10 +28,14 @@ export type { GraphQLClient } from "./ports/GraphQL.js";
 export type { CommandOutcome, Commands } from "./ports/Commands.js";
 export type { AskContext, Harness, HarnessReply } from "./ports/Harness.js";
 export type {
+  ChecksState,
+  ChecksView,
   CodeHost,
+  MergeState,
   OpenPullRequestRequest,
   PullRequestView,
   ReviewDecision,
+  ReviewRequest,
   ReviewState,
   ReviewSubmission,
   ReviewThread,

--- a/packages/core/src/ports/CodeHost.ts
+++ b/packages/core/src/ports/CodeHost.ts
@@ -18,6 +18,49 @@ export interface ReviewThread {
   isOutdated: boolean;
 }
 
+/**
+ * What the forge's own checks say. `none` where it runs none at all, which is
+ * a different answer from "not passing" and the workflow has to tell them
+ * apart: a repository with no CI must not wait forever for a verdict.
+ */
+export type ChecksState = "passing" | "failing" | "running" | "none";
+
+export interface ChecksView {
+  state: ChecksState;
+  /**
+   * The commit they ran against.
+   *
+   * Carried for the same reason a review carries one: a green rollup from
+   * three pushes ago says nothing about the head, and a workflow that could
+   * not tell would hand a broken branch to a person.
+   */
+  commitSha: string;
+}
+
+/**
+ * What stands between the branch and its base, as the forge sees it.
+ *
+ * Only the states a workflow can act on itself, plus not-yet-known — the
+ * forge works a merge out asynchronously, and `unknown` is the honest answer
+ * while it does rather than a guess in either direction.
+ *
+ * Everything else a forge reports here — blocked on a required review,
+ * unstable because checks are red — is already carried by `reviewDecision`
+ * and `checks`. A second name for it would be two fields free to disagree.
+ */
+export type MergeState = "mergeable" | "conflicting" | "behind" | "unknown";
+
+/** One pull request waiting on somebody's review. */
+export interface ReviewRequest {
+  repo: string;
+  number: number;
+  url: string;
+  title: string;
+  author: string;
+  /** The head it is asking about, so a review of an older one is visible. */
+  headSha: string;
+}
+
 export interface PullRequestView {
   number: number;
   /**
@@ -44,6 +87,9 @@ export interface PullRequestView {
   additions: number;
   deletions: number;
   reviewDecision: ReviewDecision;
+  /** What the forge's own checks say about the head, or null where it runs none. */
+  checks: ChecksView | null;
+  mergeState: MergeState;
   reviews: readonly ReviewSubmission[];
   threads: readonly ReviewThread[];
   requestedReviewers: readonly string[];
@@ -92,4 +138,17 @@ export interface CodeHost {
    * quiet in that one.
    */
   reviewLoad(repos: readonly string[]): Promise<Record<string, number>>;
+
+  /**
+   * The open pull requests waiting on one login's review, in these
+   * repositories and no others.
+   *
+   * Scoped to the list because a forge search is account-wide: asked without
+   * it, this machine would pick up work from every repository its credential
+   * can see, including ones nobody meant it to touch. `reviewLoad` answers
+   * "how buried is each reviewer"; this answers "what is waiting on me", and
+   * the second cannot be derived from the first — it counts, it does not say
+   * which.
+   */
+  reviewsRequestedOf(login: string, repos: readonly string[]): Promise<ReviewRequest[]>;
 }

--- a/packages/test-fixtures/src/builders.ts
+++ b/packages/test-fixtures/src/builders.ts
@@ -67,6 +67,10 @@ export function pullRequest(overrides: Partial<PullRequestView> = {}): PullReque
     additions: 40,
     deletions: 12,
     reviewDecision: "REVIEW_REQUIRED",
+    // Green and mergeable by default, so a test about review is about review
+    // and a test about a broken branch has to say so.
+    checks: { state: "passing", commitSha: HEAD },
+    mergeState: "mergeable",
     reviews: [],
     threads: [],
     requestedReviewers: [],

--- a/packages/test-fixtures/src/fakes.ts
+++ b/packages/test-fixtures/src/fakes.ts
@@ -58,6 +58,7 @@ export function fakeHost(pr: PullRequestView | null = null, overrides: Partial<C
     openPullRequest: vi.fn<CodeHost["openPullRequest"]>().mockResolvedValue(4940),
     requestReview: vi.fn<CodeHost["requestReview"]>().mockResolvedValue(undefined),
     reviewLoad: vi.fn<CodeHost["reviewLoad"]>().mockResolvedValue({}),
+    reviewsRequestedOf: vi.fn<CodeHost["reviewsRequestedOf"]>().mockResolvedValue([]),
     ...overrides,
   };
 }

--- a/packages/workflow-errand/tests/walkthrough.test.ts
+++ b/packages/workflow-errand/tests/walkthrough.test.ts
@@ -26,6 +26,8 @@ const PULL_REQUEST: PullRequestView = {
   additions: 40,
   deletions: 12,
   reviewDecision: null,
+  checks: { state: "passing", commitSha: "head" },
+  mergeState: "mergeable",
   reviews: [],
   threads: [],
   requestedReviewers: [],

--- a/packages/workflow-note-to-plan/tests/machine.test.ts
+++ b/packages/workflow-note-to-plan/tests/machine.test.ts
@@ -225,6 +225,8 @@ describe("PR_OPEN", () => {
         additions: 40,
         deletions: 12,
         reviewDecision: null,
+        checks: { state: "passing", commitSha: "head" },
+        mergeState: "mergeable",
         reviews: [],
         threads: [],
         requestedReviewers: [],

--- a/packages/workflow-note-to-plan/tests/runtime.test.ts
+++ b/packages/workflow-note-to-plan/tests/runtime.test.ts
@@ -63,6 +63,7 @@ function fakeHost(overrides: Partial<CodeHost> = {}): CodeHost {
     openPullRequest: vi.fn<CodeHost["openPullRequest"]>().mockResolvedValue(12),
     requestReview: vi.fn<CodeHost["requestReview"]>().mockResolvedValue(undefined),
     reviewLoad: vi.fn<CodeHost["reviewLoad"]>().mockResolvedValue({}),
+    reviewsRequestedOf: vi.fn<CodeHost["reviewsRequestedOf"]>().mockResolvedValue([]),
     ...overrides,
   };
 }
@@ -399,6 +400,8 @@ describe("the pull request the machine can see", () => {
       additions: 40,
       deletions: 12,
       reviewDecision: null,
+      checks: { state: "passing", commitSha: "head" },
+      mergeState: "mergeable",
       reviews: [],
       threads: [],
       requestedReviewers: [],

--- a/packages/workflow-note-to-plan/tests/walkthrough.test.ts
+++ b/packages/workflow-note-to-plan/tests/walkthrough.test.ts
@@ -26,6 +26,8 @@ const PULL_REQUEST: PullRequestView = {
   additions: 40,
   deletions: 12,
   reviewDecision: null,
+  checks: { state: "passing", commitSha: "head" },
+  mergeState: "mergeable",
   reviews: [],
   threads: [],
   requestedReviewers: [],

--- a/packages/workflow-ticket-to-qa/src/machine.ts
+++ b/packages/workflow-ticket-to-qa/src/machine.ts
@@ -276,11 +276,74 @@ function handBack(
   });
 }
 
+/**
+ * What the forge already knows is wrong with the branch, and nothing else.
+ *
+ * Read before a person is asked, because review time is the one currency
+ * here nobody can top up — the same reason the per-reviewer ceiling exists.
+ * A reading of red checks, of a branch that will not merge, or of one sitting
+ * on a base it has moved off, is a reading that has to be done again.
+ *
+ * No checks at all is not a complaint. A repository that runs none reports
+ * exactly that, and a machine that read it as "not passing" would hold every
+ * pull request for a verdict nobody is coming to give.
+ */
+function whatTheForgeSays(pr: PullRequestView): string | null {
+  if (pr.checks?.state === "failing") return `the checks on ${pr.headSha.slice(0, 7)} are red`;
+  if (pr.mergeState === "conflicting") return "the branch conflicts with its base";
+  if (pr.mergeState === "behind") return "the branch is behind its base";
+  return null;
+}
+
+/** The forge's complaint, handed to the owner once, the way size already is. */
+function handBackBroken(
+  record: TicketRecord,
+  pr: PullRequestView,
+  policy: Policy,
+  why: string,
+): Plan {
+  if (record.escalation && !record.escalation.resolvedAt) {
+    return wait(policy.pollBackoffMs, `waiting on the owner: ${why}`);
+  }
+
+  return advance("ESCALATED", why, {
+    type: "escalate",
+    reason: `I am not asking anybody to review this yet — ${why}. It is yours: ${pr.url}`,
+    threadIds: [],
+  });
+}
+
 function planReviewerAssignment(
   record: TicketRecord,
   obs: Observation,
   policy: Policy,
 ): Plan {
+  const pr = requirePullRequest(obs, "REVIEWER_ASSIGNED");
+  if (isPlan(pr)) return pr;
+
+  // A verdict that has not arrived is not a bad one. Waiting costs a poll;
+  // asking somebody to read what CI is about to fail costs their afternoon.
+  //
+  // Bounded, because a check that is configured and never reports leaves a
+  // rollup that says `running` for ever, and an unbounded wait here is a
+  // ticket that stops without anybody being told. The remote checks are a
+  // gate, so they answer to the same ceiling the local one does.
+  if (pr.checks?.state === "running") {
+    const looks = attemptsIn(record, "REVIEWER_ASSIGNED");
+    if (looks < policy.maxGateAttempts) {
+      return wait(policy.pollBackoffMs, `the checks on ${pr.headSha.slice(0, 7)} have not finished`);
+    }
+    return handBackBroken(
+      record,
+      pr,
+      policy,
+      `the checks on ${pr.headSha.slice(0, 7)} never finished`,
+    );
+  }
+
+  const broken = whatTheForgeSays(pr);
+  if (broken) return handBackBroken(record, pr, policy, broken);
+
   const firstLook = attemptsIn(record, "REVIEWER_ASSIGNED") === 0;
 
   if (!isConfirmedFor(obs.roster, obs.now)) {

--- a/packages/workflow-ticket-to-qa/tests/machine.test.ts
+++ b/packages/workflow-ticket-to-qa/tests/machine.test.ts
@@ -415,7 +415,7 @@ describe("REVIEWER_ASSIGNED", () => {
   });
 
   it("counts a reviewer with no open reviews as empty rather than unknown", () => {
-    const obs = observation({ reviewLoad: { "ada": 2, edsger: 1 } });
+    const obs = observation({ pullRequest: pullRequest(), reviewLoad: { "ada": 2, edsger: 1 } });
 
     const p = expectAdvance(plan(record("REVIEWER_ASSIGNED"), obs, policy));
 
@@ -424,6 +424,7 @@ describe("REVIEWER_ASSIGNED", () => {
 
   it("breaks a tie the same way every time", () => {
     const obs = observation({
+      pullRequest: pullRequest(),
       reviewLoad: { "ada": 1, alan: 1, edsger: 1 },
     });
 
@@ -436,6 +437,7 @@ describe("REVIEWER_ASSIGNED", () => {
 
   it("skips anybody marked unavailable", () => {
     const obs = observation({
+      pullRequest: pullRequest(),
       roster: roster({
         confirmedOn: "2026-09-03",
         reviewers: [
@@ -482,7 +484,7 @@ describe("REVIEWER_ASSIGNED", () => {
   });
 
   it("says nothing the second time it finds the ceiling reached", () => {
-    const obs = observation({ reviewLoad: { "ada": 5, alan: 5, edsger: 5 } });
+    const obs = observation({ pullRequest: pullRequest(), reviewLoad: { "ada": 5, alan: 5, edsger: 5 } });
 
     const p = expectWait(
       plan(record("REVIEWER_ASSIGNED", { attempts: { REVIEWER_ASSIGNED: 1 } }), obs, policy),
@@ -493,6 +495,7 @@ describe("REVIEWER_ASSIGNED", () => {
 
   it("assigns the emptiest reviewer while one is still under the ceiling", () => {
     const obs = observation({
+      pullRequest: pullRequest(),
       reviewLoad: { "ada": 4, alan: 1, edsger: 4 },
     });
 
@@ -502,7 +505,7 @@ describe("REVIEWER_ASSIGNED", () => {
   });
 
   it("refuses to assign on a workday when the roster is stale", () => {
-    const obs = observation({ roster: roster({ confirmedOn: "2026-09-01" }), now: WORKDAY });
+    const obs = observation({ pullRequest: pullRequest(), roster: roster({ confirmedOn: "2026-09-01" }), now: WORKDAY });
 
     const p = expectWait(plan(record("REVIEWER_ASSIGNED"), obs, policy));
 
@@ -511,14 +514,14 @@ describe("REVIEWER_ASSIGNED", () => {
   });
 
   it("asks only on the first look, so a stale roster does not spam", () => {
-    const obs = observation({ roster: roster({ confirmedOn: "2026-09-01" }) });
+    const obs = observation({ pullRequest: pullRequest(), roster: roster({ confirmedOn: "2026-09-01" }) });
     const later = record("REVIEWER_ASSIGNED", { attempts: { REVIEWER_ASSIGNED: 1 } });
 
     expect(expectWait(plan(later, obs, policy)).effects).toEqual([]);
   });
 
   it("does not need confirmation at the weekend", () => {
-    const obs = observation({ roster: roster({ confirmedOn: "2026-09-01" }), now: WEEKEND });
+    const obs = observation({ pullRequest: pullRequest(), roster: roster({ confirmedOn: "2026-09-01" }), now: WEEKEND });
 
     expect(expectAdvance(plan(record("REVIEWER_ASSIGNED"), obs, policy)).to).toBe(
       "HUMAN_REVIEW",
@@ -527,6 +530,7 @@ describe("REVIEWER_ASSIGNED", () => {
 
   it("holds when the whole roster is away", () => {
     const obs = observation({
+      pullRequest: pullRequest(),
       roster: roster({ reviewers: [{ tracker: "a@x", host: "edsger", available: false }] }),
     });
 
@@ -712,5 +716,95 @@ describe("QA_HANDOFF", () => {
 describe("DONE", () => {
   it("is terminal", () => {
     expect(plan(record("DONE"), observation(), policy).kind).toBe("settled");
+  });
+});
+
+describe("what the forge says, before a person is asked", () => {
+  const at = (state: "passing" | "failing" | "running"): ReturnType<typeof pullRequest> =>
+    pullRequest({ checks: { state, commitSha: HEAD } });
+
+  it("waits while the checks are still running, rather than spending a reviewer", () => {
+    const obs = observation({ pullRequest: at("running"), reviewLoad: {} });
+
+    expect(expectWait(plan(record("REVIEWER_ASSIGNED"), obs, policy)).why).toContain(
+      "have not finished",
+    );
+  });
+
+  it("hands red checks to the owner instead of assigning anybody", () => {
+    const obs = observation({ pullRequest: at("failing"), reviewLoad: {} });
+
+    const p = expectAdvance(plan(record("REVIEWER_ASSIGNED"), obs, policy));
+
+    expect(p.to).toBe("ESCALATED");
+    expect(p.why).toContain("are red");
+  });
+
+  it("hands a conflicting branch to the owner", () => {
+    const obs = observation({
+      pullRequest: pullRequest({ mergeState: "conflicting" }),
+      reviewLoad: {},
+    });
+
+    const p = expectAdvance(plan(record("REVIEWER_ASSIGNED"), obs, policy));
+
+    expect(p.to).toBe("ESCALATED");
+    expect(p.why).toContain("conflicts");
+  });
+
+  // A review read against a base the branch has moved off is a review that
+  // has to be done again.
+  it("hands a branch behind its base to the owner", () => {
+    const obs = observation({
+      pullRequest: pullRequest({ mergeState: "behind" }),
+      reviewLoad: {},
+    });
+
+    expect(expectAdvance(plan(record("REVIEWER_ASSIGNED"), obs, policy)).why).toContain("behind");
+  });
+
+  // The one that stops this becoming a machine that never assigns anybody in
+  // a repository without CI. No checks is an answer, not a red verdict.
+  it("assigns a reviewer where the forge runs no checks at all", () => {
+    const obs = observation({ pullRequest: pullRequest({ checks: null }), reviewLoad: {} });
+
+    const p = expectAdvance(plan(record("REVIEWER_ASSIGNED"), obs, policy));
+
+    // Which reviewer is the tie-break's business, and it has its own test.
+    expect(p.to).toBe("HUMAN_REVIEW");
+    expect(p.effects.map((effect) => effect.type)).toEqual(["assign-reviewer"]);
+  });
+
+  // The hazard the end-to-end walk found: a check that is configured and
+  // never reports leaves a rollup saying `running` for ever, and an
+  // unbounded wait here is a ticket that stops with nobody told.
+  it("stops waiting on a verdict that never comes, and says so", () => {
+    const r = record("REVIEWER_ASSIGNED", {
+      attempts: { REVIEWER_ASSIGNED: policy.maxGateAttempts },
+    });
+
+    const p = expectAdvance(plan(r, observation({ pullRequest: at("running") }), policy));
+
+    expect(p.to).toBe("ESCALATED");
+    expect(p.why).toContain("never finished");
+  });
+
+  it("says nothing to the owner a second time while the first is unanswered", () => {
+    const r = record("REVIEWER_ASSIGNED", {
+      escalation: { reason: "the checks are red", askedAt: WORKDAY.toISOString() },
+    });
+
+    expect(expectWait(plan(r, observation({ pullRequest: at("failing") }), policy)).why).toContain(
+      "waiting on the owner",
+    );
+  });
+
+  it("does not read a verdict as a merge state, or the other way round", () => {
+    const obs = observation({
+      pullRequest: pullRequest({ checks: { state: "passing", commitSha: HEAD } }),
+      reviewLoad: {},
+    });
+
+    expect(expectAdvance(plan(record("REVIEWER_ASSIGNED"), obs, policy)).to).toBe("HUMAN_REVIEW");
   });
 });

--- a/packages/workflow-ticket-to-qa/tests/walkthrough.test.ts
+++ b/packages/workflow-ticket-to-qa/tests/walkthrough.test.ts
@@ -40,6 +40,10 @@ class FakeWorld {
     }[] = [{ decision: "APPROVED" }],
     /** Threads the agent refuses to change, by id. */
     private readonly disagreeWith: string[] = [],
+    /** What the forge's checks say when the pull request is opened. */
+    private readonly checksStart: "passing" | "failing" | "running" = "passing",
+    /** What the forge says stands between the branch and its base. */
+    private readonly mergeState: "mergeable" | "conflicting" | "behind" = "mergeable",
   ) {}
 
   private now(): Date {
@@ -121,22 +125,26 @@ class FakeWorld {
         case "run-gate":
           outcomes.gate = { ok: true, output: "", at: this.now().toISOString() };
           break;
-        case "open-pull-request":
+        case "open-pull-request": {
+          const head = this.nextHead();
           this.pullRequest = {
             number: 4940,
             url: "https://github.example.test/acme/widgets/pull/4940",
-            headSha: this.nextHead(),
+            headSha: head,
             isDraft: false,
             changedFiles: 3,
             additions: 40,
             deletions: 12,
             reviewDecision: "REVIEW_REQUIRED",
+            checks: { state: this.checksStart, commitSha: head },
+            mergeState: this.mergeState,
             reviews: [],
             threads: [],
             requestedReviewers: [],
           };
           outcomes.pullRequestNumber = 4940;
           break;
+        }
         case "assign-reviewer":
           outcomes.reviewer = effect.host;
           this.request(effect.host);
@@ -156,6 +164,16 @@ class FakeWorld {
           outcomes.escalation = { reason: effect.reason, askedAt: this.now().toISOString() };
           // The owner sides with the reviewer, so the next pass fixes it.
           this.escalationAnswered = true;
+          // An owner handed a broken branch deals with it. Without this the
+          // walk would escalate, be answered, come back to the same red
+          // rollup and escalate again — which is a spin, not a lifecycle.
+          if (this.pullRequest) {
+            this.pullRequest = {
+              ...this.pullRequest,
+              checks: { state: "passing", commitSha: this.pullRequest.headSha },
+              mergeState: "mergeable",
+            };
+          }
           this.disagreeWith.length = 0;
           outcomes.escalationResolvedAt = this.now().toISOString();
           break;
@@ -324,5 +342,35 @@ describe("driving a ticket end to end", () => {
     expect(record.escalation?.resolvedAt).toBeDefined();
     // The owner's answer put the comment back in play instead of leaving it parked.
     expect(record.judged).toEqual([{ threadId: "T1", verdict: "fixed", note: "n" }]);
+  });
+
+  // The forge's complaint has to be a detour and not a dead end. Sending a
+  // branch back to its owner lands in ESCALATED, and ESCALATED was built for
+  // a disagreement about review comments — a state this arrives in carrying
+  // none. What proves the two fit is reaching DONE anyway.
+  it("takes the long way round when the checks are red, and still reaches QA", () => {
+    const world = new FakeWorld([], [{ decision: "APPROVED" }], [], "failing");
+
+    const { record, states } = drive(world);
+
+    expect(record.state).toBe("DONE");
+    expect(states).toContain("ESCALATED");
+  });
+
+  it("takes the long way round when the branch conflicts, and still reaches QA", () => {
+    const world = new FakeWorld([], [{ decision: "APPROVED" }], [], "passing", "conflicting");
+
+    const { record } = drive(world);
+
+    expect(record.state).toBe("DONE");
+  });
+
+  // Nobody is asked to read something the forge has not finished judging.
+  it("never asks a reviewer before the checks have a verdict", () => {
+    const world = new FakeWorld([], [{ decision: "APPROVED" }], [], "running");
+
+    const { record } = drive(world);
+
+    expect(record.state).toBe("DONE");
   });
 });

--- a/plugins/github/src/GitHubCodeHost.ts
+++ b/plugins/github/src/GitHubCodeHost.ts
@@ -1,9 +1,12 @@
 import {
+  ChecksView,
   CodeHost,
   CommandRunner,
+  MergeState,
   OpenPullRequestRequest,
   PullRequestView,
   ReviewDecision,
+  ReviewRequest,
   ReviewState,
   ReviewSubmission,
   ReviewThread,
@@ -22,6 +25,11 @@ query PullRequest($owner: String!, $name: String!, $branch: String!) {
         changedFiles
         additions
         deletions
+        mergeable
+        mergeStateStatus
+        commits(last: 1) {
+          nodes { commit { oid statusCheckRollup { state } } }
+        }
         reviewRequests(first: 20) {
           nodes {
             requestedReviewer {
@@ -53,6 +61,31 @@ query PullRequest($owner: String!, $name: String!, $branch: String!) {
   }
 }`;
 
+const REVIEW_REQUESTS_QUERY = `
+query ReviewRequests($query: String!) {
+  search(query: $query, type: ISSUE, first: 50) {
+    nodes {
+      ... on PullRequest {
+        number
+        title
+        url
+        headRefOid
+        author { login }
+        repository { nameWithOwner }
+      }
+    }
+  }
+}`;
+
+interface RawReviewRequest {
+  number?: number;
+  title?: string;
+  url?: string;
+  headRefOid?: string;
+  author?: { login: string } | null;
+  repository?: { nameWithOwner: string };
+}
+
 interface RawPullRequest {
   number: number;
   url: string;
@@ -62,6 +95,11 @@ interface RawPullRequest {
   changedFiles: number;
   additions: number;
   deletions: number;
+  mergeable: string | null;
+  mergeStateStatus: string | null;
+  commits?: {
+    nodes: { commit: { oid: string; statusCheckRollup: { state: string } | null } }[];
+  };
   reviewRequests: {
     nodes: { requestedReviewer: { login?: string; slug?: string } | null }[];
   };
@@ -175,6 +213,40 @@ export class GitHubCodeHost implements CodeHost {
     return load;
   }
 
+  /**
+   * What is waiting on one person, in these repositories and no others.
+   *
+   * The scope is not a convenience. A forge search runs across the account,
+   * so asked without it this returns pull requests from every repository the
+   * credential can see — including ones nobody meant this machine to touch.
+   * An empty list is therefore nothing to search rather than everything.
+   */
+  async reviewsRequestedOf(login: string, repos: readonly string[]): Promise<ReviewRequest[]> {
+    if (repos.length === 0) return [];
+
+    const scope = repos.map((repo) => `repo:${repo}`).join(" ");
+    const data = await this.graphql<{ search: { nodes: RawReviewRequest[] } }>(
+      REVIEW_REQUESTS_QUERY,
+      { query: `is:pr is:open review-requested:${login} ${scope}` },
+    );
+
+    return data.search.nodes.flatMap<ReviewRequest>((node) => {
+      // The search returns issues too, and the fragment leaves those empty.
+      if (node.number === undefined || !node.repository) return [];
+
+      return [
+        {
+          repo: node.repository.nameWithOwner,
+          number: node.number,
+          url: node.url ?? "",
+          title: node.title ?? "",
+          author: node.author?.login ?? "",
+          headSha: node.headRefOid ?? "",
+        },
+      ];
+    });
+  }
+
   private async defaultBranch(repo: string): Promise<string> {
     return this.gh(["api", `/repos/${repo}`, "--jq", ".default_branch"]);
   }
@@ -232,6 +304,8 @@ function toView(node: RawPullRequest): PullRequestView {
     additions: node.additions,
     deletions: node.deletions,
     reviewDecision: toDecision(node.reviewDecision),
+    checks: toChecks(node),
+    mergeState: toMergeState(node.mergeable, node.mergeStateStatus),
     requestedReviewers: node.reviewRequests.nodes
       .map((request) => request.requestedReviewer?.login ?? request.requestedReviewer?.slug)
       .filter((who): who is string => Boolean(who)),
@@ -264,6 +338,47 @@ function toView(node: RawPullRequest): PullRequestView {
       ];
     }),
   };
+}
+
+/**
+ * The forge's verdict on the head, or nothing where it runs no checks.
+ *
+ * A null rollup is a real answer and not a failure: a repository with no CI
+ * reports one, and a workflow told "not passing" would wait for a verdict
+ * that is never coming. Seen in the wild on a release pull request whose
+ * workflows are all skipped.
+ */
+function toChecks(node: RawPullRequest): ChecksView | null {
+  const commit = node.commits?.nodes[0]?.commit;
+  if (!commit?.statusCheckRollup) return null;
+
+  return { state: toChecksState(commit.statusCheckRollup.state), commitSha: commit.oid };
+}
+
+function toChecksState(state: string): NonNullable<ChecksView>["state"] {
+  switch (state) {
+    case "SUCCESS":
+      return "passing";
+    case "FAILURE":
+    case "ERROR":
+      return "failing";
+    default:
+      // EXPECTED and PENDING both mean "no verdict yet", and an unrecognised
+      // state is treated the same way: waiting is the answer that costs
+      // nothing, where guessing either verdict costs a wrong move.
+      return "running";
+  }
+}
+
+/**
+ * A conflict outranks being behind, because a branch can be both and only one
+ * of them is what has to be dealt with first.
+ */
+function toMergeState(mergeable: string | null, mergeStateStatus: string | null): MergeState {
+  if (mergeable === "CONFLICTING" || mergeStateStatus === "DIRTY") return "conflicting";
+  if (mergeStateStatus === "BEHIND") return "behind";
+  if (mergeable === "MERGEABLE") return "mergeable";
+  return "unknown";
 }
 
 function toDecision(value: string | null): ReviewDecision {

--- a/plugins/github/tests/GitHubCodeHost.test.ts
+++ b/plugins/github/tests/GitHubCodeHost.test.ts
@@ -23,6 +23,14 @@ const REAL_RESPONSE = {
             isDraft: false,
             reviewDecision: "CHANGES_REQUESTED",
             headRefOid: HEAD,
+            changedFiles: 7,
+            additions: 214,
+            deletions: 31,
+            mergeable: "MERGEABLE",
+            mergeStateStatus: "CLEAN",
+            commits: {
+              nodes: [{ commit: { oid: HEAD, statusCheckRollup: { state: "SUCCESS" } } }],
+            },
             reviewRequests: {
               nodes: [
                 { requestedReviewer: { __typename: "User", login: "adamwbm" } },
@@ -285,3 +293,165 @@ describe("GitHubCodeHost.reviewLoad", () => {
     ).resolves.toEqual({});
   });
 });
+
+/** The base fixture with one pull request field replaced. */
+function withNode(fields: Record<string, unknown>): unknown {
+  const node = REAL_RESPONSE.data.repository.pullRequests.nodes[0];
+  return {
+    data: { repository: { pullRequests: { nodes: [{ ...node, ...fields }] } } },
+  };
+}
+
+describe("GitHubCodeHost: what the forge says about the branch", () => {
+  it("maps the size the forge already counted", async () => {
+    const { host } = hostFor(REAL_RESPONSE);
+
+    expect(await host.findPullRequest("Northwind/northwind-backend", "b")).toMatchObject({
+      changedFiles: 7,
+      additions: 214,
+      deletions: 31,
+    });
+  });
+
+  it("keeps the commit the checks ran against, so a green older head is visible", async () => {
+    const { host } = hostFor(
+      withNode({
+        commits: { nodes: [{ commit: { oid: OLDER, statusCheckRollup: { state: "SUCCESS" } } }] },
+      }),
+    );
+
+    const pr = (await host.findPullRequest("Northwind/northwind-backend", "b"))!;
+
+    expect(pr.checks).toEqual({ state: "passing", commitSha: OLDER });
+    expect(pr.headSha).toBe(HEAD);
+  });
+
+  // Seen on a real release pull request whose workflows are all skipped.
+  // Told apart from "not passing", or a repository with no CI waits forever.
+  it("reports no checks where the forge ran none", async () => {
+    const { host } = hostFor(
+      withNode({ commits: { nodes: [{ commit: { oid: HEAD, statusCheckRollup: null } }] } }),
+    );
+
+    expect((await host.findPullRequest("Northwind/northwind-backend", "b"))?.checks).toBeNull();
+  });
+
+  // A forge that answered without the head commit ran no checks. Reading it
+  // as a crash takes the tick down and the ticket with it, which is a worse
+  // answer than the true one.
+  it("reports no checks where the forge did not answer with a head commit", async () => {
+    const node = REAL_RESPONSE.data.repository.pullRequests.nodes[0];
+    const { commits: _dropped, ...withoutCommits } = node as typeof node & { commits: unknown };
+    const { host } = hostFor({
+      data: { repository: { pullRequests: { nodes: [withoutCommits] } } },
+    });
+
+    expect((await host.findPullRequest("Northwind/northwind-backend", "b"))?.checks).toBeNull();
+  });
+
+  it.each([
+    ["SUCCESS", "passing"],
+    ["FAILURE", "failing"],
+    ["ERROR", "failing"],
+    ["PENDING", "running"],
+    ["EXPECTED", "running"],
+  ])("reads a %s rollup as %s", async (state, expected) => {
+    const { host } = hostFor(
+      withNode({
+        commits: { nodes: [{ commit: { oid: HEAD, statusCheckRollup: { state } } }] },
+      }),
+    );
+
+    expect((await host.findPullRequest("Northwind/northwind-backend", "b"))?.checks?.state).toBe(
+      expected,
+    );
+  });
+
+  it.each([
+    ["MERGEABLE", "CLEAN", "mergeable"],
+    ["CONFLICTING", "DIRTY", "conflicting"],
+    ["MERGEABLE", "BEHIND", "behind"],
+    ["UNKNOWN", "UNKNOWN", "unknown"],
+    // The forge works a merge out asynchronously, and says so. Guessing
+    // either way here is how a branch gets handed over as mergeable before
+    // anybody knows whether it is.
+    ["UNKNOWN", "CLEAN", "unknown"],
+  ])("reads %s/%s as %s", async (mergeable, mergeStateStatus, expected) => {
+    const { host } = hostFor(withNode({ mergeable, mergeStateStatus }));
+
+    expect((await host.findPullRequest("Northwind/northwind-backend", "b"))?.mergeState).toBe(
+      expected,
+    );
+  });
+
+  // Both at once is a real state, and only one of them is what has to be
+  // dealt with first.
+  it("calls a branch that both conflicts and is behind a conflict", async () => {
+    const { host } = hostFor(withNode({ mergeable: "CONFLICTING", mergeStateStatus: "BEHIND" }));
+
+    expect((await host.findPullRequest("Northwind/northwind-backend", "b"))?.mergeState).toBe(
+      "conflicting",
+    );
+  });
+});
+
+const SEARCH_RESPONSE = {
+  data: {
+    search: {
+      nodes: [
+        {
+          number: 4886,
+          title: "Improve logging around knit syncs",
+          url: "https://github.example.test/Northwind/northwind-backend/pull/4886",
+          headRefOid: HEAD,
+          author: { login: "alan" },
+          repository: { nameWithOwner: "Northwind/northwind-backend" },
+        },
+        // The search returns issues too, and the fragment leaves those empty.
+        {},
+      ],
+    },
+  },
+};
+
+describe("GitHubCodeHost.reviewsRequestedOf", () => {
+  it("asks only about the repositories it was given", async () => {
+    const { runner, host } = hostFor(SEARCH_RESPONSE);
+
+    await host.reviewsRequestedOf("edsger", [
+      "Northwind/northwind-backend",
+      "Northwind/northwind-frontend",
+    ]);
+
+    const asked = runner.argvFor("gh").join(" ");
+    expect(asked).toContain("review-requested:edsger");
+    expect(asked).toContain("repo:Northwind/northwind-backend");
+    expect(asked).toContain("repo:Northwind/northwind-frontend");
+    expect(asked).toContain("is:open");
+  });
+
+  // The one that matters. A forge search runs across the account, so an
+  // unscoped one returns work from every repository the credential can see.
+  it("searches nothing at all when it was given no repository", async () => {
+    const { runner, host } = hostFor(SEARCH_RESPONSE);
+
+    expect(await host.reviewsRequestedOf("edsger", [])).toEqual([]);
+    expect(runner.calls).toHaveLength(0);
+  });
+
+  it("maps a pull request and drops what is not one", async () => {
+    const { host } = hostFor(SEARCH_RESPONSE);
+
+    expect(await host.reviewsRequestedOf("edsger", ["Northwind/northwind-backend"])).toEqual([
+      {
+        repo: "Northwind/northwind-backend",
+        number: 4886,
+        title: "Improve logging around knit syncs",
+        url: "https://github.example.test/Northwind/northwind-backend/pull/4886",
+        author: "alan",
+        headSha: HEAD,
+      },
+    ]);
+  });
+});
+


### PR DESCRIPTION
Three things the forge always knew and nothing here could ask it — the three
gaps that stood between the current engine and a workflow that handles
tickets, its own pull requests, and other people's reviews.

## What the port gained

**`checks`** — what CI says about the head, and *the commit it says it about*.
Carried with the sha for the same reason a review carries one: a green rollup
from three pushes ago says nothing about what is there now.

`none` is a separate answer from `failing`. A repository that runs no checks
reports exactly that, and a machine reading it as "not passing" would hold
every pull request for a verdict nobody is coming to give. Not a
hypothetical — it came off the real API, on a release pull request whose
workflows are all skipped.

**`mergeState`** — `conflicting`, `behind`, `mergeable`, `unknown`. Only what a
workflow can act on itself, plus not-yet-known: the forge works a merge out
asynchronously, and guessing either way is how a branch gets handed over as
mergeable before anybody knows whether it is. Everything else a forge reports
here — blocked on a review, unstable because checks are red — is already
carried by `reviewDecision` and `checks`, and a second name for it would be
two fields free to disagree.

**`reviewsRequestedOf(login, repos)`** — the discovery `reviewLoad` cannot do.
It counts how buried each reviewer is; it does not say *which* pull requests,
and the second cannot be derived from the first.

Scoped to the repositories given, and that is not a convenience: a forge
search runs across the account, so an unscoped one returns work from every
repository the credential can see, including ones nobody meant this machine to
touch. An empty list is nothing to search rather than everything. That guard
was watched failing without it.

## And a consumer, because a field nobody reads is a guess

**Nothing is offered to a reviewer that the forge already says is broken.**
Red checks, a conflict, or a branch sitting on a base it has moved off now go
back to the ticket's owner rather than onto somebody's pile. Review time is
the one currency here nobody can top up — the reason the per-reviewer ceiling
exists — and a reading of a branch that is about to change is a reading done
twice.

## What the end-to-end walk caught

The first run of the lifecycle scenario after this **spun**: 18/30 in 60
looks, never settling.

The cause was a real defect, not a fixture. A rollup that says `running` and
never resolves left an unbounded wait, so a ticket would stop with nobody told
— exactly what a required check that is configured and never reports does in
production. The wait is now bounded by the same ceiling the local gate answers
to. The gate found a bug the unit tests could not.

Sending a branch back also lands in `ESCALATED`, a state built for a
disagreement about review comments and arriving here carrying none. Three
walkthrough cases now drive red checks, a conflict, and an unfinished verdict
all the way to `DONE`, which is what proves the detour is not a dead end.

## The stand-in forges were lying by omission

Neither the adapter fixture nor the scenario's fake `gh` carried the
`changedFiles`/`additions`/`deletions` a previous change added, so that
mapping was never exercised end to end either. Both now answer in the shape
the real one does, and the adapter tolerates a forge that answers without a
head commit rather than taking the tick down with it.

## Proof

- `npm run gate` exits 0 — `sf check`: 33 rules, no findings; `sf verify`:
  33/33 proven to fire.
- 952 tests pass, up from 923.
- All seven end-to-end scenarios re-run and all seven gates resealed.
- Both mappings are checked against responses shaped from real API answers,
  captured from this repository's own open pull requests.