### PR TITLE
docs(plans): an answer reaches the agent

### DIFF
--- a/plans/an-answer-reaches-the-agent.md
+++ b/plans/an-answer-reaches-the-agent.md
@@ -1,0 +1,108 @@
+# An answer reaches the agent
+
+`CLARIFYING` exists so that a ticket which does not say enough can be asked
+about. It asks, it waits, and when somebody answers it looks again — with
+exactly the information it had before.
+
+`hasReplyAfter` returns a `boolean` (`plugins/linear/src/LinearTracker.ts:87`).
+Its query already walks the conversation:
+
+```graphql
+comments(first: 100) { nodes { createdAt user { id } } }
+```
+
+and asks for the timestamp and the author id and not the text. No other method
+on the tracker port returns a comment either — the surface is `inProgress`,
+`get`, `comment`, `hasReplyAfter`, `setStatus`, `assign`, `createFollowUp`. So
+amy can know *that* it was answered and never what was said.
+
+The state then re-runs `triage` on an unchanged ticket, gets the same
+questions back, asks them again, and does that until `maxClarifyAttempts` and
+escalates. **`CLARIFYING` cannot clear because it was answered. It can only
+time out.** The one path built for "a human knows something the ticket does
+not" throws that knowledge away on arrival.
+
+This is the sibling of [the ticket body](the-ticket-body-reaches-the-agent.md)
+and worse in one way: that one produced wrong work from a thin input, and this
+one guarantees that asking never fixes anything.
+
+## The conversation is also polluted
+
+`trackerChannel` posts announcement text straight onto the ticket
+(`plugins/linear/src/plugin.ts:33`), and the fan-out reaches every mounted
+channel with no way to choose one per announcement. Two of these were found on
+a real ticket on a real board:
+
+> TBO-1239 is failing in DISCOVERED and I am retrying: catalogue is not defined
+
+> TBO-1239 is moving again in DISCOVERED after 1 failed attempt(s)
+
+Nothing marks them as machine-written, so the moment comments *are* readable
+they arrive looking like a person answering. An operator's only lever is
+`notify.tracker: false`, which also silences the question amy actually wanted
+to ask. Whatever reads comments has to be able to tell its own writing from
+somebody else's, or reading them is worse than not.
+
+## What changes
+
+`Comment` is `{ author, body, at, fromAmy }`, and the port gains one method:
+
+```ts
+comments(ticketId: string, since?: string): Promise<Comment[]>
+```
+
+`hasReplyAfter` stays — a waiting state wants a cheap boolean and should not
+pay for text on every poll — and is expressed in terms of the new method for a
+tracker that would rather implement one.
+
+`fromAmy` is the tracker's answer, not a guess by whatever reads it. The
+Linear adapter already resolves `viewer()` for `hasReplyAfter`, so it knows
+which comments are its own account's; a marker in the body is the fallback for
+an adapter that cannot.
+
+The `triage` prompt carries the conversation, split by who wrote it, and says
+that an answer to an earlier question is part of the ticket. Anything amy
+wrote is labelled as a question it already asked, so it does not read its own
+words as new information and ask them twice.
+
+And `trackerChannel` stops posting progress. A tracker comment is for a
+question that needs a person; `failing`, `recovered` and `gave-up` are for the
+operator and belong on the operator's channels. That removes the pollution
+rather than teaching every reader to filter it.
+
+## The gate
+
+`ticket-to-qa`, extended. It owns `CLARIFYING`, and this is the only state
+whose whole purpose is a round trip through a human:
+
+- `clarifying.clears_when_the_question_is_answered`
+- `clarifying.does_not_ask_the_same_question_twice`
+- `clarifying.ignores_its_own_comments`
+
+`plugin-agent-relay` for the prompt half, beside the assertions the ticket-body
+plan adds there:
+
+- `prompt.carries_the_answers_to_its_own_questions`
+
+## Acceptance criteria
+
+- [ ] `comments` returns author, text and time for a ticket
+      (proof: test:plugins/linear/tests/LinearTracker.test.ts)
+- [ ] A comment amy wrote comes back marked as its own
+      (proof: test:plugins/linear/tests/LinearTracker.test.ts)
+- [ ] An answered question moves the work on rather than being re-asked
+      (proof: assertion:clarifying.clears_when_the_question_is_answered)
+- [ ] A second look does not repeat a question already answered
+      (proof: assertion:clarifying.does_not_ask_the_same_question_twice)
+- [ ] amy's own comments are not read as answers
+      (proof: assertion:clarifying.ignores_its_own_comments)
+- [ ] The prompt contains the answers, attributed
+      (proof: assertion:prompt.carries_the_answers_to_its_own_questions)
+- [ ] No progress announcement reaches a tracker comment
+      (proof: test:plugins/linear/tests/ticketChannel.test.ts)
+- [ ] `hasReplyAfter` still answers without fetching text
+      (proof: test:plugins/linear/tests/LinearTracker.test.ts)
+
+**Exit condition:** a ticket that did not say enough is answered by a person
+in a comment, and the work proceeds on that answer — `CLARIFYING` clears
+because it was answered rather than because it ran out of attempts.

--- a/plans/next-steps.md
+++ b/plans/next-steps.md
@@ -14,14 +14,15 @@ yet.
 | # | Work | Exit condition |
 | --- | --- | --- |
 | 1 | [The ticket body reaches the agent](the-ticket-body-reaches-the-agent.md) | A ticket whose description carries an instruction its title does not is implemented in accordance with it, and a ticket with no description is asked about rather than guessed at |
-| 2 | [The config `amy init` writes must boot](the-config-amy-writes-must-boot.md) | `amy init && amy doctor` is green with no line deleted from the file amy wrote |
-| 3 | [A spec is a name, a URL or a path](a-spec-is-a-name-a-url-or-a-path.md) | One function turns any of the five forms into what npm installs and what the config names, and nothing else in the CLI parses a spec |
-| 4 | [Plugins live where amy can see them](plugins-live-in-amy-home.md) | A machine adds one plugin and runs work with `npm prefix -g` holding nothing of amy's |
-| 5 | [`amy add` and `amy remove`](amy-add-and-amy-remove.md) | One command with a URL, a name or a path in it, and the next `amy tick` moves work through the workflow that arrived |
-| 6 | [`amy update`](amy-update.md) | A machine two versions behind runs one command, keeps its work, and its harness skills describe the CLI now installed |
-| 7 | [A workflow is yours, not a package](a-workflow-is-yours-not-a-package.md) | Somebody who has never published anything ends with a workflow in `~/.amy/workflows` that amy is driving |
-| 8 | [Nothing is installed by default](nothing-is-installed-by-default.md) | A fresh machine installs one package, and the only workflow on it is one the person there chose or wrote |
-| 9 | [A skill ladder for your own steps](a-skill-ladder-for-your-own-steps.md) | A workflow somebody wrote gives one of its own steps a cheaper model and a skill, from `config.yaml` |
-| 10 | [A checkout root per repository](a-checkout-root-per-repository.md) | An install drives work in two repositories under two unrelated parents, with no symlink anywhere |
-| 11 | [A base branch per repository](a-base-branch-per-repository.md) | Two repositories with two base branch names, and no workflow package carrying a branch mapping of its own |
-| 12 | [Compatibility is a capability, not a version](compatibility-is-a-capability-not-a-version.md) | A plugin built against an older core is told at boot which member it lost, and one copy of the core resolves anywhere in the install |
+| 2 | [An answer reaches the agent](an-answer-reaches-the-agent.md) | A ticket that did not say enough is answered by a person in a comment, and the work proceeds on that answer — `CLARIFYING` clears because it was answered rather than because it ran out of attempts |
+| 3 | [The config `amy init` writes must boot](the-config-amy-writes-must-boot.md) | `amy init && amy doctor` is green with no line deleted from the file amy wrote |
+| 4 | [A spec is a name, a URL or a path](a-spec-is-a-name-a-url-or-a-path.md) | One function turns any of the five forms into what npm installs and what the config names, and nothing else in the CLI parses a spec |
+| 5 | [Plugins live where amy can see them](plugins-live-in-amy-home.md) | A machine adds one plugin and runs work with `npm prefix -g` holding nothing of amy's |
+| 6 | [`amy add` and `amy remove`](amy-add-and-amy-remove.md) | One command with a URL, a name or a path in it, and the next `amy tick` moves work through the workflow that arrived |
+| 7 | [`amy update`](amy-update.md) | A machine two versions behind runs one command, keeps its work, and its harness skills describe the CLI now installed |
+| 8 | [A workflow is yours, not a package](a-workflow-is-yours-not-a-package.md) | Somebody who has never published anything ends with a workflow in `~/.amy/workflows` that amy is driving |
+| 9 | [Nothing is installed by default](nothing-is-installed-by-default.md) | A fresh machine installs one package, and the only workflow on it is one the person there chose or wrote |
+| 10 | [A skill ladder for your own steps](a-skill-ladder-for-your-own-steps.md) | A workflow somebody wrote gives one of its own steps a cheaper model and a skill, from `config.yaml` |
+| 11 | [A checkout root per repository](a-checkout-root-per-repository.md) | An install drives work in two repositories under two unrelated parents, with no symlink anywhere |
+| 12 | [A base branch per repository](a-base-branch-per-repository.md) | Two repositories with two base branch names, and no workflow package carrying a branch mapping of its own |
+| 13 | [Compatibility is a capability, not a version](compatibility-is-a-capability-not-a-version.md) | A plugin built against an older core is told at boot which member it lost, and one copy of the core resolves anywhere in the install |


### PR DESCRIPTION
Sibling of #28, listed immediately after it. That one produces wrong work from
a thin input; this one guarantees that asking about it never helps.

## `CLARIFYING` cannot clear

It exists so a ticket that does not say enough can be asked about. It asks, it
waits, and when somebody answers it looks again — with exactly the information
it had before.

`hasReplyAfter` returns a `boolean` (`LinearTracker.ts:87`). Its query already
walks the conversation:

```graphql
comments(first: 100) { nodes { createdAt user { id } } }
```

and asks for the timestamp and the author id and **not the text**. No other
method on the port returns a comment either. So amy knows *that* it was
answered and never what was said, re-runs `triage` on an unchanged ticket, gets
the same questions, and asks them again until `maxClarifyAttempts` and
escalates.

The one path built for "a human knows something the ticket does not" throws
that knowledge away on arrival.

## The conversation is polluted too

`trackerChannel` posts announcement text onto the ticket, and the fan-out
reaches every channel with no per-announcement choice. Two of these were found
on a real ticket on a real board:

> TBO-1239 is failing in DISCOVERED and I am retrying: catalogue is not defined

Nothing marks them as machine-written. The moment comments *are* readable, they
arrive looking like a person answering. The only lever an operator has is
`notify.tracker: false`, which also silences the question amy wanted to ask.

## What the plan proposes

- `comments(ticketId, since?)` on the port, returning `{author, body, at, fromAmy}`
- `hasReplyAfter` stays — a waiting state wants a cheap boolean and should not
  pay for text on every poll
- `fromAmy` decided by the adapter, which already resolves `viewer()`, not
  guessed by the reader
- the `triage` prompt carries the conversation split by author, so amy does not
  read its own questions as new information
- `trackerChannel` stops posting progress: a ticket comment is for a question
  that needs a person, and `failing`/`recovered`/`gave-up` are for the operator

## Checks

- `sf check --changed origin/main` — 33 rules, no findings
- `npm run check:plans` — green
- pre-commit hook ran the full gate — green
- no changeset: plans-only

## Found how

Same way as #28: driving a private workflow against a real board. The
workaround there now reads Linear's comments itself and splits them by a marker
it signs with — plus a pattern match for amy's own unsigned progress notices,
which is the belt this plan removes the need for.