### PR TITLE
ci: pin the release job to the sf version the gate locks with

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,13 @@ jobs:
       # nothing verifies is a supply chain nobody is watching.
       - name: Install sf
         env:
-          SF_VERSION: v0.3.0
+          # The same version the submission gate installs: the catalog ships
+          # inside the binary, so two versions in one repository re-lock from
+          # two catalogs. The v0.3.0 binary here was the quiet red: `sf lock`
+          # regenerated the locks against its older catalog, the version bump
+          # moved `catalog.lock.json` with it, and the scope check refused a
+          # release that may not carry that change — on every push, forever.
+          SF_VERSION: v0.4.0
         # Downloaded outside the checkout, because the next step in this job
         # commits the working tree. `sf.sha256` was left behind here and rode
         # into main on a version bump, where L4.ROOT_FILES_ARE_DECLARED caught


### PR DESCRIPTION
## Summary

- the release job downloaded sf **v0.3.0**; the submission gate installs **v0.4.0** and main's committed locks are v0.4.0's
- on every push to main, `sf lock` in the release job regenerated the locks against the older catalog, the version bump moved `catalog.lock.json`, and `check-lock-scope.mjs` refused the release: `A release may move the dependency lock... It may not move the others`
- one line: `SF_VERSION: v0.3.0` → `v0.4.0`, with the reasoning recorded where the next bump will read it

## Verification

- `gh run view 34146944344 --log-failed` names the `changesets/action` step; its log ends with the scope check's refusal naming `catalog.lock.json`
- local `sf lock` (v0.4.0, this tree) writes no diff — the failure exists only for the v0.3.0 binary
- the last three `release` runs on main failed this way (#24, #25, #26 merges); `software factory` stayed green throughout