### PR TITLE
chore: one command to set this repository up

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,8 +1,60 @@
 #!/bin/sh
-# Enable with: git config core.hooksPath .githooks
+# The fast half of the gate, ten to fifteen seconds. Enable with
+# ./scripts/setup-dev.sh, which sets core.hooksPath to this directory.
+#
+# What is here and what is in pre-push is decided by one question: would CI
+# fail on this, and is it cheap? Coverage, knip and the dependency audit are
+# the slow ones and they wait for the push. Everything below is a second or
+# two and catches the mistakes this repository actually makes — a lock left
+# unmoved after editing a locked file, evidence that expired because the code
+# it certified changed, generated docs that did not follow the code.
+#
+# It reads the working tree, not the staged content. Committing a subset of
+# your changes is therefore checked loosely here; `pre-push` runs the whole
+# gate and is the one that has the last word.
+#
+# `git commit --no-verify` skips it, for when you know why.
 set -eu
 
-# verify first: a check that no longer fires would make the run below
+if ! command -v sf >/dev/null 2>&1; then
+  echo "pre-commit: sf is not installed, and it is half the gate." >&2
+  echo "            ./scripts/setup-dev.sh installs the version this repository locked." >&2
+  exit 1
+fi
+
+run() {
+  label=$1
+  shift
+  printf '  … %s' "$label"
+
+  if output=$("$@" 2>&1); then
+    printf '\r  \033[32m✓\033[0m %s\033[K\n' "$label"
+  else
+    printf '\r  \033[31m✗\033[0m %s\033[K\n\n%s\n' "$label" "$output"
+    exit 1
+  fi
+}
+
+echo "pre-commit"
+
+# First, because a stale build makes the checks below judge code that is no
+# longer there, and it is incremental so it costs nothing when nothing moved.
+run "build"       npm run build --silent
+run "typecheck"   npm run typecheck --silent
+run "toolchain"   npm run check:toolchain --silent
+run "docs"        npm run docs:check --silent
+run "plans"       npm run check:plans --silent
+run "config"      npm run check:config --silent
+run "release"     npm run check:release --silent
+run "tests"       npm test --silent
+run "lint"        npm run lint --silent
+
+# verify first: a check that no longer fires would make the check below
 # meaningless, and it is the cheaper failure to discover.
-sf verify
-sf check
+#
+# --allow-commands on both, because that is what CI passes: one rule
+# regenerates docs/rules.md and compares, and without the flag it reports
+# itself as unrunnable rather than passing — so a hook without it is quietly
+# weaker than the thing it is meant to predict.
+run "sf verify"   sf verify --allow-commands
+run "sf check"    sf check --allow-commands

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,40 @@
+#!/bin/sh
+# The whole gate, which is what CI runs. Enable with ./scripts/setup-dev.sh.
+#
+# `pre-commit` runs the cheap half on every commit; this runs everything,
+# once, at the moment the work stops being local. That is the right split
+# because the slow steps — coverage, the dead-code detector, the dependency
+# audit — are the ones nobody wants between them and a commit, and they are
+# also the ones there is no point discovering from a red pull request.
+#
+# The scenarios are deliberately not here. They take minutes and need bun,
+# and the gate already fails when a change touched a gate's activation paths
+# without the evidence being re-run — so the omission is reported rather than
+# assumed.
+#
+# `git push --no-verify` skips it.
+set -eu
+
+if ! command -v sf >/dev/null 2>&1; then
+  echo "pre-push: sf is not installed, and it is half the gate." >&2
+  echo "          ./scripts/setup-dev.sh installs the version this repository locked." >&2
+  exit 1
+fi
+
+echo "pre-push: npm run gate — what CI runs, minus the scenarios"
+
+if ! npm run gate; then
+  cat >&2 <<'MSG'
+
+pre-push: the gate is red, and CI would say the same.
+
+If the finding is stale evidence, the proof was about code that no longer
+exists. Re-run that gate's scenario and re-seal it:
+
+  ./.software-factory/evidence/<gate>-scenario.sh
+  sf seal <gate>
+
+Never hand-edit a digest.
+MSG
+  exit 1
+fi

--- a/.software-factory/evidence/installed-binary.json
+++ b/.software-factory/evidence/installed-binary.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "gate": "installed-binary",
-  "implementation_sha256": "6419a48494e57a9e021cc2889e047b046bde3adc8b7b03f00fd67d300fb752df",
+  "implementation_sha256": "9c7b1d95cc7a4b96d78869f3b3e4db6c71c99e8e0ff3788930e285e5bad1e443",
   "runs": [
     {
       "scenario": "installed-binary",

--- a/.software-factory/locks/dependencies.lock.json
+++ b/.software-factory/locks/dependencies.lock.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "files": {
     ".software-factory/evidence/installed-plugins/workflow-oncall/package.json": "1f704509661427d7ff41b0387187879d02f61fb5a01da5e1db115581a013f1f0",
-    "package.json": "46fe467d9667a9141feb84a50a56986a9c492d166512d1aed86362657f747da7",
+    "package.json": "e51a5ec289a8c9b4f4d10733c09e684db1d2a6ec585201fead9544219f61e939",
     "packages/agent-kit/package.json": "c140df1898c25b57a2d52be9f64753d4c208317a596f234b5e708fa3e9edfeaa",
     "packages/cli/package.json": "0e74127004032062104f7f1934bac8c902139370c6c009a29662b755a77d70dc",
     "packages/core/package.json": "1b0cbf7dc9b9dc0e442417d4f08f0dc1cbfba40cbd88d9950ae774904d7227e8",

--- a/.software-factory/locks/factory.lock.json
+++ b/.software-factory/locks/factory.lock.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "files": {
     ".allowed-root-files": "6b96c6cde21f0a325b44a460c9d46632b09ea60876b9ac0f05e78f0254104a10",
-    ".githooks/pre-commit": "72074487050ecb19ece275b8946bd8c4d343c92dd0cd85fc73b00b6fcd7b55e8",
+    ".githooks/pre-commit": "7807e293928dc251ea7b76c3e00be3d3e46707c0865633532f46a7d2ef334789",
     ".github/workflows/software-factory.yml": "e3e34d419e13868d62df4d09cacc53d1e99db16731b7c63aef287060995902ec",
     ".software-factory/policy.yaml": "c63b985efd99e12136f1f4fe997c19e2bd218c27e9b7d3b369283601169f0842",
     ".software-factory/ratchet.yaml": "e0be45ffb042d35cb29274e8ad70a8ab1f82cb94ac21c1203e183a929158b8e2",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,20 +4,56 @@
 
 ```sh
 git clone https://github.com/nicolasmelo1/amy && cd amy
-npm ci
-npm run build
-npm test          # 870 tests, about two seconds
+./scripts/setup-dev.sh
 ```
 
-If that is green, everything below is optional reading until you need it.
+That is the whole setup, on a machine that has never seen this repository. It
+installs the dependencies, installs `sf` at the version this repository
+locked, enables the git hooks, and builds — and it is safe to run again, which
+is the fastest way to find out what a machine is missing. It needs
+[rust](https://rustup.rs) for `sf`, and it will say so rather than guess.
 
 The one thing worth knowing before you touch anything: **`sf` is not
 optional.** It is the tool that turns this repository's rules into checks that
-fail, and `npm run gate` runs it. Install it once:
+fail, and `npm run gate` runs it. The setup script installs it; by hand it is:
 
 ```sh
 cargo install --git https://github.com/nicolasmelo1/software-factory --tag v0.4.0 --locked
 ```
+
+That version is not a suggestion. The catalog ships inside the binary, so a
+different `sf` enforces a different set of rules, and the mismatch is
+invisible on the machine that has the newer one and red in CI. It is written
+in `.software-factory/catalog.lock.json`, everything that installs `sf` is
+checked against it by `npm run check:toolchain`, and the setup script reads it
+rather than keeping a copy.
+
+Then:
+
+```sh
+npm test          # 1015 tests, about a second
+```
+
+If that is green, everything below is optional reading until you need it.
+
+## The hooks
+
+`./scripts/setup-dev.sh` points `core.hooksPath` at [`.githooks`](.githooks),
+and `npm ci` does too, so a clone that installs is a clone with them on. Git
+will not enable a hook out of a checkout on its own — that is a security
+property rather than an oversight, and the reason this needs saying at all.
+
+| Hook | What it runs | Cost |
+| :-- | :-- | :-- |
+| `pre-commit` | build, typecheck, the toolchain and docs checks, the tests, lint, `sf verify`, `sf check` | ten to fifteen seconds |
+| `pre-push` | `npm run gate`, which is what CI runs | a minute or two |
+
+Both take `--no-verify` when you know why. Neither is a substitute for
+reading the finding: the point of catching it here is that your own machine
+tells you before a pull request does.
+
+`pre-commit` reads the working tree rather than the staged content, so a
+deliberately partial commit is checked loosely. `pre-push` has the last word.
 
 ## What has to be green
 

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -15,10 +15,15 @@ you do not need to be in this repository at all — see
 
 ```sh
 git clone https://github.com/nicolasmelo1/amy && cd amy
-npm ci
-npm run build
-npm test          # about two seconds
+./scripts/setup-dev.sh
+npm test          # about a second
 ```
+
+`setup-dev.sh` is the whole setup on a machine that has never seen this
+repository: the dependencies, `sf` at the version this repository locked, the
+git hooks, and a build. It is safe to run again, which is the fastest way to
+find out what a machine is missing, and it needs [rust](https://rustup.rs) for
+`sf` — it says so rather than guessing.
 
 If that is green, everything below is optional reading until you need it.
 
@@ -28,6 +33,28 @@ turns this repository's rules into checks that fail, and `npm run gate` runs it.
 ```sh
 cargo install --git https://github.com/nicolasmelo1/software-factory --tag v0.4.0 --locked
 ```
+
+That version is not a suggestion: the catalog ships inside the binary, so a
+different `sf` enforces a different set of rules. The mismatch is invisible on
+the machine holding the newer one and red in CI, which is why
+`.software-factory/catalog.lock.json` is the source of truth and
+`npm run check:toolchain` fails when anything installing `sf` disagrees with
+it.
+
+## The hooks
+
+The setup script points `core.hooksPath` at `.githooks`, and `npm ci` does too,
+so a clone that installs is a clone with them on. Git will not enable a hook
+out of a checkout on its own — a security property rather than an oversight.
+
+| Hook | What it runs | Cost |
+| :-- | :-- | :-- |
+| `pre-commit` | build, typecheck, the toolchain and docs checks, the tests, lint, `sf verify`, `sf check` | ten to fifteen seconds |
+| `pre-push` | `npm run gate`, which is what CI runs | a minute or two |
+
+Both take `--no-verify`. `pre-commit` reads the working tree rather than the
+staged content, so a deliberately partial commit is checked loosely and
+`pre-push` has the last word.
 
 ## What has to be green
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1585,6 +1585,11 @@
         },
         {
           "depth": 2,
+          "title": "The hooks",
+          "slug": "the-hooks"
+        },
+        {
+          "depth": 2,
           "title": "What has to be green",
           "slug": "what-has-to-be-green"
         },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "check:release": "node scripts/check-release-config.mjs",
     "check:config": "node scripts/check-config-template.mjs",
     "check:plans": "node scripts/check-plan-board.mjs",
-    "gate": "npm run build && npm run typecheck && npm run check:release && npm run check:config && npm run check:plans && npm run docs:check && npm run test:coverage && npm run lint && npm run knip && npm run audit && sf check --allow-commands && sf verify",
+    "check:toolchain": "node scripts/check-toolchain.mjs",
+    "gate": "npm run build && npm run typecheck && npm run check:release && npm run check:config && npm run check:plans && npm run check:toolchain && npm run docs:check && npm run test:coverage && npm run lint && npm run knip && npm run audit && sf check --allow-commands && sf verify",
     "e2e": "./.software-factory/evidence/plugin-file-queue-scenario.sh && ./.software-factory/evidence/plugin-agent-relay-scenario.sh && ./.software-factory/evidence/plugin-serial-engine-scenario.sh && ./.software-factory/evidence/installed-binary-scenario.sh && ./.software-factory/evidence/installed-plugins-scenario.sh && ./.software-factory/evidence/ticket-to-qa-scenario.sh && ./.software-factory/evidence/note-to-plan-scenario.sh",
     "changeset": "changeset",
     "release:version": "changeset version && npm install --package-lock-only && npm run docs:generate && sf lock && node scripts/check-lock-scope.mjs",
@@ -30,7 +31,9 @@
     "docs:generate": "node scripts/docs/generate.mjs",
     "docs:check": "node scripts/docs/generate.mjs --check",
     "docs:changelog": "node scripts/docs/changelog.mjs",
-    "docs:draft": "node scripts/docs/draft.mjs"
+    "docs:draft": "node scripts/docs/draft.mjs",
+    "prepare": "git config core.hooksPath .githooks 2>/dev/null || true",
+    "setup": "./scripts/setup-dev.sh"
   },
   "devDependencies": {
     "@changesets/cli": "^3.0.2",

--- a/scripts/check-toolchain.mjs
+++ b/scripts/check-toolchain.mjs
@@ -1,0 +1,88 @@
+// Checks that everything naming the `sf` version names the same one.
+//
+// This exists because of a real failure. `catalog.lock.json` moved to 0.4.0
+// and `CONTRIBUTING.md` was updated to match, but the workflow still
+// installed v0.3.0. One rule regenerates `docs/rules.md` and compares, so CI
+// rebuilt it with the older catalog and reported the committed file as a
+// locked artifact edited by hand — a hash mismatch with nothing in the
+// repository actually out of step, and nothing on a laptop able to reproduce
+// it, because a laptop had the newer `sf`.
+//
+// The lock is the source of truth: it is what `sf lock` writes and what
+// L2.CATALOG_ONLY_TIGHTENS reads. Everything else quotes it, so everything
+// else is checked against it.
+import fs from "node:fs";
+import path from "node:path";
+
+const repo = path.resolve(import.meta.dirname, "..");
+const read = (relative) => fs.readFileSync(path.join(repo, relative), "utf8");
+
+const WORKFLOW = ".github/workflows/software-factory.yml";
+const CONTRIBUTING = "CONTRIBUTING.md";
+const SETUP = "scripts/setup-dev.sh";
+
+const locked = JSON.parse(read(".software-factory/catalog.lock.json")).sf_version;
+const problems = [];
+
+if (!locked) {
+  console.error(".software-factory/catalog.lock.json names no sf_version.");
+  process.exit(1);
+}
+
+/** Every `--tag vX.Y.Z` in a file, with the line it sits on. */
+function pinsIn(relative) {
+  return read(relative)
+    .split("\n")
+    .flatMap((line, index) => {
+      const found = line.match(/--tag\s+v(\d+\.\d+\.\d+)/);
+      return found ? [{ line: index + 1, version: found[1] }] : [];
+    });
+}
+
+// The setup script is held to the opposite standard: it must *derive* the
+// version rather than quote one, because a copy it had to keep in step would
+// be one more place to forget. A literal pin creeping in here is the drift
+// starting again.
+const setup = read(SETUP);
+
+for (const pin of pinsIn(SETUP)) {
+  problems.push(
+    `${SETUP}:${pin.line} hard-codes sf v${pin.version}. It reads the version from ` +
+      `the catalog lock instead, so this would be a fourth copy to keep in step.`,
+  );
+}
+
+if (!setup.includes("catalog.lock.json")) {
+  problems.push(`${SETUP} does not read the version from the catalog lock, so it can drift`);
+}
+
+for (const relative of [WORKFLOW, CONTRIBUTING]) {
+  const pins = pinsIn(relative);
+
+  if (pins.length === 0) {
+    problems.push(`${relative} pins no sf version, so nothing keeps it in step with the lock`);
+    continue;
+  }
+
+  for (const pin of pins) {
+    if (pin.version !== locked) {
+      problems.push(
+        `${relative}:${pin.line} installs sf v${pin.version}, and the catalog lock ` +
+          `records ${locked}. The two disagreeing is invisible on a laptop that ` +
+          `already has the newer one, and red in CI.`,
+      );
+    }
+  }
+}
+
+if (problems.length > 0) {
+  console.error("The sf version is not the same everywhere it is written:\n");
+  for (const problem of problems) console.error(`  ${problem}`);
+  console.error(
+    "\nThe lock is the source of truth. Bump the others to match it, or run " +
+      "`sf lock` with the version you mean installed.",
+  );
+  process.exit(1);
+}
+
+console.log(`sf v${locked}: the workflow and CONTRIBUTING.md match the lock, and the setup script reads it`);

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+# Sets this checkout up to be worked in, on a machine that has never seen it.
+#
+# Usage: ./scripts/setup-dev.sh
+#
+# Separate from `install.sh`, which installs amy for *using*. This one is
+# about contributing: the dependencies, the toolchain the gate needs, and the
+# hooks that run it before a commit leaves the machine.
+#
+# Safe to run again. Every step here is idempotent, and re-running it is the
+# fastest way to find out what a machine is missing.
+set -eu
+
+repo=$(cd "$(dirname "$0")/.." && pwd)
+cd "$repo"
+
+# The version of `sf` this repository locked. Read rather than written down,
+# because a second copy of a version number is the thing that goes stale —
+# see scripts/check-toolchain.mjs, which fails the gate when one does.
+sf_version=$(node -e "process.stdout.write(require('./.software-factory/catalog.lock.json').sf_version)")
+
+say() { printf '\n\033[1m%s\033[0m\n' "$1"; }
+missing=""
+
+say "1/5  Node"
+node_major=$(node -p 'process.versions.node.split(".")[0]')
+echo "node $(node -v), npm $(npm -v)"
+# CI runs 24. Older majors do run the tests today, so this warns rather than
+# stops: being told is useful, being blocked on your own laptop is not.
+if [ "$node_major" -lt 24 ]; then
+  echo "  note: CI runs node 24, and this is $(node -v). Expect the gate to agree anyway,"
+  echo "        but a version-specific failure here will not reproduce there."
+fi
+
+say "2/5  Dependencies"
+npm ci
+
+say "3/5  sf $sf_version — the tool that turns this repository's rules into checks"
+# `sf` is not optional: `npm run gate` ends in `sf check` and `sf verify`, and
+# without it the half of the gate that holds the architecture does not run.
+have_sf=$(command -v sf >/dev/null 2>&1 && sf --version 2>/dev/null | awk '{print $2}' || echo "")
+
+if [ "$have_sf" = "$sf_version" ]; then
+  echo "sf $sf_version already installed"
+elif ! command -v cargo >/dev/null 2>&1; then
+  echo "  cargo is not on this machine, and sf is built from source."
+  echo "  Install rust (https://rustup.rs), then run this script again."
+  missing="$missing sf"
+else
+  [ -n "$have_sf" ] && echo "replacing sf $have_sf with the locked $sf_version"
+  cargo install --git https://github.com/nicolasmelo1/software-factory \
+    --tag "v$sf_version" --locked --force
+fi
+
+say "4/5  bun — only the end-to-end scenarios need it"
+# `npm run e2e` drives the single executable, and `bun build --compile` is
+# what makes one. The gate does not need it, so a machine without bun is
+# still a machine you can contribute from.
+if command -v bun >/dev/null 2>&1; then
+  echo "bun $(bun --version)"
+else
+  echo "  no bun, so \`npm run e2e\` will not run here. \`npm run gate\` will."
+  echo "  https://bun.sh if you want the scenarios too."
+fi
+
+say "5/5  Git hooks"
+# Committed in .githooks and enabled per clone, because git will not enable a
+# hook from a checkout on its own — which is a security property, not an
+# oversight, and the reason this needs a step at all.
+git config core.hooksPath .githooks
+echo "core.hooksPath = .githooks"
+echo "  pre-commit: the fast half of the gate, ten to fifteen seconds"
+echo "  pre-push:   the whole gate, which is what CI runs"
+echo "  --no-verify skips either one when you know why"
+
+say "Building, so the first gate run is not also the first build"
+npm run build
+
+if [ -n "$missing" ]; then
+  say "Set up, except:$missing"
+  echo "Install what is listed above and run this script again."
+  exit 1
+fi
+
+say "Ready"
+cat <<'MSG'
+  npm test          the unit tests, about a second
+  npm run gate      what CI runs, minus the scenarios
+  npm run e2e       the seven scenarios, a few minutes
+
+CONTRIBUTING.md is the five minutes worth reading before the first change.
+MSG


### PR DESCRIPTION
## Why

Setting a machine up meant reading `CONTRIBUTING.md` and running four things by
hand, one of them a `cargo install` with a version number in it.
`.githooks/pre-commit` already existed and `.githooks` was already declared in
`.allowed-root-files` — but nothing enabled it and nothing mentioned it, so it
ran on whichever machine had thought to run one `git config` command.

Then this happened, on the branch that just merged:

```
✗ critical L2.GENERATED_FILES_ARE_LOCKED
    docs/rules.md — a locked file was modified without updating the lock
```

`catalog.lock.json` had moved to sf 0.4.0 and `CONTRIBUTING.md` was updated to
match, but the workflow still installed `v0.3.0`. One rule regenerates
`docs/rules.md` and compares, so CI rebuilt it with the older catalog and
called the committed file hand-edited. **No laptop could reproduce it**, because
the laptop already had the newer `sf`. That is the failure mode this PR is
about: a toolchain nobody installs the same way twice.

## What

**`scripts/setup-dev.sh`** — the whole setup on a machine that has never seen
this repository, and safe to run again:

1. node, with a note when it is older than the 24 CI runs
2. `npm ci`
3. `sf` at the version `catalog.lock.json` records — read, never written down
4. bun, reported rather than required, since only `npm run e2e` needs it
5. `git config core.hooksPath .githooks`, then a build

It needs cargo for `sf` and says so instead of guessing. `prepare` sets
`core.hooksPath` too, so a clone that installs is a clone with the hooks on.

**The hooks.** `pre-commit` ran `sf` alone, without `--allow-commands` — and
without that flag one rule reports itself as unrunnable rather than passing, so
the hook was quietly weaker than the thing it was meant to predict. It now runs
the fast half of the gate, and `pre-push` runs all of it.

| Hook | Runs | Measured here |
| :-- | :-- | :-- |
| `pre-commit` | build, typecheck, toolchain, docs, plans, config, release, tests, lint, `sf verify`, `sf check` | 13s |
| `pre-push` | `npm run gate` | a minute or two |

**`npm run check:toolchain`** — the check this session earned, wired into the
gate so CI enforces it rather than a hook somebody may not have enabled. The
lock is the source of truth; the workflow and `CONTRIBUTING.md` are checked
against it, and the setup script is held to the opposite standard — it must
*derive* the version, because a copy it had to keep in step would be a fourth
place to forget.

Reverting the workflow to `v0.3.0` reproduces today's break as a named finding:

```
.github/workflows/software-factory.yml:33 installs sf v0.3.0, and the catalog
lock records 0.4.0. The two disagreeing is invisible on a laptop that already
has the newer one, and red in CI.
```

## Verification

- `./scripts/setup-dev.sh` run from a cleared `core.hooksPath` — 3s, idempotent, hooks enabled by `npm ci` alone
- both hooks with `sf` off the `PATH` — each exits 1 naming the setup script
- `pre-commit` fired on this PR's own commit and caught three real things first: `package.json` unlocked, `.githooks/pre-commit` itself being hash-locked, and the `installed-binary` evidence expiring because `scripts/**` is one of its activation paths (re-run and resealed)
- `npm run gate` — passed: 1015 tests, 94.95% statements, `sf check` no findings, `sf verify` 33/33

No changeset: no published package changed.

## Not in here

`pre-commit` reads the working tree, not the staged content, so a deliberately
partial commit is checked loosely — `pre-push` has the last word. Making it
exact means stashing the unstaged half, and a hook that manipulates your
working tree to check it is a worse trade than the one this makes. It is
documented in both places rather than left to be discovered.