### PR TITLE
docs(plans): the ticket body reaches the agent

### DIFF
--- a/plans/next-steps.md
+++ b/plans/next-steps.md
@@ -13,14 +13,15 @@ yet.
 
 | # | Work | Exit condition |
 | --- | --- | --- |
-| 1 | [The config `amy init` writes must boot](the-config-amy-writes-must-boot.md) | `amy init && amy doctor` is green with no line deleted from the file amy wrote |
-| 2 | [A spec is a name, a URL or a path](a-spec-is-a-name-a-url-or-a-path.md) | One function turns any of the five forms into what npm installs and what the config names, and nothing else in the CLI parses a spec |
-| 3 | [Plugins live where amy can see them](plugins-live-in-amy-home.md) | A machine adds one plugin and runs work with `npm prefix -g` holding nothing of amy's |
-| 4 | [`amy add` and `amy remove`](amy-add-and-amy-remove.md) | One command with a URL, a name or a path in it, and the next `amy tick` moves work through the workflow that arrived |
-| 5 | [`amy update`](amy-update.md) | A machine two versions behind runs one command, keeps its work, and its harness skills describe the CLI now installed |
-| 6 | [A workflow is yours, not a package](a-workflow-is-yours-not-a-package.md) | Somebody who has never published anything ends with a workflow in `~/.amy/workflows` that amy is driving |
-| 7 | [Nothing is installed by default](nothing-is-installed-by-default.md) | A fresh machine installs one package, and the only workflow on it is one the person there chose or wrote |
-| 8 | [A skill ladder for your own steps](a-skill-ladder-for-your-own-steps.md) | A workflow somebody wrote gives one of its own steps a cheaper model and a skill, from `config.yaml` |
-| 9 | [A checkout root per repository](a-checkout-root-per-repository.md) | An install drives work in two repositories under two unrelated parents, with no symlink anywhere |
-| 10 | [A base branch per repository](a-base-branch-per-repository.md) | Two repositories with two base branch names, and no workflow package carrying a branch mapping of its own |
-| 11 | [Compatibility is a capability, not a version](compatibility-is-a-capability-not-a-version.md) | A plugin built against an older core is told at boot which member it lost, and one copy of the core resolves anywhere in the install |
+| 1 | [The ticket body reaches the agent](the-ticket-body-reaches-the-agent.md) | A ticket whose description carries an instruction its title does not is implemented in accordance with it, and a ticket with no description is asked about rather than guessed at |
+| 2 | [The config `amy init` writes must boot](the-config-amy-writes-must-boot.md) | `amy init && amy doctor` is green with no line deleted from the file amy wrote |
+| 3 | [A spec is a name, a URL or a path](a-spec-is-a-name-a-url-or-a-path.md) | One function turns any of the five forms into what npm installs and what the config names, and nothing else in the CLI parses a spec |
+| 4 | [Plugins live where amy can see them](plugins-live-in-amy-home.md) | A machine adds one plugin and runs work with `npm prefix -g` holding nothing of amy's |
+| 5 | [`amy add` and `amy remove`](amy-add-and-amy-remove.md) | One command with a URL, a name or a path in it, and the next `amy tick` moves work through the workflow that arrived |
+| 6 | [`amy update`](amy-update.md) | A machine two versions behind runs one command, keeps its work, and its harness skills describe the CLI now installed |
+| 7 | [A workflow is yours, not a package](a-workflow-is-yours-not-a-package.md) | Somebody who has never published anything ends with a workflow in `~/.amy/workflows` that amy is driving |
+| 8 | [Nothing is installed by default](nothing-is-installed-by-default.md) | A fresh machine installs one package, and the only workflow on it is one the person there chose or wrote |
+| 9 | [A skill ladder for your own steps](a-skill-ladder-for-your-own-steps.md) | A workflow somebody wrote gives one of its own steps a cheaper model and a skill, from `config.yaml` |
+| 10 | [A checkout root per repository](a-checkout-root-per-repository.md) | An install drives work in two repositories under two unrelated parents, with no symlink anywhere |
+| 11 | [A base branch per repository](a-base-branch-per-repository.md) | Two repositories with two base branch names, and no workflow package carrying a branch mapping of its own |
+| 12 | [Compatibility is a capability, not a version](compatibility-is-a-capability-not-a-version.md) | A plugin built against an older core is told at boot which member it lost, and one copy of the core resolves anywhere in the install |

--- a/plans/the-ticket-body-reaches-the-agent.md
+++ b/plans/the-ticket-body-reaches-the-agent.md
@@ -1,0 +1,126 @@
+# The ticket body reaches the agent
+
+`ISSUE_FIELDS` asks Linear for `id`, `identifier`, `title`, `url`,
+`branchName`, `state` and `team` (`plugins/linear/src/LinearTracker.ts:16`).
+Not `description`. `toTicket` cannot carry what was never fetched (`:211`), so
+`Ticket` has no body and never has.
+
+`HarnessAgent.triage` then builds its prompt from three of those fields and
+tells the agent to go and get the rest:
+
+```
+Ticket ${ticket.id}: ${ticket.title}
+Tracker: ${ticket.url}
+
+Read the ticket and enough of this repository to judge it.
+```
+
+An agent under `claude -p` has no Linear credential and no browser. It is
+being asked to read a page it cannot open, and the instruction reads as though
+the body were available. `implement` is built the same way.
+
+## Why this is worse than a missing field
+
+It fails in two directions and only one of them is visible.
+
+A ticket whose title does not carry the work produces an honest refusal. Ours
+said:
+
+> I'm unable to access the Linear ticket in this non-interactive session — both
+> the Linear MCP and WebFetch require authentication that can't be set up
+> automatically.
+
+That is the good case. It surfaces as `action.failed`, the ceiling catches it,
+and somebody is told.
+
+A ticket whose title *sounds* sufficient produces work instead. On the install
+where this was found, a 2-point ticket became 8 files and +615 lines. Its
+description said, in bold, *"Consume the DB-layer aggregate from TBO-1236 — do
+not rebuild the SUM here"*, and named the file that other ticket owns. The
+agent added 75 lines to exactly that file, including the aggregate, duplicating
+an open pull request. It also had four acceptance criteria and a warning about
+an enum that would fail in SQL; the agent got none of them, guessed the enum
+right, and was never going to guess the ownership boundary.
+
+Nothing about that run looked wrong. The gate was green, every source file had
+a test beside it, the reviewer was assigned. The whole pipeline behaved, on an
+input that was one line long.
+
+The workaround, on that install, was a private workflow package reading the
+Linear API itself with the key from `~/.amy/.env`, and replacing `triage` and
+`implement` with `run-errand` so it could write its own prompt. A workflow
+reimplementing the tracker because the tracker would not carry a body, and
+stepping off two of the core's actions to do it.
+
+## What changes
+
+`Ticket` gains `body`, and the fetch asks for it:
+
+```ts
+const ISSUE_FIELDS = `
+  id
+  identifier
+  title
+  description
+  url
+  branchName
+  state { name }
+  team { id key name }
+`;
+```
+
+`toTicket` maps `description` to `body`. Absent stays absent — a ticket with
+an empty description is a real state and is not an error.
+
+The two prompts in `agent-kit` include it, and stop instructing a fetch nobody
+can perform:
+
+```
+Ticket ${ticket.id}: ${ticket.title}
+Tracker: ${ticket.url}
+
+${ticket.body ?? "(this ticket has no description)"}
+```
+
+`Read the ticket` becomes `Read enough of this repository to judge it`. The
+tracker is the thing that reads a tracker; the agent reads a repository. When
+a ticket genuinely has no body, saying so is what lets an agent ask for one
+through `CLARIFYING` rather than invent one.
+
+A tracker that cannot supply a body is unaffected: `body` is optional, and the
+prompt says which case it is in.
+
+## The gate
+
+`plugin-agent-relay`, extended. It already drives the agent side against fake
+CLIs with no credential, which is exactly what proving a prompt needs — the
+fake records what it was asked. Add:
+
+- `prompt.carries_the_ticket_body`
+- `prompt.says_so_when_a_ticket_has_none`
+
+`ticket-to-qa` covers the other half, that a body fetched from the tracker
+survives the trip to the action:
+
+- `triage.reads_a_body_the_tracker_supplied`
+
+## Acceptance criteria
+
+- [ ] The prompt an agent receives contains the ticket's description
+      (proof: assertion:prompt.carries_the_ticket_body)
+- [ ] A ticket with no description produces a prompt that says so, rather than
+      one that looks truncated
+      (proof: assertion:prompt.says_so_when_a_ticket_has_none)
+- [ ] No prompt tells an agent to read a tracker page
+      (proof: test:packages/agent-kit/tests/HarnessAgent.test.ts)
+- [ ] `inProgress` and `get` both return the body
+      (proof: test:plugins/linear/tests/LinearTracker.test.ts)
+- [ ] A body reaches `triage` and `implement` through the runtime unchanged
+      (proof: assertion:triage.reads_a_body_the_tracker_supplied)
+- [ ] A tracker that supplies no body still mounts and still drives work
+      (proof: test:packages/workflow-ticket-to-qa/tests/runtime.test.ts)
+
+**Exit condition:** a ticket whose description contains an instruction the
+title does not — an ownership boundary, an acceptance criterion, a named
+file — is implemented in accordance with it, and a ticket with no description
+is asked about rather than guessed at.


### PR DESCRIPTION
## What this is

A plan, listed **first** on the board. It is the only row that produces
plausible wrong work rather than a visible failure, which is the argument for
the position — the renumbering is the whole rest of the diff.

## The finding

`ISSUE_FIELDS` does not ask Linear for `description`
(`plugins/linear/src/LinearTracker.ts:16`), so `Ticket` has no body. And
`HarnessAgent.triage` builds its prompt from `id`, `title` and `url`, then
says:

> Read the ticket and enough of this repository to judge it.

An agent under `claude -p` has no Linear credential and no browser. It is
told to read a page it cannot open, in wording that reads as though the body
were already there. `implement` is built the same way.

## How it was found

Driving a private workflow against real tickets on a real board.

**The good case.** A ticket whose title did not carry the work refused
honestly — *"I'm unable to access the Linear ticket in this non-interactive
session"*. That surfaces as `action.failed`, the ceiling catches it, somebody
is told.

**The bad case.** A ticket whose title *sounded* sufficient produced work
instead. A 2-point ticket became 8 files and +615 lines. Its description said
in bold *"Consume the DB-layer aggregate from TBO-1236 — do not rebuild the
SUM here"* and named the file that other ticket owns; the agent added 75 lines
to exactly that file, duplicating an open pull request. Four acceptance
criteria and a warning about an enum that would fail in SQL never reached it.

The gate was green. Every source file had a test beside it. The reviewer was
assigned. Nothing about the run looked wrong, on an input one line long.

## Why it is not one line

Adding `description` to `ISSUE_FIELDS` alone changes nothing, because the
prompt does not read a body. It is three places in two packages: the fetch,
`toTicket`, and both prompts in `agent-kit`.

## The gate

`plugin-agent-relay`, extended — it already drives the agent side against fake
CLIs with no credential, and a fake records what it was asked, which is
exactly what proving a prompt needs. Plus one assertion on `ticket-to-qa` for
the trip from tracker to action.

## Checks

- `sf check --changed origin/main` — 33 rules, no findings
- `L4.PLAN_DECLARES_EXIT_CONDITION`, `L4.PLAN_CRITERION_NAMES_ITS_CHECK` — green
- `npm run check:plans` — green
- pre-commit hook ran the full gate — green
- no changeset: `changeset status` bumps nothing for a plans-only change

## Note

The workaround on the install where this was found is a private workflow
package reading the Linear API itself and replacing `triage` and `implement`
with `run-errand` to write its own prompt. That is a workflow reimplementing
the tracker because the tracker would not carry a body, and it is recorded in
the plan as the shape of the problem rather than a solution to keep.