### PR TITLE
docs(plans): twelve plans for a machine you install your own workflow into

### DIFF
--- a/plans/a-base-branch-per-repository.md
+++ b/plans/a-base-branch-per-repository.md
@@ -1,0 +1,57 @@
+# A base branch per repository
+
+`defaultBranch` is one string for the whole install (`config.ts:155`), and it
+reaches five places from `pluginSlices`: the gate that decides what to compare
+against, all three harness plugins, and both shipped workflows. A machine
+whose repositories do not all agree on the name has one global answer and no
+way to say otherwise.
+
+The workaround, on the install where this was found, was a `baseByRepo`
+mapping inside a private workflow package — a workflow reimplementing a piece
+of host configuration because the host would not carry it. That is the shape
+of the problem rather than the size of it: the next workflow does it again,
+differently, and two workflows on one machine disagree about what `main` means
+for the same repository.
+
+## What changes
+
+`baseBranch:` maps a repository to its branch; `defaultBranch` is the fallback
+and keeps its name, because most installs will never write the mapping.
+
+```yaml
+defaultBranch: main
+baseBranch:
+  Northwind/northwind-infra: master
+```
+
+Every consumer already knows which repository it is working in — the gate has
+a checkout, the harness has a `cwd`, the workflows have a record naming a
+repo — so this is a lookup replacing a constant at five call sites, not a new
+concept. `pluginSlices` hands down the mapping alongside the fallback rather
+than resolving it, because the slice is built once and the repository is known
+per piece of work.
+
+## The gate
+
+`plugin-serial-engine`, extended: it is the gate that proves a piece of work
+moves through actions, and a base branch is what two of those actions are
+about. Add:
+
+- `base.a_repository_can_name_its_own_branch`
+- `base.the_fallback_still_answers_for_the_rest`
+
+## Acceptance criteria
+
+- [ ] A repository with its own base branch is compared against that one
+      (proof: assertion:base.a_repository_can_name_its_own_branch)
+- [ ] A repository without one still gets `defaultBranch`
+      (proof: assertion:base.the_fallback_still_answers_for_the_rest)
+- [ ] A pull request opens against the repository's own base
+      (proof: test:plugins/github/tests/plugin.test.ts)
+- [ ] A config with no `baseBranch:` block behaves exactly as before
+      (proof: test:packages/cli/tests/slices.test.ts)
+- [ ] The mapping reaches a workflow that never heard of it
+      (proof: test:packages/cli/tests/slices.test.ts)
+
+**Exit condition:** an install works in two repositories with two base branch
+names, and no workflow package on it carries a branch mapping of its own.

--- a/plans/a-ceiling-that-cannot-be-inert.md
+++ b/plans/a-ceiling-that-cannot-be-inert.md
@@ -1,0 +1,66 @@
+# A ceiling that cannot be inert
+
+`packages/model-specs/specs.json` prices `claude-opus-4-5`, `4-6`, `4-7` and
+`claude-sonnet-4-5`. It has no entry for the Claude 5 family. `specFor`
+returns `undefined` for a model it does not know
+(`packages/model-specs/src/specs.ts:90`), the run is recorded with no
+`costUsd` — *"Nobody knows. `costUsd` is absent, and that is the honest
+answer"* (`core/src/agent-run.ts:52`) — and `spend.costUsd` adds nothing
+(`core/src/budget.ts:57`).
+
+Every part of that is correct on its own, and together they produce the one
+failure a budget must not have: an install running a current model with
+`budget.perWeek.costUsd: 150` set has no dollar ceiling at all. It is not
+loose, it is inert. The token ceiling beside it still fires, which is what
+makes this quiet — the machine does stop sometimes, just never for the reason
+that was written down.
+
+The table lagging is not a bug to fix once. A price table always lags, and
+`amy models refresh` exists because of it. What has to change is that the
+ceiling knows.
+
+## What changes
+
+Two things, and the second is the one that lasts.
+
+The table gains the current models, through `amy models refresh` against
+models.dev and committed — `packages/model-specs/specs.json` is under
+`L2.GENERATED_FILES_ARE_LOCKED`, so it moves visibly or not at all.
+
+And a `costUsd` ceiling is refused at boot when a rung in any ladder names a
+model the table cannot price. The relay already refuses *"a budget it cannot
+mean"* (`assertion:relay.refuses_a_budget_it_cannot_mean_at_boot`); this is
+the same sentence about a different half of the same thing, and it says which
+model and which rung, so the answer is either `amy models refresh` or a
+ceiling in tokens.
+
+`amy budget` says the same thing while it is running: a window with a dollar
+ceiling and unpriced runs in it reports how many, rather than reporting a
+spend that is arithmetically true and practically a lie.
+
+## The gate
+
+`plugin-agent-relay`, extended — it owns the ceiling and its activation covers
+`packages/agent-kit/src/**`. Add:
+
+- `relay.refuses_a_dollar_ceiling_it_cannot_price`
+- `relay.names_the_model_that_has_no_price`
+- `relay.a_token_ceiling_needs_no_price_table`
+
+## Acceptance criteria
+
+- [ ] The price table prices every model the shipped template names
+      (proof: test:packages/model-specs/tests/specs.test.ts)
+- [ ] A `costUsd` ceiling over an unpriced rung is refused at boot
+      (proof: assertion:relay.refuses_a_dollar_ceiling_it_cannot_price)
+- [ ] The refusal names the model and the rung
+      (proof: assertion:relay.names_the_model_that_has_no_price)
+- [ ] A ceiling in tokens alone boots against an unpriced model
+      (proof: assertion:relay.a_token_ceiling_needs_no_price_table)
+- [ ] `amy budget` reports how many runs in the window carry no price
+      (proof: test:packages/cli/tests/budget.test.ts)
+- [ ] `amy models refresh` keeps what models.dev does not carry
+      (proof: test:packages/model-specs/tests/refresh.test.ts)
+
+**Exit condition:** no install can hold a dollar ceiling that cannot stop
+anything — either the model is priced, or the machine refused to start.

--- a/plans/a-checkout-root-per-repository.md
+++ b/plans/a-checkout-root-per-repository.md
@@ -1,0 +1,64 @@
+# A checkout root per repository
+
+`workspaceRoot` is one string, and a checkout is found by joining it with the
+repository name after the slash (`packages/cli/src/doctor.ts:221`). That is
+right for one team with one directory of clones, and it is wrong the moment
+work spans two: repositories at work and repositories of your own do not live
+under a common parent, and there is no reason they should.
+
+The install this was found on answered with a directory of symlinks —
+`workspaceRoot: ~/.amy/checkouts`, every entry a link to somewhere else. It
+works, and it is a workaround with two costs. Adding a repository to `repos:`
+now means remembering to add a link, or `amy doctor` reports a checkout that
+is missing for a reason the config cannot show. And the state directory is
+holding configuration, so the machine cannot be rebuilt from `config.yaml`.
+
+## What changes
+
+`workspaceRoot` keeps meaning what it means: where a checkout is, unless
+something says otherwise. Beside it, `checkouts:` maps a repository to its
+path, and a repository in it is not looked for under the root at all.
+
+```yaml
+workspaceRoot: ~/workspaces/northwind
+checkouts:
+  Northwind/northwind-infra: ~/work/infra
+  acme/amy: ~/code/amy
+```
+
+`hostPaths` (`slices.ts:190`) returns one workspace path today, so what it
+returns becomes a lookup rather than a directory, and every caller asks it for
+a repository instead of joining a string. `amy doctor` reports which of the
+two answered for each repository, so a wrong path is one line to find rather
+than a missing directory with no explanation.
+
+`~` expands, the way `workspaceRoot` already does (`config.ts:193`).
+
+## The gate
+
+`ticket-to-qa`, extended — it is the gate that drives work in a checkout, and
+a second root is only real if a piece of work runs in one. Add:
+
+- `checkout.a_repository_can_name_its_own_root`
+- `checkout.the_root_still_answers_for_the_rest`
+- `checkout.a_missing_checkout_names_which_root_was_asked`
+
+Its scenario gains a second repository outside the workspace root, and drives
+one piece of work in it.
+
+## Acceptance criteria
+
+- [ ] A repository with its own path is found there, not under the root
+      (proof: assertion:checkout.a_repository_can_name_its_own_root)
+- [ ] A repository without one is still found under the root
+      (proof: assertion:checkout.the_root_still_answers_for_the_rest)
+- [ ] `amy doctor` names which root it asked for a missing checkout
+      (proof: assertion:checkout.a_missing_checkout_names_which_root_was_asked)
+- [ ] `~` expands in a per-repository path
+      (proof: test:packages/cli/tests/config.test.ts)
+- [ ] A config with no `checkouts:` block behaves exactly as before
+      (proof: test:packages/cli/tests/slices.test.ts)
+
+**Exit condition:** an install drives work in two repositories under two
+unrelated parents, with no symlink anywhere and nothing in `~/.amy` that is
+not state.

--- a/plans/a-gate-outlives-its-plan.md
+++ b/plans/a-gate-outlives-its-plan.md
@@ -1,0 +1,71 @@
+# A gate outlives its plan
+
+A plan is a thing you are about to do. A gate is a thing that stays true.
+Seven gates in `.software-factory/policy.yaml` name a plan as the document
+their criteria live in, which welds the two together: the plan cannot be
+deleted when the work is done, because deleting it takes the gate's criteria
+with it and `L3.GATE_COVERS_THE_PLAN` goes red.
+
+So `plans/` has become an archive. Nine of its entries are delivered, the
+execution order in `plans/next-steps.md` reads as history rather than as work,
+and the one question the directory exists to answer — *what is next* — takes
+longer to answer every time something ships.
+
+The fix is one line per gate. `sf` does not require `gates.<name>.plan` to
+point inside `plans/`: it reads the criteria out of whatever path it is given.
+Point it at a design note instead, and the criteria live where the decision
+lives — `docs/nav.yaml` already calls that group *"the argument behind a
+decision, kept where the decision can link to it"*.
+
+## What changes
+
+Each of the seven gated plans gets a design note under `docs/design/`,
+carrying its acceptance criteria verbatim, its exit condition and the
+paragraph of argument that explains why the gate asserts what it asserts.
+`gates.<name>.plan` moves to that path, `sf lock` records the new policy hash,
+and the plan file is deleted.
+
+The ungated delivered plans — the roadmap, the release plan, the daemon plan,
+the errand plan, the engine-drives-a-workflow plan and the parked bun plan —
+are deleted outright. What they decided is already in `docs/`; what they
+promised is already gated or already shipped.
+
+`plans/next-steps.md` is rewritten to hold only unfinished work.
+
+## The rule that keeps it that way
+
+Nothing in `sf` can see the invariant this creates, because it is about the
+absence of a path rather than the content of one. So it becomes a check of
+this repository's own, next to `check:config`, which is the same shape of
+claim: `npm run check:plans` refuses a `gates.*.plan` that points inside
+`plans/`, and refuses a plan file the execution order does not list.
+
+The logic lives in `packages/cli/src/plan-board.ts` and the script in
+`scripts/check-plan-board.mjs` calls it, the way `check-config-template.mjs`
+already calls `config-template.ts` — a check with no test is a check nobody
+can trust, and only a package's `tests/` directory is on vitest's path.
+
+From then on the handover is mechanical: work lands, its criteria move into
+the design note the gate cites, the plan file goes. `L3.GATE_COVERS_THE_PLAN`
+holds the assertions from that moment on, and it holds them against a document
+that has no reason to be deleted.
+
+## Acceptance criteria
+
+- [ ] No gate names a document under `plans/`
+      (proof: test:packages/cli/tests/plan-board.test.ts)
+- [ ] A gate pointed back into `plans/` turns `npm run check:plans` red
+      (proof: test:packages/cli/tests/plan-board.test.ts)
+- [ ] A plan the execution order does not list turns it red too
+      (proof: test:packages/cli/tests/plan-board.test.ts)
+- [ ] Every assertion the seven gates require is still named by a criterion,
+      now in the design note (proof: test:packages/cli/tests/plan-board.test.ts)
+- [ ] `npm run gate` runs the check, so the board cannot rot between releases
+      (proof: test:packages/cli/tests/plan-board.test.ts)
+- [ ] `plans/` holds only work nobody has done yet
+      (proof: unspecified:it is a property of the diff, not of a run)
+
+**Exit condition:** `sf check` is green with every `gates.*.plan` pointing at a
+document under `docs/design/`, `plans/` contains no delivered work, and
+`plans/next-steps.md` read top to bottom is a list of things that have not
+happened.

--- a/plans/a-skill-ladder-for-your-own-steps.md
+++ b/plans/a-skill-ladder-for-your-own-steps.md
@@ -1,0 +1,71 @@
+# A skill ladder for your own steps
+
+`HarnessRelay.ask` looks up a skill ladder by whatever step the caller named:
+`context.step && this.deps.skills?.[context.step]`
+(`packages/agent-kit/src/HarnessRelay.ts:46`). Any string works, because the
+runtime has no opinion about where an action name came from.
+
+`parseSkills` has one. It refuses any key that is not a core action
+dispatching to the agent port — *"`skills.<step>` is not a step an agent
+performs"* (`plugins/agent-relay/src/skills.ts:31`), checked against
+`CORE_ACTIONS` (`core/src/actions.ts:21`). So a workflow that emits its own
+action names — which is every workflow somebody writes for themselves, and the
+thing amy is now about — cannot give any of its steps a skill. The relay would
+run it. The validator will not let the config say it.
+
+The validator is right to exist: a typo in a `skills:` key is a ladder that
+silently never fires, and finding that out costs a run. It is checking against
+the wrong list. The list of steps that exist is the mounted workflow's
+`usesActions`, which is data on the workflow for exactly this reason —
+*"`usesActions` is data so the mount can be refused when an action has no port
+behind it"*.
+
+`ladderByStep` has the same shape and the same freedom on the runtime side
+(`rungsFor`, `agent-kit/src/ladders.ts:35`), and nothing validates its keys at
+all. Both should be checked the same way, once, against the same list.
+
+## What changes
+
+The step-name check moves from `register` to `ready`. `mount()` runs a second
+pass for exactly this — *"a plugin that composes others can only judge its own
+settings once those others have contributed themselves"*
+(`core/src/mount.ts:87`) — and the workflow has registered by then.
+
+A step is valid if it is a core action dispatching to the agent, or an action
+the mounted workflow declares in `usesActions` that resolves to the agent
+port. Everything else is refused by name at boot, with the list of steps there
+were — the same shape as every other refusal here.
+
+Both `skills` and `ladderByStep` go through it. A ladder keyed by a step
+nobody dispatches has never been anything but a typo.
+
+## The gate
+
+`plugin-agent-relay`, extended. Add:
+
+- `relay.a_workflows_own_step_can_have_a_skill`
+- `relay.a_step_nobody_declares_is_refused_at_boot`
+- `relay.the_refusal_lists_the_steps_there_were`
+- `relay.a_model_ladder_is_checked_like_a_skill_ladder`
+
+Its scenario already mounts a workflow written outside this repository, so the
+step it declares is the one to key a skill on.
+
+## Acceptance criteria
+
+- [ ] A skill ladder keyed by a workflow's own action is accepted and fires
+      (proof: assertion:relay.a_workflows_own_step_can_have_a_skill)
+- [ ] A key no workflow declares is refused at boot
+      (proof: assertion:relay.a_step_nobody_declares_is_refused_at_boot)
+- [ ] The refusal lists the steps there were
+      (proof: assertion:relay.the_refusal_lists_the_steps_there_were)
+- [ ] `ladderByStep` is validated by the same rule
+      (proof: assertion:relay.a_model_ladder_is_checked_like_a_skill_ladder)
+- [ ] A core action still works as a key, unchanged
+      (proof: test:plugins/agent-relay/tests/skills.test.ts)
+- [ ] An action that does not reach the agent port is still refused
+      (proof: test:plugins/agent-relay/tests/skills.test.ts)
+
+**Exit condition:** a workflow somebody wrote themselves gives one of its own
+steps a cheaper model and a skill of its own, from `config.yaml`, with nothing
+in amy's code naming that step.

--- a/plans/a-spec-is-a-name-a-url-or-a-path.md
+++ b/plans/a-spec-is-a-name-a-url-or-a-path.md
@@ -1,0 +1,65 @@
+# A spec is a name, a URL or a path
+
+`amy plugin add` takes one argument and calls it a spec: *"anything Node can
+import: a package name, or a path"* (`packages/cli/src/index.ts:895`). It then
+writes that string into `.amy/config.yaml` and tells you to install it
+yourself. Two different strings are being conflated, and the seam only shows
+once amy is the thing doing the installing.
+
+What npm takes is an **install spec**: `@acme/workflow-oncall`,
+`@acme/workflow-oncall@2.1.0`, `github:acme/workflow-oncall`,
+`https://example.com/workflow-oncall-2.1.0.tgz`, `./workflow-oncall`. What the
+config has to name is an **import specifier** — the string the loader passes
+to `import()`, which is the package's own `name`. For a plain package name the
+two coincide, which is why nobody has noticed. For every other form they do
+not: nothing imports `https://example.com/workflow-oncall-2.1.0.tgz`.
+
+A relative path has a third problem on top. `.amy/config.yaml` is read from
+`~/.amy` no matter where you were standing when you typed the command, so
+`./workflow-oncall` written into it means a different directory to every
+caller — the same class of bug `strayState` exists to refuse
+(`packages/cli/src/home.ts:33`).
+
+## What changes
+
+One pure function, and nothing else in this PR. It takes the argument and
+returns what to hand npm, what the config should name, and which of the five
+kinds it was, so a caller can say something useful about each.
+
+```ts
+classify(spec: string, cwd: string): Resolved
+// { kind: "name" | "range" | "git" | "tarball" | "path",
+//   install: string, imported: string | undefined, absolute?: string }
+```
+
+`imported` is undefined for a git URL and a tarball, because the name is not
+knowable until the package is on disk — which is the honest answer, and it is
+what makes the installing command read `package.json` afterwards rather than
+guess. A path is resolved against `cwd` on the way in, so what lands in the
+config is absolute and means the same thing from anywhere.
+
+## The gate
+
+No new gate and no scenario. This is a pure function with five inputs and it
+is proven by a table test, which is the cheapest deterministic check there is.
+It is the precondition for `amy add`, `amy remove` and `amy update`, and it
+ships alone so those three arrive with the parsing already argued about.
+
+## Acceptance criteria
+
+- [ ] A bare package name gives the same string to npm and to the config
+      (proof: test:packages/cli/tests/spec.test.ts)
+- [ ] A name carrying a range installs the range and names the package
+      (proof: test:packages/cli/tests/spec.test.ts)
+- [ ] A git URL and a tarball URL are classified as such, and name nothing yet
+      (proof: test:packages/cli/tests/spec.test.ts)
+- [ ] A relative path is resolved against the caller's directory, not amy's
+      (proof: test:packages/cli/tests/spec.test.ts)
+- [ ] A path that is not a package is refused by name, before anything is run
+      (proof: test:packages/cli/tests/spec.test.ts)
+- [ ] A Windows-shaped path is not mistaken for a scoped name
+      (proof: test:packages/cli/tests/spec.test.ts)
+
+**Exit condition:** one function turns any of the five forms into the pair
+`(what npm installs, what the config names)`, and nothing else in the CLI
+parses a spec.

--- a/plans/a-workflow-is-yours-not-a-package.md
+++ b/plans/a-workflow-is-yours-not-a-package.md
@@ -1,0 +1,80 @@
+# A workflow is yours, not a package
+
+`/amy-workflow` interrogates somebody into a design and then tells them to
+publish it: *"A workflow is a package"*, and the last step is
+`npm install -g @acme/workflow-oncall`. For the workflow that skill exists to
+produce — an on-call week, a private review rotation, a process that names
+your employer's tooling — that is exactly backwards. Publishing it is a thing
+you might do. Owning it is the whole point.
+
+The mechanism is already there and is only reachable the long way round: a
+profile names an import specifier, and a path is an import specifier. Nobody
+does it because there is nowhere obvious to put the directory, and because
+writing the seven things a workflow declares from an empty file is an hour
+that ends in a boot refusal about a runtime you forgot to contribute.
+
+## What changes
+
+`~/.amy/workflows` is where a workflow lives. A directory in it is a workflow,
+named by its directory: `workflow: oncall` in the config means
+`~/.amy/workflows/oncall`, resolved before anything is looked for in a
+registry. A scoped name still resolves as a package, so an install can have
+both and nothing has to move to be shared later.
+
+```sh
+amy workflow new oncall      # a directory that runs, unedited
+amy workflow check oncall    # drive the lifecycle against a stub world
+```
+
+`new` writes a workflow that already works: the states, a pure `plan()`, a
+runtime, and the `registry.contribute("workflow-runtime", ...)` line whose
+absence produces the one refusal everybody meets first. It is also a valid
+npm package from the moment it is written, so publishing it later is
+`npm publish` in that directory and no restructuring.
+
+`check` is the walkthrough test as a command. The skill has always said that
+test is the only real proof, and then left the person to set up a test runner
+to get it. Instead amy drives the workflow's own lifecycle against a stub
+world and asserts the four things that are true of every workflow: it walks in
+the order it claims, one look makes at most one move, a waiting state moves
+nothing until the world does, and it settles rather than spinning.
+
+`/amy-workflow` is rewritten around this. The default answer becomes a
+directory under `~/.amy/workflows`; the package is what you do if the process
+belongs to more than you.
+
+## The gate
+
+New: `a-workflow-of-your-own`, scenario in
+`.software-factory/evidence/workflow-new-scenario.sh`, joined to
+`npm run e2e`. Activation on `packages/cli/src/scaffold.ts`,
+`packages/cli/src/loader.ts`, `packages/cli/skills/amy-workflow/SKILL.md`.
+
+The scenario is the claim: a scratch machine with only the command installed
+runs `amy workflow new`, edits nothing, and gets a green `check` and a moved
+piece of work. A scaffold that does not run unedited is a scaffold that
+teaches the boot refusal instead of the shape.
+
+## Acceptance criteria
+
+- [ ] `amy workflow new` produces a workflow that drives work unedited
+      (proof: assertion:mine.the_scaffold_runs_before_it_is_edited)
+- [ ] It is resolved from `~/.amy/workflows` by its directory name
+      (proof: assertion:mine.a_directory_name_is_a_workflow)
+- [ ] `amy workflow check` fails a lifecycle that does not settle
+      (proof: assertion:mine.a_workflow_that_spins_is_refused)
+- [ ] It fails one that claims a state it never reaches
+      (proof: assertion:mine.a_state_nothing_reaches_is_refused)
+- [ ] It fails one whose plan emits an action no port answers
+      (proof: assertion:mine.an_action_with_no_port_is_refused)
+- [ ] The scaffold is a package `npm publish` accepts, with nothing moved
+      (proof: test:packages/cli/tests/scaffold.test.ts)
+- [ ] A scoped package and a local directory can both be configured, and the
+      directory wins on a name collision
+      (proof: test:packages/cli/tests/loader.test.ts)
+- [ ] `/amy-workflow` writes a directory by default and names publishing as a
+      later choice (proof: unspecified:the skill is prose, and only a reader checks it)
+
+**Exit condition:** somebody who has never published anything describes their
+process to `/amy-workflow`, and ends with a workflow in `~/.amy/workflows`
+that amy is driving — with no registry involved at any point.

--- a/plans/amy-add-and-amy-remove.md
+++ b/plans/amy-add-and-amy-remove.md
@@ -1,0 +1,85 @@
+# `amy add` and `amy remove`
+
+Adding a workflow to an install takes four moves today: install the package
+yourself into a directory amy might not resolve from, write a `workflows:`
+entry by hand, work out which plugins it needs, and run `amy doctor` until the
+boot refusals stop. `amy plugin add` does one of the four, and only for a
+plugin.
+
+There is a smaller thing wrong inside it. `plugin add` writes
+`[...pluginList(config, profile), spec]` (`index.ts:874`), and `pluginList`
+returns the *recommended* set when the profile lists nothing
+(`slices.ts:166`). So adding one plugin freezes today's recommendation into
+your config permanently: a later amy that recommends a new plugin will not
+give it to you, and nothing will say so.
+
+## What changes
+
+Two commands at the top level, because adding a workflow and adding a plugin
+are the same act from the operator's side and only differ in what came back.
+
+```sh
+amy add @acme/workflow-oncall            # from the registry
+amy add ./workflow-oncall                # from a path
+amy add https://example.com/wf.tgz       # from a URL
+amy remove @acme/workflow-oncall
+```
+
+**Which of the two it is, is asked rather than assumed.** No name convention,
+no `package.json` field: install it, mount it alone into a throwaway registry,
+and see whether `mounted.workflow` is set. A package that registers a workflow
+is a workflow; everything else is a plugin. That is the same question
+`mount()` already answers at boot, asked one package at a time.
+
+A workflow lands in `~/.amy/workflows` and gets a profile entry, its records
+directory and its queue. A plugin lands in `~/.amy/plugins` and is appended to
+the current profile — appended to what the profile *itself lists*, so a
+profile that was on the recommended set stays on it and gains one, rather than
+having the recommendation copied in behind your back.
+
+`amy remove` is the same in reverse: drop the entry, uninstall from the root,
+and never touch records, queue or log. It refuses when what is left would not
+boot, and names the action that would have no port — the refusal the mount
+already writes, moved to the moment somebody can still change their mind.
+
+A package that fails to mount is uninstalled again. A half-added workflow that
+only shows up as a boot refusal three commands later is worse than a command
+that failed.
+
+## The gate
+
+New: `amy-add-remove`, with a scenario in
+`.software-factory/evidence/amy-add-remove-scenario.sh`, joined to
+`npm run e2e`. Activation on `packages/cli/src/index.ts`,
+`packages/cli/src/spec.ts`, `packages/cli/src/registry.ts` and
+`packages/cli/src/config.ts`.
+
+The scenario installs the command onto a scratch machine, adds the same
+third-party workflow three ways — from a path, from a tarball and from a
+directory that is not a package — drives one piece of work, then removes it
+and drives nothing.
+
+## Acceptance criteria
+
+- [ ] A workflow added from a path drives work, with no config edited by hand
+      (proof: assertion:add.a_path_becomes_a_workflow_that_runs)
+- [ ] The same workflow added from a tarball URL is the same install
+      (proof: assertion:add.a_url_and_a_path_agree)
+- [ ] Whether it was a workflow or a plugin is decided by mounting it
+      (proof: assertion:add.what_it_is_comes_from_mounting_it)
+- [ ] A package that mounts as a plugin joins the profile without copying the
+      recommended set into the config
+      (proof: assertion:add.adding_one_plugin_keeps_the_recommendation)
+- [ ] A package that does not mount is uninstalled again, and says why
+      (proof: assertion:add.a_package_that_does_not_mount_leaves_nothing)
+- [ ] `amy remove` drops the entry and the package, and keeps every record
+      (proof: assertion:add.removing_keeps_the_state)
+- [ ] Removing something the workflow still needs is refused, naming the
+      action that would have no port
+      (proof: assertion:add.a_removal_that_would_not_boot_is_refused)
+- [ ] Adding the same thing twice is one install and says so
+      (proof: test:packages/cli/tests/add.test.ts)
+
+**Exit condition:** somebody with only `@amykit/cli` installed types one
+command with a URL, a package name or a path in it, and the next `amy tick`
+moves a piece of work through the workflow that arrived.

--- a/plans/amy-update.md
+++ b/plans/amy-update.md
@@ -1,0 +1,72 @@
+# `amy update`
+
+There is no way to move an install forward. A new version of a workflow means
+finding where it was installed, running npm there by hand, and remembering
+that the skills amy wrote into `~/.claude/skills` came from the old CLI and
+are now describing subcommands that may not exist — `install()` overwrites
+them deliberately for exactly that reason (`harnesses.ts:36`), and nothing
+calls it after the first time.
+
+That last one is the failure worth naming, because it is silent and it lands
+on an agent rather than on a person: a skill telling a harness to run
+`amy add` on an install that predates it produces a confident wrong answer,
+not an error.
+
+## What changes
+
+```sh
+amy update                 # everything in both roots
+amy update @acme/workflow-oncall
+amy update --check         # what would move, and to what
+```
+
+It reads the two roots, resolves what the ranges in them now point at, and
+reports one line per package: name, the version installed, the version it
+would move to. `--check` stops there. Otherwise it installs, then re-mounts
+every configured profile before saying it worked — an update that leaves a
+config that cannot boot has not worked, and finding that out at the next tick
+means finding it out from the daemon.
+
+Two refusals. It will not run while the daemon holds `daemon.pid`, because
+swapping a package under a running loop is the one thing that turns a
+deterministic machine into a flaky one. And a package that fails to mount at
+the new version is rolled back to the version that did, which is knowable
+because the old one was resolvable a second ago.
+
+When `@amykit/cli` itself moves, the skills are rewritten into every harness
+they were written into before. Which harnesses those were is a fact about this
+machine, so it is recorded in `~/.amy` when `amy skills` runs rather than
+guessed from what is installed now.
+
+## The gate
+
+New: `amy-update`, with a scenario in
+`.software-factory/evidence/amy-update-scenario.sh`, joined to `npm run e2e`.
+Activation on `packages/cli/src/update.ts`, `packages/cli/src/skills.ts`,
+`packages/cli/src/harnesses.ts`.
+
+The scenario packs the third-party workflow twice, at two versions, into a
+directory used as a registry. It installs the first, drives one move, updates,
+drives another, and asserts the version that moved and the record that did
+not. No network, no credential.
+
+## Acceptance criteria
+
+- [ ] `--check` names every package that would move, and moves nothing
+      (proof: assertion:update.a_check_changes_nothing)
+- [ ] An update moves the version and keeps records, queue and log
+      (proof: assertion:update.the_state_survives_the_version)
+- [ ] Every configured profile is mounted before the update is called done
+      (proof: assertion:update.a_config_that_stops_booting_fails_the_update)
+- [ ] A version that will not mount is rolled back to the one that did
+      (proof: assertion:update.a_bad_version_is_rolled_back)
+- [ ] An update refuses while the loop is running, naming the pid
+      (proof: test:packages/cli/tests/update.test.ts)
+- [ ] Updating the CLI rewrites its skills into the harnesses it wrote to
+      before (proof: assertion:update.the_skills_follow_the_version)
+- [ ] A harness that was never written to is not written to now
+      (proof: test:packages/cli/tests/skills.test.ts)
+
+**Exit condition:** a machine two versions behind runs one command, ends up on
+the current one with its work untouched, and the skills in its harnesses
+describe the CLI that is now installed.

--- a/plans/next-steps.md
+++ b/plans/next-steps.md
@@ -6,24 +6,48 @@ weekly, and the file an agent reads to know what is next.
 A plan not listed here is written, valid, and off the critical path until its
 precondition exists. Park it in the second table rather than deleting it.
 
-O roadmap inteiro, com as treze fases e o estado de cada uma, está em
-[the roadmap](the-roadmap.md). Este arquivo é a ordem de execução dele.
+Every row below is one pull request. If a row cannot be reviewed in one
+sitting it is two rows, and each of them names the gate that proves it — a
+plan whose proof is "the tests pass" is a plan that has not been thought
+about yet.
 
 | # | Work | Exit condition |
 | --- | --- | --- |
-| 1 | [Every plugin is proven end to end](every-plugin-is-proven-end-to-end.md) | Changing a plugin's source turns the build red until its end-to-end run happens again |
-| 2 | [What runs is not this repo](what-runs-is-not-this-repo.md) | `amy` resolves on `PATH`, runs from a directory that is not this repository, and every log line names the version and commit that produced it |
-| 3 | [The relay is proven end to end](the-relay-is-proven-end-to-end.md) | A quota refusal, a killed child and a mistyped ladder are each proven against the built artifacts, with no credential involved |
-| 4 | [The engine fails out loud](the-engine-fails-out-loud.md) | A dependency that goes down produces one warning on the way down, silence while it is down, and one warning when it comes back, and no broken notification channel ever costs a ticket a move |
-| 5 | [The lifecycle is proven end to end](the-lifecycle-is-proven-end-to-end.md) | The installed executable walks one ticket from the working status to a QA handoff against a world of stand-ins, twice, with no credential and no network |
-| 6 | [The engine drives a workflow it does not know](the-engine-drives-a-workflow-it-does-not-know.md) | `plugins/serial-engine/src/**` names no workflow package, and a second workflow runs on the same engine by contributing a plan and a runtime |
-| 7 | [Friction becomes a plan, and the queue stops needing a ticket](friction-becomes-a-plan.md) | A friction note becomes a pull request adding a plan to the right repository, with no tracker involved and no change to the engine |
-| 8 | [What runs is a released version](what-runs-is-a-released-version.md) | A machine with no checkout installs `@amykit/cli` from GitHub Packages, `amy --version` names a version changesets published, and a dirty tree only ever says `dev` |
-| 9 | [Plugins are installed, not compiled in](plugins-are-installed-not-compiled-in.md) | A second machine runs work with only the plugins it needs installed, a workflow it wrote itself drives on the same engine, and one it never installed is refused by name at boot |
+| 1 | [A gate outlives its plan](a-gate-outlives-its-plan.md) | Every `gates.*.plan` points at a document under `docs/design/`, and `plans/` holds only work nobody has done yet |
+| 2 | [The config `amy init` writes must boot](the-config-amy-writes-must-boot.md) | `amy init && amy doctor` is green with no line deleted from the file amy wrote |
+| 3 | [A spec is a name, a URL or a path](a-spec-is-a-name-a-url-or-a-path.md) | One function turns any of the five forms into what npm installs and what the config names, and nothing else in the CLI parses a spec |
+| 4 | [Plugins live where amy can see them](plugins-live-in-amy-home.md) | A machine adds one plugin and runs work with `npm prefix -g` holding nothing of amy's |
+| 5 | [`amy add` and `amy remove`](amy-add-and-amy-remove.md) | One command with a URL, a name or a path in it, and the next `amy tick` moves work through the workflow that arrived |
+| 6 | [`amy update`](amy-update.md) | A machine two versions behind runs one command, keeps its work, and its harness skills describe the CLI now installed |
+| 7 | [A workflow is yours, not a package](a-workflow-is-yours-not-a-package.md) | Somebody who has never published anything ends with a workflow in `~/.amy/workflows` that amy is driving |
+| 8 | [Nothing is installed by default](nothing-is-installed-by-default.md) | A fresh machine installs one package, and the only workflow on it is one the person there chose or wrote |
+| 9 | [A skill ladder for your own steps](a-skill-ladder-for-your-own-steps.md) | A workflow somebody wrote gives one of its own steps a cheaper model and a skill, from `config.yaml` |
+| 10 | [A checkout root per repository](a-checkout-root-per-repository.md) | An install drives work in two repositories under two unrelated parents, with no symlink anywhere |
+| 11 | [A base branch per repository](a-base-branch-per-repository.md) | Two repositories with two base branch names, and no workflow package carrying a branch mapping of its own |
+| 12 | [A ceiling that cannot be inert](a-ceiling-that-cannot-be-inert.md) | No install can hold a dollar ceiling that cannot stop anything |
 
-| 10 | [amy is a machine you leave running](amy-is-a-machine-you-leave-running.md) | `amy start` leaves a loop running that outlives the terminal, state is one directory per machine, and the skills reach every harness installed |
+## Delivered
 
-| 11 | [Something said in passing becomes work](something-said-in-passing.md) | `amy btw "<sentence>"` puts work on a queue that amy drives to a pull request or to an answer, and the ceiling keeps cheap capture from becoming an expensive pile |
+These are done. Their criteria move into the design note their gate cites, and
+these files go, as [phase 1](a-gate-outlives-its-plan.md) above.
+
+O roadmap inteiro, com as treze fases e o estado de cada uma, está em
+[the roadmap](the-roadmap.md).
+
+| Work | What proves it |
+| --- | --- |
+| [Every plugin is proven end to end](every-plugin-is-proven-end-to-end.md) | gate `plugin-file-queue` |
+| [What runs is not this repo](what-runs-is-not-this-repo.md) | gate `installed-binary` |
+| [The relay is proven end to end](the-relay-is-proven-end-to-end.md) | gate `plugin-agent-relay` |
+| [The engine fails out loud](the-engine-fails-out-loud.md) | gate `plugin-serial-engine` |
+| [The lifecycle is proven end to end](the-lifecycle-is-proven-end-to-end.md) | gate `ticket-to-qa` |
+| [The engine drives a workflow it does not know](the-engine-drives-a-workflow-it-does-not-know.md) | gate `installed-plugins` |
+| [Friction becomes a plan](friction-becomes-a-plan.md) | gate `note-to-plan` |
+| [What runs is a released version](what-runs-is-a-released-version.md) | changesets, and the release job |
+| [Plugins are installed, not compiled in](plugins-are-installed-not-compiled-in.md) | gate `installed-plugins` |
+| [amy is a machine you leave running](amy-is-a-machine-you-leave-running.md) | gate `installed-binary` |
+| [Something said in passing becomes work](something-said-in-passing.md) | `packages/workflow-errand/tests/walkthrough.test.ts` |
+| [The roadmap](the-roadmap.md) | the twelve rows above it |
 
 ## Parked
 

--- a/plans/nothing-is-installed-by-default.md
+++ b/plans/nothing-is-installed-by-default.md
@@ -1,0 +1,77 @@
+# Nothing is installed by default
+
+`plugins-are-installed-not-compiled-in.md` ended with two names still in the
+host: `@amykit/cli` depends on `@amykit/workflow-ticket-to-qa`, because the
+roster is that workflow's vocabulary living in the host, and on
+`@amykit/plugin-notify-hermes`, because `amy doctor` imports a function to
+check a delivery target. There are seven more beside them in
+`packages/cli/package.json`.
+
+So installing the command installs a workflow, four plugins and a notifier,
+and then `amy init` offers to install about fifteen more — because
+`SHIPPED_PROFILES` gives three profiles to any config that declares none
+(`profiles.ts:41`), `EXAMPLE_CONFIG` writes two of them into the file, and
+`init` walks all of them working out what is absent (`index.ts:216`).
+
+Every one of those is a real workflow that somebody real might want. None of
+them is the one the person installing amy is about to write, and a machine
+that arrives pre-loaded with three processes teaches that amy is a thing with
+processes in it rather than a thing you put yours into.
+
+## What changes
+
+`@amykit/cli` depends on the command and nothing else. The two names the
+previous plan left behind are the reason this is not just a `package.json`
+edit: the roster moves to the workflow whose vocabulary it is, and `doctor`
+asks the mounted notification port whether its target is reachable instead of
+importing one notifier's reader. Both are the same fix — a host holding a
+plugin's knowledge — and neither is large.
+
+`SHIPPED_PROFILES` becomes empty. A config with no `workflows:` block drives
+nothing, which `resolveProfile` already says in the right words:
+*"no workflow is configured, so there is nothing to drive"* (`profiles.ts:139`)
+— it gains one sentence naming `amy workflow new` and `amy add`.
+
+`EXAMPLE_CONFIG` stops declaring two workflows it cannot promise are
+installed. It keeps them as commented examples, which is what they were
+always doing for the reader.
+
+`amy init` writes the config, the roster and the notes directory, and installs
+nothing. `--install` keeps working for a config that already names things,
+which is the machine being rebuilt rather than the machine being set up.
+
+`/amy-init` does the asking, and asks in the right order: what process do you
+want amy to drive, and would you like to write it — then an existing one, if
+the answer is that somebody already has.
+
+## The gate
+
+New: `a-bare-install`, scenario in
+`.software-factory/evidence/bare-install-scenario.sh`, joined to
+`npm run e2e`. Activation on `packages/cli/package.json`,
+`packages/cli/src/profiles.ts`, `packages/cli/src/config.ts`,
+`packages/cli/src/doctor.ts`.
+
+`L2.DEPENDENCIES_CHANGE_DELIBERATELY` already refuses a manifest that moves
+without an explicit lock update, so the dependency half of this cannot land
+quietly.
+
+## Acceptance criteria
+
+- [ ] Installing `@amykit/cli` installs no workflow and no plugin
+      (proof: assertion:bare.the_command_arrives_alone)
+- [ ] `amy init` on that machine writes its files and installs nothing
+      (proof: assertion:bare.init_installs_nothing)
+- [ ] With no workflow configured, every command says so and names what to
+      run next (proof: assertion:bare.it_says_what_to_do_instead_of_failing)
+- [ ] `amy doctor` reports a reachable notification target without importing
+      a notifier (proof: assertion:bare.doctor_asks_the_port_not_the_package)
+- [ ] The roster is the workflow's, and an install without that workflow needs
+      no roster (proof: test:packages/cli/tests/roster.test.ts)
+- [ ] `amy init --install` still supplies a config that names things
+      (proof: test:packages/cli/tests/init.test.ts)
+- [ ] The config template still names every setting there is
+      (proof: test:packages/cli/tests/config-template.test.ts)
+
+**Exit condition:** a fresh machine installs one package, and the only
+workflow on it afterwards is one the person there chose or wrote.

--- a/plans/plugins-live-in-amy-home.md
+++ b/plans/plugins-live-in-amy-home.md
@@ -1,0 +1,75 @@
+# Plugins live where amy can see them
+
+`amy init --install` runs `npm install --global`
+(`packages/cli/src/install.ts:35`). `scripts/install.sh` installs amy into
+`~/.local/lib/amy` and symlinks the command onto `PATH`. A plugin installed by
+the first is in `$(npm prefix -g)/lib/node_modules`; the loader looks for it by
+walking `node_modules` up from its own file (`loader.ts:66`), and that walk
+never reaches the global prefix.
+
+The CLI already knows. `supply()` ends with *"npm succeeded, but these still
+do not resolve … Check `npm prefix -g` against where amy is installed"*
+(`index.ts:263`). That is a design describing its own bug in a warning, and
+the warning is the best case: the machine that hits the bad case gets a boot
+refusal naming a plugin it just watched npm install successfully.
+
+There is a third party to this that should not be one. A global prefix is
+shared with everything else on the machine, so `amy add` would be reaching
+outside its own state directory to change something nobody scoped to amy —
+and `npm install -g` needing a different permission than writing to `~/.amy`
+is the smallest sign that the boundary is wrong.
+
+## What changes
+
+`~/.amy/plugins` becomes a real npm root: its own `package.json`, its own
+`node_modules`, written by `npm install --prefix`. `paths()` gains it, so
+`AMY_HOME` moves it with everything else and a test gets its own.
+
+The loader stops relying on where its own file happens to sit. It resolves
+through that root explicitly — `createRequire(<root>/package.json).resolve(spec)`
+and then `import(pathToFileURL(...))` — which is the same resolution Node
+would do from inside the root, made explicit instead of inherited. A path spec
+resolves as itself, unchanged.
+
+`installedPlugins()` reads that one directory rather than walking twelve levels
+of parent looking for names that pattern-match a plugin. It becomes an answer
+instead of a heuristic, and the refusal that lists *"what was installed
+instead"* stops depending on how amy was installed.
+
+`scripts/install.sh` keeps installing the command, and stops being the only
+way to add a plugin to an install.
+
+## The gate
+
+`installed-plugins`, extended. Its activation already covers `loader.ts`,
+`profiles.ts`, `paths.ts` and `scripts/install.sh`, so this change expires its
+evidence on its own — which is correct, because the last run proved a machine
+whose resolution worked differently.
+
+Its scenario grows one step: after installing the command with nothing else,
+install the third-party workflow into `~/.amy/plugins` through amy rather than
+by running npm inside the install directory, and drive the same lifecycle.
+Add to `required_assertions`:
+
+- `plugins.resolve_from_amys_own_root`
+- `plugins.a_global_install_is_not_needed`
+- `plugins.the_listing_is_read_from_one_directory`
+
+## Acceptance criteria
+
+- [ ] A plugin installed into `~/.amy/plugins` mounts, with nothing installed
+      globally (proof: assertion:plugins.resolve_from_amys_own_root)
+- [ ] The scenario installs no package globally and touches no global prefix
+      (proof: assertion:plugins.a_global_install_is_not_needed)
+- [ ] `amy plugin list` reports what is in that root rather than what a
+      parent walk found
+      (proof: assertion:plugins.the_listing_is_read_from_one_directory)
+- [ ] `AMY_HOME` moves the plugin root with the rest of the state
+      (proof: test:packages/cli/tests/paths.test.ts)
+- [ ] A spec that is a path still resolves as a path
+      (proof: test:packages/cli/tests/loader.test.ts)
+- [ ] A plugin named and absent is still refused at boot, with the list of
+      what is there (proof: assertion:plugins.a_missing_plugin_is_refused_at_boot)
+
+**Exit condition:** a machine installs amy, adds one plugin, and runs work
+with `npm prefix -g` pointing at a directory that contains nothing of amy's.

--- a/plans/the-config-amy-writes-must-boot.md
+++ b/plans/the-config-amy-writes-must-boot.md
@@ -1,0 +1,66 @@
+# The config `amy init` writes must boot
+
+`EXAMPLE_CONFIG` ships this:
+
+```yaml
+agent:
+  ladder: [claude:sonnet, claude:opus]
+  ladderByStep:
+    triage: [claude:haiku]
+    implement: [claude:opus]
+```
+
+`everyLadderEntry` unions the default ladder with every per-step one and does
+not dedupe (`packages/cli/src/slices.ts:153`). `tiersFor` turns that into
+`["sonnet", "opus", "haiku", "opus"]`, `contributeTiers` contributes one agent
+per entry named `claude:<model>` (`packages/agent-kit/src/tiers.ts:36`), and
+the second `claude:opus` meets `mount.ts:197` — *"`claude:opus` is already in
+the `agent` collection"*. The mount is refused.
+
+So `amy init` writes a config that cannot boot, and the only way to make the
+machine start is to delete the per-step ladder that the template is there to
+teach. This was found on a real install and worked around by leaving
+`implement` out, which means the feature was configured out of an install
+because of a missing `Set`.
+
+`checkConfigTemplate` exists because two template bugs had already shipped
+(`packages/cli/src/config-template.ts`), and it checks that the file parses
+and that it names every setting. It does not check the one thing that matters
+most: that what it writes runs.
+
+## What changes
+
+The union dedupes, in one place, preserving first-seen order — a ladder is
+ordered and the first mention is the one that means something.
+
+And the template check grows the claim it was always about: assemble the
+config `amy init` writes, against the plugins it names, and refuse a template
+whose mount produces problems. `npm run check:config` already runs in
+`npm run gate`, so a template that cannot boot cannot be released.
+
+## The gate
+
+`plugin-agent-relay`, extended — its activation covers
+`packages/agent-kit/src/**`, so this expires its evidence. Add:
+
+- `relay.a_rung_named_twice_mounts_once`
+- `relay.the_first_mention_sets_the_order`
+
+Plus `npm run check:config`, which becomes deterministic proof of the template
+itself rather than of its syntax.
+
+## Acceptance criteria
+
+- [ ] A model named in both `ladder` and `ladderByStep` mounts one agent
+      (proof: assertion:relay.a_rung_named_twice_mounts_once)
+- [ ] The ladder's order is the order of first mention
+      (proof: assertion:relay.the_first_mention_sets_the_order)
+- [ ] The config `amy init` writes assembles with no problems
+      (proof: test:packages/cli/tests/config-template.test.ts)
+- [ ] A template whose config cannot mount turns `npm run check:config` red
+      (proof: test:packages/cli/tests/config-template.test.ts)
+- [ ] The shipped template keeps its per-step ladder, unedited
+      (proof: test:packages/cli/tests/config-template.test.ts)
+
+**Exit condition:** `amy init && amy doctor` on a machine with the packages
+that template names is green, with no line deleted from the file amy wrote.


### PR DESCRIPTION
The board held eleven delivered phases and no unfinished work, so the one question `plans/` exists to answer — *what is next* — took a re-read to answer. This replaces the execution order with twelve rows. Each row is one pull request, and each names the gate that proves it.

## The first one is what makes the rest possible

A gate's `plan:` does not have to point inside `plans/`. I probed it: point `gates.plugin-file-queue.plan` at a file under `docs/design/` and `sf` reads the criteria out of it and enforces the assertion exactly as before — only `sf lock` needs re-running.

So [`a-gate-outlives-its-plan.md`](plans/a-gate-outlives-its-plan.md) moves the seven gated plans' criteria into design notes, repoints the gates, and deletes the plans. A plan becomes a thing you delete the day its work lands, which is what a plan is for. It adds `npm run check:plans` to hold the invariant `sf` cannot see: no gate points into `plans/`, and no plan is missing from the execution order.

**The delivered plans are still here.** Deleting them now turns `L3.GATE_COVERS_THE_PLAN` red — that deletion is phase 1's payload. They sit in a `## Delivered` section until it lands.

## The order

| # | Work | Gate |
| --- | --- | --- |
| 1 | A gate outlives its plan | `npm run check:plans` (new) |
| 2 | The config `amy init` writes must boot | `plugin-agent-relay` + `check:config` |
| 3 | A spec is a name, a URL or a path | table test (pure function) |
| 4 | Plugins live where amy can see them | `installed-plugins` |
| 5 | `amy add` and `amy remove` | `amy-add-remove` (new) |
| 6 | `amy update` | `amy-update` (new) |
| 7 | A workflow is yours, not a package | `a-workflow-of-your-own` (new) |
| 8 | Nothing is installed by default | `a-bare-install` (new) |
| 9 | A skill ladder for your own steps | `plugin-agent-relay` |
| 10 | A checkout root per repository | `ticket-to-qa` |
| 11 | A base branch per repository | `plugin-serial-engine` |
| 12 | A ceiling that cannot be inert | `plugin-agent-relay` |

## Two things worth reading the diff for

**The template `amy init` writes cannot boot.** `EXAMPLE_CONFIG` names `claude:opus` in `ladder` and again in `ladderByStep.implement`. `everyLadderEntry` (`packages/cli/src/slices.ts:153`) unions them without deduping, `contributeTiers` (`packages/agent-kit/src/tiers.ts:36`) contributes one agent per entry, and the second `claude:opus` meets `mount.ts:197` — *"already in the `agent` collection"*. Found on a real install, worked around by deleting the per-step ladder the template exists to teach. Phase 2 dedupes, and makes `check:config` assemble the template rather than only parse it.

**`amy init --install` installs where the loader does not look.** It runs `npm install --global` (`install.ts:35`), but `scripts/install.sh` installs into `~/.local/lib/amy` and the loader walks up `node_modules` from its own file — a walk that never reaches the global prefix. The CLI already half-knows: `supply()` ends by telling you to check `npm prefix -g` against where amy is installed. Phase 4 makes `~/.amy/plugins` the root and resolves through it with `createRequire` instead of inheriting the module's position on disk.

## What is not here

No code. This is the board, and the twelve pull requests underneath it are the work.

`sf check` and `npm run docs:check` are green.
