### PR TITLE
chore: temporary npm credential diagnostic (do not merge)

### DIFF
--- a/.github/workflows/npm-auth-check.yml
+++ b/.github/workflows/npm-auth-check.yml
@@ -1,0 +1,47 @@
+name: temporary npm authentication check
+
+on:
+  pull_request:
+    branches: [main]
+    paths: [.github/workflows/npm-auth-check.yml]
+
+permissions: {}
+
+jobs:
+  authenticate:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      # No checkout or dependencies: only the runner talks to npm's identity endpoint.
+      - name: Check existing npm credential without publishing
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        shell: bash
+        run: |
+          node --input-type=module <<'NODE'
+          const token = process.env.NPM_TOKEN;
+          if (!token?.trim()) {
+            console.error('NPM_TOKEN is missing or empty in this workflow context.');
+            process.exit(1);
+          }
+          console.log('NPM_TOKEN is present; checking npm authentication.');
+          try {
+            const response = await fetch('https://registry.npmjs.org/-/whoami', {
+              headers: { authorization: `Bearer ${token}` },
+              signal: AbortSignal.timeout(20000),
+              redirect: 'error',
+            });
+            console.log(`npm identity endpoint HTTP status: ${response.status}`);
+            if (!response.ok) process.exit(1);
+            const identity = await response.json();
+            if (typeof identity.username !== 'string' || !identity.username) {
+              console.error('npm did not return a valid account identity.');
+              process.exit(1);
+            }
+            console.log('npm accepted the credential. No package was published; publish authorization is not tested.');
+          } catch {
+            console.error('npm authentication probe could not complete. No credential or response body is logged.');
+            process.exit(1);
+          }
+          NODE


### PR DESCRIPTION
## Temporary diagnostic — do not merge

The failed release run [33994678199](https://github.com/nicolasmelo1/amy/actions/runs/33994678199) logged an empty `NODE_AUTH_TOKEN` and npm `ENEEDAUTH`, although the repository lists an Actions secret named `NPM_TOKEN`.

This deliberately temporary workflow checks the existing repository secret directly:
- same-repository PRs only;
- no checkout, dependency installation, or GitHub token permissions;
- HTTPS request only to npm's read-only identity endpoint, with redirects refused;
- logs presence and HTTP status, never the token, identity, or response body;
- no package publication, token creation, or credential changes.

An accepted identity does not prove publish permission for `@amykit`; it distinguishes a missing/rejected credential from later publishing/configuration failures.

Verified locally that the missing-token path exits 1 before attempting a request. Close this PR and delete its branch after recording the Actions result. The separate release-repair branch fixes the installer and adds permanent preflight checks.

Existing unrelated factory failures on `main` (tracked `sf.sha256`) are not bypassed or fixed in this diagnostic PR.
