### PR TITLE
feat: the config amy init writes must boot

### DIFF
--- a/.changeset/the-config-amy-writes-must-boot.md
+++ b/.changeset/the-config-amy-writes-must-boot.md
@@ -1,0 +1,33 @@
+---
+"@amykit/agent-kit": minor
+"@amykit/cli": minor
+"@amykit/plugin-agent-relay": minor
+---
+
+The config `amy init` writes boots — and the check that says so runs from the
+gate, not from a memory of a real install.
+
+`EXAMPLE_CONFIG` shipped `claude:opus` in the default ladder and again in a
+step's own. `everyLadderEntry` unions the default ladder with every per-step
+one and does not dedupe, so `tiersFor` produced `["sonnet", "opus", "haiku",
+"opus"]`, `contributeTiers` contributed a second agent named `claude:opus`, and
+the second one met the collection's one-name rule at mount. `amy init` wrote a
+config its own first `amy doctor` refused, and the workaround — deleting the
+per-step ladder the template exists to teach — configured the feature out of
+an install because of a missing `Set`.
+
+The union dedupes in one place, `contributeTiers`, preserving first-seen
+order: a ladder is ordered and the first mention is the one that means
+something.
+
+And the template check grows the claim it was always about: `npm run
+check:config` now assembles the config `amy init` writes — the same `load`,
+the same `pluginList`, the same `mount` a real boot runs — and refuses a
+template whose machine does not start. The unit tests prove both directions:
+the shipped example mounts, and a template whose budget window nothing meters,
+or whose ladder names a harness nothing contributes, turns the check red.
+
+The relay's gate carries the proof: `relay.a_rung_named_twice_mounts_once`
+mounts the template's own ladder shape against the built plugins, and
+`relay.the_first_mention_sets_the_order` walks a step onto the rung its
+step's ladder names first.

--- a/.software-factory/evidence/installed-binary.json
+++ b/.software-factory/evidence/installed-binary.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "gate": "installed-binary",
-  "implementation_sha256": "9c7b1d95cc7a4b96d78869f3b3e4db6c71c99e8e0ff3788930e285e5bad1e443",
+  "implementation_sha256": "195b0cf2bef643c454cc24e1636ea316ec69ac34b08c9b1ec900e23898478f9a",
   "runs": [
     {
       "scenario": "installed-binary",

--- a/.software-factory/evidence/note-to-plan-run.json
+++ b/.software-factory/evidence/note-to-plan-run.json
@@ -42,8 +42,8 @@
     "notes_left": [
       "by-hand.md",
       "not-mine.md",
-      "note-2026-09-08T000414550.md",
-      "note-2026-09-08T000419697.md",
+      "note-2026-09-08T233034109.md",
+      "note-2026-09-08T233039810.md",
       "will-break.md"
     ],
     "budget": "new work: allowed"

--- a/.software-factory/evidence/note-to-plan-run.json
+++ b/.software-factory/evidence/note-to-plan-run.json
@@ -42,8 +42,8 @@
     "notes_left": [
       "by-hand.md",
       "not-mine.md",
-      "note-2026-09-07T144734104.md",
-      "note-2026-09-07T144737754.md",
+      "note-2026-09-08T000414550.md",
+      "note-2026-09-08T000419697.md",
       "will-break.md"
     ],
     "budget": "new work: allowed"

--- a/.software-factory/evidence/note-to-plan-run.json
+++ b/.software-factory/evidence/note-to-plan-run.json
@@ -42,8 +42,8 @@
     "notes_left": [
       "by-hand.md",
       "not-mine.md",
-      "note-2026-09-08T233034109.md",
-      "note-2026-09-08T233039810.md",
+      "note-2026-09-09T020139734.md",
+      "note-2026-09-09T020143393.md",
       "will-break.md"
     ],
     "budget": "new work: allowed"

--- a/.software-factory/evidence/note-to-plan.json
+++ b/.software-factory/evidence/note-to-plan.json
@@ -8,7 +8,7 @@
       "status": "passed",
       "actor": "Claude (agent), driving the installed executable from a written-down piece of friction to a pull request against stand-in services on macOS, for Nicolas Melo",
       "report": ".software-factory/evidence/note-to-plan-run.json",
-      "report_sha256": "335519c52bb5b51c311aeb22f559e5c31db1905e950a8c705cdec582c204f39b",
+      "report_sha256": "f3a44baf1056514cf9cbe17f6309e4c8fff86a65e009cedc096bc0fb5a48b856",
       "required_assertions": []
     }
   ]

--- a/.software-factory/evidence/note-to-plan.json
+++ b/.software-factory/evidence/note-to-plan.json
@@ -1,14 +1,14 @@
 {
   "schema_version": 1,
   "gate": "note-to-plan",
-  "implementation_sha256": "bb31a3e39561bade1333738b59d69c55028fecd6210b0262315241d80ae171f0",
+  "implementation_sha256": "090d91b3dc571e122434253676e3938454fd51ecb26dfaa0026fddd870ea8ef6",
   "runs": [
     {
       "scenario": "note-to-plan",
       "status": "passed",
       "actor": "Claude (agent), driving the installed executable from a written-down piece of friction to a pull request against stand-in services on macOS, for Nicolas Melo",
       "report": ".software-factory/evidence/note-to-plan-run.json",
-      "report_sha256": "f3a44baf1056514cf9cbe17f6309e4c8fff86a65e009cedc096bc0fb5a48b856",
+      "report_sha256": "4a44676b1ac2aeb97cac030981800c0cd029dd67157cefa42d5e4aacb791f07e",
       "required_assertions": []
     }
   ]

--- a/.software-factory/evidence/note-to-plan.json
+++ b/.software-factory/evidence/note-to-plan.json
@@ -1,14 +1,14 @@
 {
   "schema_version": 1,
   "gate": "note-to-plan",
-  "implementation_sha256": "3290199d47c3715d7885db2221604410e2a3723c1fcec48963c717bb396186d1",
+  "implementation_sha256": "bb31a3e39561bade1333738b59d69c55028fecd6210b0262315241d80ae171f0",
   "runs": [
     {
       "scenario": "note-to-plan",
       "status": "passed",
       "actor": "Claude (agent), driving the installed executable from a written-down piece of friction to a pull request against stand-in services on macOS, for Nicolas Melo",
       "report": ".software-factory/evidence/note-to-plan-run.json",
-      "report_sha256": "cc642a7559abf151606ceba9a851a1ba5fa1bac26ae208fbee07fc83bb2becea",
+      "report_sha256": "335519c52bb5b51c311aeb22f559e5c31db1905e950a8c705cdec582c204f39b",
       "required_assertions": []
     }
   ]

--- a/.software-factory/evidence/plugin-agent-relay-run.json
+++ b/.software-factory/evidence/plugin-agent-relay-run.json
@@ -12,11 +12,19 @@
     ]
   },
   "observed": {
-    "assertions_run": 33,
+    "assertions_run": 35,
     "assertions_failed": 0,
-    "node": "v22.22.1"
+    "node": "v22.22.2"
   },
   "assertions": [
+    {
+      "type": "relay.a_rung_named_twice_mounts_once",
+      "status": "passed"
+    },
+    {
+      "type": "relay.the_first_mention_sets_the_order",
+      "status": "passed"
+    },
     {
       "type": "relay.mounts_the_agent_port",
       "status": "passed"

--- a/.software-factory/evidence/plugin-agent-relay-scenario.sh
+++ b/.software-factory/evidence/plugin-agent-relay-scenario.sh
@@ -134,6 +134,7 @@ async function hostWith(
     models = ["sonnet", "opus"],
     codexModels = ["gpt-5"],
     hermesModels = ["hermes-4-405b"],
+    ladderByStep,
   } = {},
 ) {
   const events = [...seed];
@@ -145,6 +146,7 @@ async function hostWith(
       "@amykit/plugin-hermes-agent": { defaultBranch: "main", models: hermesModels },
       "@amykit/plugin-agent-relay": {
         ladder,
+        ...(ladderByStep === undefined ? {} : { ladderByStep }),
         ...(budget === undefined ? {} : { budget }),
         ...(skills === undefined ? {} : { skills, skillRoots: [path.join(work, "skills")] }),
       },
@@ -162,6 +164,7 @@ async function hostWith(
     events,
     agent: outcome.ok ? outcome.mounted.ports.get("agent") : null,
     budget: outcome.ok ? outcome.mounted.ports.get("budget") : null,
+    mounted: outcome.ok ? outcome.mounted : null,
   };
 }
 
@@ -176,12 +179,49 @@ function spent(at, costUsd) {
 
 const LADDER = ["claude:sonnet", "claude:opus", "codex:gpt-5"];
 
+// The shape `amy init` ships: the default ladder and a step's own both naming
+// the same rung. Before the union deduped, this was the config that could not
+// boot — the second `claude:opus` met the collection's one-name rule and the
+// template's own example was refused at mount.
+const TEMPLATE_LADDER = ["claude:sonnet", "claude:opus", "claude:haiku"];
+
 function reset(mode) {
   fs.writeFileSync(calls, "");
   process.env.AMY_E2E_CLAUDE = mode;
 }
 
 const called = () => fs.readFileSync(calls, "utf-8").trim().split("\n").filter(Boolean);
+
+// 0. The config `amy init` writes mounts. A rung named in both the default
+// ladder and a step's own is one rung — the collection holds one `claude:opus`
+// where the raw union held two — and the step's own ladder decides who a step
+// meets first, which is how the order a first mention set stays observable.
+{
+  const { outcome, agent } = await hostWith(TEMPLATE_LADDER, {
+    models: ["sonnet", "opus", "haiku", "opus"],
+    ladderByStep: { triage: ["claude:haiku"], implement: ["claude:opus"] },
+  });
+
+  record(
+    "relay.a_rung_named_twice_mounts_once",
+    outcome.ok === true && Boolean(agent),
+  );
+
+  reset("fine");
+  const { agent: stepped } = await hostWith(TEMPLATE_LADDER, {
+    models: ["sonnet", "opus", "haiku", "opus"],
+    ladderByStep: { triage: ["claude:haiku"], implement: ["claude:opus"] },
+  });
+  await stepped.triage(TICKET);
+
+  // `triage` was handed to the rung its step's ladder names first, and the
+  // default ladder's opening rungs were not consulted on the way: the order
+  // the config meant is the order the relay walked.
+  record(
+    "relay.the_first_mention_sets_the_order",
+    called()[0] === "claude:haiku",
+  );
+}
 
 // 1. The relay is what mounts the port. The harnesses only contribute, so
 // without it the agent actions have no owner at all.

--- a/.software-factory/evidence/plugin-agent-relay.json
+++ b/.software-factory/evidence/plugin-agent-relay.json
@@ -1,14 +1,14 @@
 {
   "schema_version": 1,
   "gate": "plugin-agent-relay",
-  "implementation_sha256": "691e9dfe85b2026ea0b0e778ae475cc5e72999c019e9b44b91a15f9802d2ab22",
+  "implementation_sha256": "9fc5b6ece12f761857bc402fafce8fb66bbdd09d30afb5e39f64fdbcc7d2942c",
   "runs": [
     {
       "scenario": "plugin-agent-relay",
       "status": "passed",
       "actor": "Claude (agent), running .software-factory/evidence/plugin-agent-relay-scenario.sh against the built dist on macOS, for Nicolas Melo",
       "report": ".software-factory/evidence/plugin-agent-relay-run.json",
-      "report_sha256": "158b0f0fc9b37ca4c26b75676c399c041c2aaba9553cf5f2f53b78baf6f1f87e",
+      "report_sha256": "0385f959706ab266d9c1dbe512a05bc11e713f2144ae67fd6d1b1bab4b3853c1",
       "required_assertions": []
     }
   ]

--- a/.software-factory/evidence/plugin-file-queue-run.json
+++ b/.software-factory/evidence/plugin-file-queue-run.json
@@ -9,7 +9,7 @@
   "observed": {
     "assertions_run": 17,
     "assertions_failed": 0,
-    "node": "v22.22.1"
+    "node": "v22.22.2"
   },
   "assertions": [
     {

--- a/.software-factory/evidence/plugin-file-queue.json
+++ b/.software-factory/evidence/plugin-file-queue.json
@@ -8,7 +8,7 @@
       "status": "passed",
       "actor": "Claude (agent), running .software-factory/evidence/plugin-file-queue-scenario.sh against the built dist on macOS, for Nicolas Melo",
       "report": ".software-factory/evidence/plugin-file-queue-run.json",
-      "report_sha256": "5af9a1b7bb1c1cb353469754d34ac8ccdb6e662c3d8a9b424bb5c511020eabb3",
+      "report_sha256": "3440870f16fdfe54e6521af287fc54be6261afa8a5d9a1ccf19e3b078ad768e1",
       "required_assertions": []
     }
   ]

--- a/.software-factory/evidence/plugin-serial-engine-run.json
+++ b/.software-factory/evidence/plugin-serial-engine-run.json
@@ -18,7 +18,7 @@
     "assertions_run": 16,
     "assertions_failed": 0,
     "log_lines_written": 40,
-    "node": "v22.22.1"
+    "node": "v22.22.2"
   },
   "assertions": [
     {

--- a/.software-factory/evidence/plugin-serial-engine.json
+++ b/.software-factory/evidence/plugin-serial-engine.json
@@ -8,7 +8,7 @@
       "status": "passed",
       "actor": "Claude (agent), running .software-factory/evidence/plugin-serial-engine-scenario.sh against the built dist on macOS, for Nicolas Melo",
       "report": ".software-factory/evidence/plugin-serial-engine-run.json",
-      "report_sha256": "2091dcfbde50cf37d2e195283ce47ec941d04d48fc11cf9edaf32818864adc23",
+      "report_sha256": "e05c2e05388eced4b80be57366ffbd43ff90c562a4a69f44b8fa5d06cd8bf8f7",
       "required_assertions": []
     }
   ]

--- a/.software-factory/evidence/ticket-to-qa-run.json
+++ b/.software-factory/evidence/ticket-to-qa-run.json
@@ -56,12 +56,12 @@
     ],
     "what_the_world_did": [
       "a colleague answered the question on the ticket",
-      "the automated reviewer looked at 40b7e5b and left one comment",
-      "the automated reviewer looked at 2912fe0 and had nothing to say",
+      "the automated reviewer looked at 0e6e8a3 and left one comment",
+      "the automated reviewer looked at 4d96d89 and had nothing to say",
       "one of ada's other reviews was merged, so she is carrying one",
-      "ada asked for changes on 2912fe0",
+      "ada asked for changes on 4d96d89",
       "the owner settled the disagreement on the ticket",
-      "ada approved 2113a9e"
+      "ada approved fc47dd8"
     ],
     "agent_calls": [
       "triage",

--- a/.software-factory/evidence/ticket-to-qa-run.json
+++ b/.software-factory/evidence/ticket-to-qa-run.json
@@ -56,12 +56,12 @@
     ],
     "what_the_world_did": [
       "a colleague answered the question on the ticket",
-      "the automated reviewer looked at af5ac20 and left one comment",
-      "the automated reviewer looked at 46e5931 and had nothing to say",
+      "the automated reviewer looked at 40b7e5b and left one comment",
+      "the automated reviewer looked at 2912fe0 and had nothing to say",
       "one of ada's other reviews was merged, so she is carrying one",
-      "ada asked for changes on 46e5931",
+      "ada asked for changes on 2912fe0",
       "the owner settled the disagreement on the ticket",
-      "ada approved 1f43f74"
+      "ada approved 2113a9e"
     ],
     "agent_calls": [
       "triage",

--- a/.software-factory/evidence/ticket-to-qa-run.json
+++ b/.software-factory/evidence/ticket-to-qa-run.json
@@ -56,12 +56,12 @@
     ],
     "what_the_world_did": [
       "a colleague answered the question on the ticket",
-      "the automated reviewer looked at 0e6e8a3 and left one comment",
-      "the automated reviewer looked at 4d96d89 and had nothing to say",
+      "the automated reviewer looked at f457b0b and left one comment",
+      "the automated reviewer looked at 4116a18 and had nothing to say",
       "one of ada's other reviews was merged, so she is carrying one",
-      "ada asked for changes on 4d96d89",
+      "ada asked for changes on 4116a18",
       "the owner settled the disagreement on the ticket",
-      "ada approved fc47dd8"
+      "ada approved 1287c2e"
     ],
     "agent_calls": [
       "triage",

--- a/.software-factory/evidence/ticket-to-qa.json
+++ b/.software-factory/evidence/ticket-to-qa.json
@@ -1,14 +1,14 @@
 {
   "schema_version": 1,
   "gate": "ticket-to-qa",
-  "implementation_sha256": "5e8c16be88ab8978809cdf833e87c8a3ea78d865e7f94d3a194cfb02edbd9bd8",
+  "implementation_sha256": "c991238e58415f80866c60f5881bb6ffaa9c34ce6e341a91ab157613acc3b5c4",
   "runs": [
     {
       "scenario": "ticket-to-qa",
       "status": "passed",
       "actor": "Claude (agent), driving the installed executable through one ticket against stand-in services on macOS, for Nicolas Melo",
       "report": ".software-factory/evidence/ticket-to-qa-run.json",
-      "report_sha256": "f98ed5306d0d486971d24263c08051a7e149208f6023f20bf85e06235d25229d",
+      "report_sha256": "50f857f8377d34df4e90756c9d203bfada3ff3dc26c5429bc8068099c1e20fbd",
       "required_assertions": []
     }
   ]

--- a/.software-factory/evidence/ticket-to-qa.json
+++ b/.software-factory/evidence/ticket-to-qa.json
@@ -8,7 +8,7 @@
       "status": "passed",
       "actor": "Claude (agent), driving the installed executable through one ticket against stand-in services on macOS, for Nicolas Melo",
       "report": ".software-factory/evidence/ticket-to-qa-run.json",
-      "report_sha256": "d44fd1e26c7d6c8ca8c2ecd56ff5b192e599fafa8d90ab3a76fcfcf04e489454",
+      "report_sha256": "f98ed5306d0d486971d24263c08051a7e149208f6023f20bf85e06235d25229d",
       "required_assertions": []
     }
   ]

--- a/.software-factory/evidence/ticket-to-qa.json
+++ b/.software-factory/evidence/ticket-to-qa.json
@@ -1,14 +1,14 @@
 {
   "schema_version": 1,
   "gate": "ticket-to-qa",
-  "implementation_sha256": "9eec18e7e5ae2f974d197b9725642ce69027ac55031744ae28fff8101eb15a8f",
+  "implementation_sha256": "5e8c16be88ab8978809cdf833e87c8a3ea78d865e7f94d3a194cfb02edbd9bd8",
   "runs": [
     {
       "scenario": "ticket-to-qa",
       "status": "passed",
       "actor": "Claude (agent), driving the installed executable through one ticket against stand-in services on macOS, for Nicolas Melo",
       "report": ".software-factory/evidence/ticket-to-qa-run.json",
-      "report_sha256": "c8ba45060f664cb73e06625b2fdf746dd21a92e5632944c6295c885444bae240",
+      "report_sha256": "d44fd1e26c7d6c8ca8c2ecd56ff5b192e599fafa8d90ab3a76fcfcf04e489454",
       "required_assertions": []
     }
   ]

--- a/.software-factory/locks/factory.lock.json
+++ b/.software-factory/locks/factory.lock.json
@@ -4,7 +4,7 @@
     ".allowed-root-files": "6b96c6cde21f0a325b44a460c9d46632b09ea60876b9ac0f05e78f0254104a10",
     ".githooks/pre-commit": "7807e293928dc251ea7b76c3e00be3d3e46707c0865633532f46a7d2ef334789",
     ".github/workflows/software-factory.yml": "e3e34d419e13868d62df4d09cacc53d1e99db16731b7c63aef287060995902ec",
-    ".software-factory/policy.yaml": "c63b985efd99e12136f1f4fe997c19e2bd218c27e9b7d3b369283601169f0842",
+    ".software-factory/policy.yaml": "343dfc795294d3952f8b07c4528e9545f593693d0eab113a7719d9a6f3e17f68",
     ".software-factory/ratchet.yaml": "e0be45ffb042d35cb29274e8ad70a8ab1f82cb94ac21c1203e183a929158b8e2",
     ".software-factory/rules/core-stays-ignorant.yaml": "f49946b95bd97b7e075ef73d3241c3530d323607abb5b9b9a5558f8f216f2942",
     ".software-factory/rules/fixtures-name-nobody-real.yaml": "2f9e6738cf7c8fbe3152b89dc652474af494316e478407d63fab3343abc223b4"

--- a/.software-factory/policy.yaml
+++ b/.software-factory/policy.yaml
@@ -51,6 +51,8 @@ gates:
     plan: "docs/design/the-relay-is-proven-end-to-end.md"
     required_assertions:
       - "relay.mounts_the_agent_port"
+      - "relay.a_rung_named_twice_mounts_once"
+      - "relay.the_first_mention_sets_the_order"
       - "relay.escalates_the_model_after_a_failure"
       - "relay.does_not_change_harness_on_a_failure"
       - "relay.changes_harness_after_a_rate_limit"

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -76,6 +76,37 @@ price it by and codex reports nothing to price it with. Name the model
 
 `patch` · `@amykit/cli`
 
+
+
+### The config `amy init` writes boots — and the check that says so runs from the gate, not from a memory of a real install.
+
+`minor` · `@amykit/agent-kit`, `@amykit/cli`, `@amykit/plugin-agent-relay`
+
+`EXAMPLE_CONFIG` shipped `claude:opus` in the default ladder and again in a
+step's own. `everyLadderEntry` unions the default ladder with every per-step
+one and does not dedupe, so `tiersFor` produced `["sonnet", "opus", "haiku",
+"opus"]`, `contributeTiers` contributed a second agent named `claude:opus`, and
+the second one met the collection's one-name rule at mount. `amy init` wrote a
+config its own first `amy doctor` refused, and the workaround — deleting the
+per-step ladder the template exists to teach — configured the feature out of
+an install because of a missing `Set`.
+
+The union dedupes in one place, `contributeTiers`, preserving first-seen
+order: a ladder is ordered and the first mention is the one that means
+something.
+
+And the template check grows the claim it was always about: `npm run
+check:config` now assembles the config `amy init` writes — the same `load`,
+the same `pluginList`, the same `mount` a real boot runs — and refuses a
+template whose machine does not start. The unit tests prove both directions:
+the shipped example mounts, and a template whose budget window nothing meters,
+or whose ladder names a harness nothing contributes, turns the check red.
+
+The relay's gate carries the proof: `relay.a_rung_named_twice_mounts_once`
+mounts the template's own ladder shape against the built plugins, and
+`relay.the_first_mention_sets_the_order` walks a step onto the rung its
+step's ladder names first.
+
 <!-- amy:end changelog-unreleased -->
 
 ## Released

--- a/docs/design/the-relay-is-proven-end-to-end.md
+++ b/docs/design/the-relay-is-proven-end-to-end.md
@@ -84,11 +84,32 @@ not answer is not something a good day produces, and a skill named in a config
 that nobody installed has to be refused before a ticket is touched rather than
 after one escalates for no reason.
 
+## The config the template writes is the same machine
+
+`amy init` ships a default ladder and a step's own that name the same rung —
+`claude:opus` in both. Unioned raw, the second contribution met the
+collection's one-name rule and the template's own example was refused at
+mount: found on a real install, worked around by deleting the per-step ladder,
+which configured the feature out of the install because of a missing `Set`.
+The union dedupes now, keeping the first mention, and the proof lives in this
+gate because the shared tier code is what changed.
+
+`relay.a_rung_named_twice_mounts_once` mounts that exact shape against the
+built plugins. `relay.the_first_mention_sets_the_order` walks a step onto the
+rung its step's ladder names first, which is how an order stays observable
+rather than a claim about internals.
+
 ## Acceptance criteria
 
 - [x] The relay is what mounts the `agent` port, and the harnesses on their
       own leave it unowned
       (proof: assertion:relay.mounts_the_agent_port)
+- [x] A rung named in both the default ladder and a step's own mounts one
+      agent, where the raw union mounted two and was refused
+      (proof: assertion:relay.a_rung_named_twice_mounts_once)
+- [x] A step meets the rung its step's ladder names first, so the order a
+      first mention set is the order the relay walks
+      (proof: assertion:relay.the_first_mention_sets_the_order)
 - [x] A failure escalates to the stronger model of the same harness
       (proof: assertion:relay.escalates_the_model_after_a_failure)
 - [x] A failure does not change harness while that harness still has a
@@ -142,7 +163,7 @@ after one escalates for no reason.
       (proof: assertion:relay.names_the_skills_there_were_to_choose_from)
 
 **Exit condition:** the gate carries a sealed manifest whose report shows
-these nineteen assertions passing against the built artifacts, and touching
+these twenty-one assertions passing against the built artifacts, and touching
 the relay or the shared agent kit turns `sf check` red until the run is
 repeated and resealed.
 

--- a/docs/development/the-gate.md
+++ b/docs/development/the-gate.md
@@ -133,7 +133,7 @@ asserts what the thing promises, and writes a report sealed with a digest.
 | `installed-binary` | `packages/cli/src/stamp.ts`<br>`packages/cli/src/home.ts`<br>`packages/core/src/build.ts`<br>`scripts/**` | 7 |
 | `installed-plugins` | `packages/cli/src/loader.ts`<br>`packages/cli/src/profiles.ts`<br>`packages/cli/src/paths.ts`<br>`packages/cli/src/slices.ts`<br>`scripts/install.sh`<br>`scripts/write-install-manifest.mjs` | 12 |
 | `note-to-plan` | `packages/workflow-note-to-plan/src/**`<br>`packages/agent-kit/src/**`<br>`packages/cli/src/**`<br>`plugins/file-notes/src/**`<br>`plugins/plan-check/src/**`<br>`plugins/agent-relay/src/**`<br>`plugins/serial-engine/src/**`<br>`plugins/github/src/**` | 19 |
-| `plugin-agent-relay` | `plugins/agent-relay/src/**`<br>`packages/agent-kit/src/**` | 20 |
+| `plugin-agent-relay` | `plugins/agent-relay/src/**`<br>`packages/agent-kit/src/**` | 22 |
 | `plugin-file-queue` | `plugins/file-queue/src/**` | 9 |
 | `plugin-serial-engine` | `plugins/serial-engine/src/**`<br>`plugins/notify-fanout/src/**` | 11 |
 | `ticket-to-qa` | `packages/workflow-ticket-to-qa/src/**`<br>`packages/agent-kit/src/**`<br>`packages/cli/src/**`<br>`plugins/serial-engine/src/**`<br>`plugins/linear/src/**`<br>`plugins/github/src/**`<br>`plugins/claude/src/**`<br>`plugins/command-gate/src/**`<br>`plugins/notify-fanout/src/**`<br>`plugins/notify-inbox/src/**` | 24 |

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -678,6 +678,11 @@
           "slug": "add-the-plan-board-consistency-check-to-the-gate-so-delivered-plans-can-move-into-durable-design-notes-without-losing-their-required-assertions"
         },
         {
+          "depth": 3,
+          "title": "The config amy init writes boots — and the check that says so runs from the gate, not from a memory of a real install.",
+          "slug": "the-config-amy-init-writes-boots-and-the-check-that-says-so-runs-from-the-gate-not-from-a-memory-of-a-real-install"
+        },
+        {
           "depth": 2,
           "title": "Released",
           "slug": "released"
@@ -1528,6 +1533,11 @@
           "depth": 2,
           "title": "And who does the step, which is the same ladder again",
           "slug": "and-who-does-the-step-which-is-the-same-ladder-again"
+        },
+        {
+          "depth": 2,
+          "title": "The config the template writes is the same machine",
+          "slug": "the-config-the-template-writes-is-the-same-machine"
         },
         {
           "depth": 2,
@@ -5243,6 +5253,8 @@
         "plan": "docs/design/the-relay-is-proven-end-to-end.md",
         "assertions": [
           "relay.mounts_the_agent_port",
+          "relay.a_rung_named_twice_mounts_once",
+          "relay.the_first_mention_sets_the_order",
           "relay.escalates_the_model_after_a_failure",
           "relay.does_not_change_harness_on_a_failure",
           "relay.changes_harness_after_a_rate_limit",
@@ -5697,6 +5709,26 @@
           }
         ],
         "level": "patch"
+      },
+      {
+        "id": "the-config-amy-writes-must-boot",
+        "title": "The config `amy init` writes boots — and the check that says so runs from the gate, not from a memory of a real install.",
+        "body": "`EXAMPLE_CONFIG` shipped `claude:opus` in the default ladder and again in a\nstep's own. `everyLadderEntry` unions the default ladder with every per-step\none and does not dedupe, so `tiersFor` produced `[\"sonnet\", \"opus\", \"haiku\",\n\"opus\"]`, `contributeTiers` contributed a second agent named `claude:opus`, and\nthe second one met the collection's one-name rule at mount. `amy init` wrote a\nconfig its own first `amy doctor` refused, and the workaround — deleting the\nper-step ladder the template exists to teach — configured the feature out of\nan install because of a missing `Set`.\n\nThe union dedupes in one place, `contributeTiers`, preserving first-seen\norder: a ladder is ordered and the first mention is the one that means\nsomething.\n\nAnd the template check grows the claim it was always about: `npm run\ncheck:config` now assembles the config `amy init` writes — the same `load`,\nthe same `pluginList`, the same `mount` a real boot runs — and refuses a\ntemplate whose machine does not start. The unit tests prove both directions:\nthe shipped example mounts, and a template whose budget window nothing meters,\nor whose ladder names a harness nothing contributes, turns the check red.\n\nThe relay's gate carries the proof: `relay.a_rung_named_twice_mounts_once`\nmounts the template's own ladder shape against the built plugins, and\n`relay.the_first_mention_sets_the_order` walks a step onto the rung its\nstep's ladder names first.",
+        "bumps": [
+          {
+            "package": "@amykit/agent-kit",
+            "level": "minor"
+          },
+          {
+            "package": "@amykit/cli",
+            "level": "minor"
+          },
+          {
+            "package": "@amykit/plugin-agent-relay",
+            "level": "minor"
+          }
+        ],
+        "level": "minor"
       }
     ],
     "changelogs": [

--- a/packages/agent-kit/src/tiers.ts
+++ b/packages/agent-kit/src/tiers.ts
@@ -33,7 +33,19 @@ export interface TierOptions {
  * level reads it.
  */
 export function contributeTiers(registry: Registry, opts: TierOptions): NamedAgent[] {
-  const models = opts.models.length > 0 ? opts.models : [""];
+  // The union the config sent can name a model twice — `ladder` and a step's
+  // own both saying `claude:opus` is the shape `amy init` ships. A rung is a
+  // name in a collection here, and a second contribution under a name already
+  // present is refused at boot. Dedupe, keeping the first mention: a ladder
+  // is ordered, and the first mention is the one that means something.
+  const seen = new Set<string>();
+  const models = opts.models.filter((model) => {
+    const key = `${model}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+  if (models.length === 0) models.push("");
 
   return models.map((model) => {
     const cli = opts.make(model);

--- a/packages/agent-kit/tests/tiers.test.ts
+++ b/packages/agent-kit/tests/tiers.test.ts
@@ -141,6 +141,38 @@ describe("contributing tiers", () => {
     expect(named(AGENT_COLLECTION)).toEqual(["hermes"]);
   });
 
+  it("mounts a rung named twice once, keeping the first mention", () => {
+    // The shape `amy init` ships: `ladder` and a step's own ladder both naming
+    // `claude:opus`. Unioned raw, the second contribution met the collection's
+    // one-name rule and the mount was refused — the template's own example was
+    // a config that could not boot.
+    const { registry, named } = recordingRegistry();
+
+    contributeTiers(registry, {
+      harness: "claude",
+      models: ["sonnet", "opus", "haiku", "opus"],
+      git: git(),
+      make: fakeHarness,
+    });
+
+    expect(named(AGENT_COLLECTION)).toEqual(["claude:sonnet", "claude:opus", "claude:haiku"]);
+  });
+
+  it("names each surviving rung once in the harness collection too", () => {
+    // Two collections are written from the same list, so a dedupe that only
+    // fixed the agents would leave the harnesses refusing the same mount.
+    const { registry, named } = recordingRegistry();
+
+    contributeTiers(registry, {
+      harness: "claude",
+      models: ["opus", "opus"],
+      git: git(),
+      make: fakeHarness,
+    });
+
+    expect(named(HARNESS_COLLECTION)).toEqual(["claude:opus"]);
+  });
+
   it("never mounts the agent port itself", () => {
     // The point of the whole inversion: a harness that mounted the port would
     // refuse to coexist with the next harness installed.

--- a/packages/cli/src/config-template.ts
+++ b/packages/cli/src/config-template.ts
@@ -1,3 +1,16 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { mount, MountOutcome, NodeCommandRunner } from "@amykit/core";
+import { FileEventLog } from "@amykit/plugin-file-log";
+import type { Roster } from "@amykit/workflow-ticket-to-qa";
+import { EXAMPLE_CONFIG, loadConfigFrom } from "./config.js";
+import { loadEnv } from "./env.js";
+import { hostPlugin } from "./hostPlugin.js";
+import { load } from "./loader.js";
+import { profiles } from "./profiles.js";
+import { hostPaths, pluginList, pluginSlices } from "./slices.js";
+
 /**
  * One settings surface: what a block of the config accepts, and where it is.
  *
@@ -78,19 +91,6 @@ function named(at: string, key: string): string {
   return at ? `${at}.${key}` : key;
 }
 
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
-import { mount, MountOutcome, NodeCommandRunner } from "@amykit/core";
-import { FileEventLog } from "@amykit/plugin-file-log";
-import type { Roster } from "@amykit/workflow-ticket-to-qa";
-import { EXAMPLE_CONFIG, loadConfigFrom } from "./config.js";
-import { loadEnv } from "./env.js";
-import { hostPlugin } from "./hostPlugin.js";
-import { load } from "./loader.js";
-import { profiles } from "./profiles.js";
-import { hostPaths, pluginList, pluginSlices } from "./slices.js";
-
 export interface BootCheck {
   ok: boolean;
   problems: string[];
@@ -122,32 +122,21 @@ export async function checkConfigBoots(configRoot: string): Promise<BootCheck> {
   const profile = profiles(config)[config.defaultWorkflow] ?? Object.values(profiles(config))[0]!;
   if (!profile) return { ok: false, problems: ["the template declares no workflow to drive"] };
 
-  // The working directory a real machine boots from, read the way every
-  // command reads it. What a fresh install starts without is the operator's
-  // first errand — `amy doctor` says FAIL and names the key — not a fault in
-  // the text `amy init` wrote, so a credential this machine has not been
-  // given yet is stood in for rather than reported as a template bug. Only
-  // when absent: a value already exported stays the one the check means.
+  // The environment a real machine boots from, read the way every command
+  // reads it — from the config root it was handed, not from wherever the
+  // caller happened to be standing. A check whose answer moved with the
+  // working directory would pass on the machine that ran it and nowhere else.
+  //
+  // What a fresh install starts without is the operator's first errand —
+  // `amy doctor` says FAIL and names the key — not a fault in the text `amy
+  // init` wrote, so a credential this machine has not been given yet is stood
+  // in for rather than reported as a template bug. Only when absent: a value
+  // already exported stays the one the check means.
   const credentials: Record<string, string> = { LINEAR_API_KEY: "lin_api_boot-check" };
-  for (const [key, value] of Object.entries(credentials)) {
-    if (process.env[key] === undefined) process.env[key] = value;
-  }
-  loadEnv(process.cwd());
-
-  const specs = pluginList(config, profile);
-  const loaded = await load(specs);
-  // Nothing below means anything if a named plugin is missing: that is an
-  // install problem, said in the loader's own words, and the caller decides
-  // whether it is this check's to enforce.
-  if (loaded.problems.length > 0) return { ok: false, problems: loaded.problems };
-
-  // The roster `amy init` writes beside the config, handed to the host plugin
-  // unread: the check mounts the machine, it does not judge the roster.
-  const roster: Roster = {
-    confirmedOn: "1970-01-01",
-    reviewers: [],
-    qa: { tracker: "", host: "", available: false },
-  };
+  const borrowed = borrowEnv(credentials);
+  // `loadEnv` only sets a name nothing had set, so the names it reports back
+  // are exactly the ones to unset again.
+  const fromFile = loadEnv(configRoot);
 
   // A state directory of its own, outside the checkout: the mount writes the
   // empty log a fresh install would have, and a check that littered the
@@ -155,22 +144,70 @@ export async function checkConfigBoots(configRoot: string): Promise<BootCheck> {
   // (L4.ROOT_FILES_ARE_DECLARED).
   const state = fs.mkdtempSync(path.join(os.tmpdir(), "amy-boot-check-"));
 
-  const outcome: MountOutcome = await mount(
-    [...loaded.plugins, hostPlugin(() => roster)],
-    pluginSlices(config, profile),
-    {
-      // A runner a boot never uses: registration wires the CLIs, the ladder
-      // is judged from the rungs' names, and the engine is built on the
-      // first tick. The real one shells out; this one is the real adapter
-      // and reaches nothing, because nothing here asks it to.
-      runner: new NodeCommandRunner(),
-      now: () => new Date(),
-      // The budget is read off a log at boot; an empty one is what a fresh
-      // install has.
-      log: new FileEventLog(path.join(state, "events"), () => new Date()),
-      paths: hostPaths(config, state),
-    },
-  );
+  // Everything borrowed above is given back below, on every path out. A check
+  // is an observation: run twice it answers the same, and the process it ran
+  // in is left as it was found — this one runs inside `amy doctor` and inside
+  // a test suite whose next case must not inherit its stand-in credential.
+  try {
+    const specs = pluginList(config, profile);
+    const loaded = await load(specs);
+    // Nothing below means anything if a named plugin is missing: that is an
+    // install problem, said in the loader's own words, and the caller decides
+    // whether it is this check's to enforce.
+    if (loaded.problems.length > 0) return { ok: false, problems: loaded.problems };
 
-  return outcome.ok ? { ok: true, problems: [] } : { ok: false, problems: outcome.problems };
+    // The roster `amy init` writes beside the config, handed to the host
+    // plugin unread: the check mounts the machine, it does not judge the roster.
+    const roster: Roster = {
+      confirmedOn: "1970-01-01",
+      reviewers: [],
+      qa: { tracker: "", host: "", available: false },
+    };
+
+    const outcome: MountOutcome = await mount(
+      [...loaded.plugins, hostPlugin(() => roster)],
+      pluginSlices(config, profile),
+      {
+        // A runner a boot never uses: registration wires the CLIs, the ladder
+        // is judged from the rungs' names, and the engine is built on the
+        // first tick. The real one shells out; this one is the real adapter
+        // and reaches nothing, because nothing here asks it to.
+        runner: new NodeCommandRunner(),
+        now: () => new Date(),
+        // The budget is read off a log at boot; an empty one is what a fresh
+        // install has.
+        log: new FileEventLog(path.join(state, "events"), () => new Date()),
+        paths: hostPaths(config, state),
+      },
+    );
+
+    return outcome.ok ? { ok: true, problems: [] } : { ok: false, problems: outcome.problems };
+  } finally {
+    fs.rmSync(state, { recursive: true, force: true });
+    restoreEnv(borrowed);
+    for (const key of fromFile) delete process.env[key];
+  }
+}
+
+/**
+ * Sets the names the mount needs and remembers what was there, so a caller can
+ * put the environment back exactly as it found it — including unsetting a name
+ * that was never set.
+ */
+function borrowEnv(values: Record<string, string>): Map<string, string | undefined> {
+  const before = new Map<string, string | undefined>();
+
+  for (const [key, value] of Object.entries(values)) {
+    before.set(key, process.env[key]);
+    if (process.env[key] === undefined) process.env[key] = value;
+  }
+
+  return before;
+}
+
+function restoreEnv(before: Map<string, string | undefined>): void {
+  for (const [key, value] of before) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
 }

--- a/packages/cli/src/config-template.ts
+++ b/packages/cli/src/config-template.ts
@@ -77,3 +77,100 @@ export function checkConfigTemplate(
 function named(at: string, key: string): string {
   return at ? `${at}.${key}` : key;
 }
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { mount, MountOutcome, NodeCommandRunner } from "@amykit/core";
+import { FileEventLog } from "@amykit/plugin-file-log";
+import type { Roster } from "@amykit/workflow-ticket-to-qa";
+import { EXAMPLE_CONFIG, loadConfigFrom } from "./config.js";
+import { loadEnv } from "./env.js";
+import { hostPlugin } from "./hostPlugin.js";
+import { load } from "./loader.js";
+import { profiles } from "./profiles.js";
+import { hostPaths, pluginList, pluginSlices } from "./slices.js";
+
+export interface BootCheck {
+  ok: boolean;
+  problems: string[];
+}
+
+/**
+ * Whether the config `amy init` writes is one that boots.
+ *
+ * The check above proves the file parses and names every setting; this proves
+ * the one thing that matters most: assembling it against the plugins it names
+ * produces a working host. Both syntax half and boot half live in one module
+ * because they are one claim about one file — `npm run check:config` runs
+ * them in that order, and the unit tests hold them side by side.
+ *
+ * Assembled against the build rather than parsed as text, so a template bug
+ * is caught by the same `mount` that will refuse it on somebody's laptop —
+ * there is no second interpretation of the config to drift apart.
+ */
+export async function checkConfigBoots(configRoot: string): Promise<BootCheck> {
+  // `amy init` writes the example; the loader reads it back the way any
+  // command would. Failures here are the parse half of the check, which is
+  // `checkConfigTemplate`'s to report — this is the boot half.
+  const config = loadConfigFrom(configRoot, EXAMPLE_CONFIG);
+
+  // The default profile is what a fresh install runs first, so it is the one
+  // whose mount the template has to guarantee. A second workflow's block is
+  // operator-edited config, not template text, and is somebody else's to
+  // refuse on the day it is added.
+  const profile = profiles(config)[config.defaultWorkflow] ?? Object.values(profiles(config))[0]!;
+  if (!profile) return { ok: false, problems: ["the template declares no workflow to drive"] };
+
+  // The working directory a real machine boots from, read the way every
+  // command reads it. What a fresh install starts without is the operator's
+  // first errand — `amy doctor` says FAIL and names the key — not a fault in
+  // the text `amy init` wrote, so a credential this machine has not been
+  // given yet is stood in for rather than reported as a template bug. Only
+  // when absent: a value already exported stays the one the check means.
+  const credentials: Record<string, string> = { LINEAR_API_KEY: "lin_api_boot-check" };
+  for (const [key, value] of Object.entries(credentials)) {
+    if (process.env[key] === undefined) process.env[key] = value;
+  }
+  loadEnv(process.cwd());
+
+  const specs = pluginList(config, profile);
+  const loaded = await load(specs);
+  // Nothing below means anything if a named plugin is missing: that is an
+  // install problem, said in the loader's own words, and the caller decides
+  // whether it is this check's to enforce.
+  if (loaded.problems.length > 0) return { ok: false, problems: loaded.problems };
+
+  // The roster `amy init` writes beside the config, handed to the host plugin
+  // unread: the check mounts the machine, it does not judge the roster.
+  const roster: Roster = {
+    confirmedOn: "1970-01-01",
+    reviewers: [],
+    qa: { tracker: "", host: "", available: false },
+  };
+
+  // A state directory of its own, outside the checkout: the mount writes the
+  // empty log a fresh install would have, and a check that littered the
+  // source tree would be a finding the next `sf check` would rightly report
+  // (L4.ROOT_FILES_ARE_DECLARED).
+  const state = fs.mkdtempSync(path.join(os.tmpdir(), "amy-boot-check-"));
+
+  const outcome: MountOutcome = await mount(
+    [...loaded.plugins, hostPlugin(() => roster)],
+    pluginSlices(config, profile),
+    {
+      // A runner a boot never uses: registration wires the CLIs, the ladder
+      // is judged from the rungs' names, and the engine is built on the
+      // first tick. The real one shells out; this one is the real adapter
+      // and reaches nothing, because nothing here asks it to.
+      runner: new NodeCommandRunner(),
+      now: () => new Date(),
+      // The budget is read off a log at boot; an empty one is what a fresh
+      // install has.
+      log: new FileEventLog(path.join(state, "events"), () => new Date()),
+      paths: hostPaths(config, state),
+    },
+  );
+
+  return outcome.ok ? { ok: true, problems: [] } : { ok: false, problems: outcome.problems };
+}

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -170,6 +170,21 @@ function expandHome(value: string): string {
   return value;
 }
 
+/**
+ * Parses one config document through the loader's own merge.
+ *
+ * `loadConfig` reads the file an install has; this reads the one `amy init`
+ * *would write* — the same words, from a string. The boot check assembles the
+ * template through this rather than through any second parser, because a
+ * template check that parsed the file differently from the machine would
+ * prove the wrong file.
+ */
+export function loadConfigFrom(root: string, text: string): AmyConfig {
+  const parsed = (yaml.parse(text) ?? {}) as Partial<AmyConfig>;
+
+  return fromParsed(root, parsed, () => root);
+}
+
 export function loadConfig(root: string): AmyConfig {
   const file = paths(root).config;
   if (!fs.existsSync(file)) {
@@ -178,6 +193,15 @@ export function loadConfig(root: string): AmyConfig {
 
   const parsed = (yaml.parse(fs.readFileSync(file, "utf-8")) ?? {}) as Partial<AmyConfig>;
 
+  return fromParsed(root, parsed, expandHome);
+}
+
+/** The merge behind both readers, so there is exactly one. */
+function fromParsed(
+  root: string,
+  parsed: Partial<AmyConfig>,
+  home: (value: string) => string,
+): AmyConfig {
   return {
     ...DEFAULT_CONFIG,
     ...parsed,
@@ -190,7 +214,7 @@ export function loadConfig(root: string): AmyConfig {
     agent: { ...DEFAULT_CONFIG.agent, ...(parsed.agent ?? {}) },
     plans: plansFrom(parsed.plans),
     errands: { policy: parsed.errands?.policy ?? {} },
-    workspaceRoot: expandHome(parsed.workspaceRoot ?? DEFAULT_CONFIG.workspaceRoot),
+    workspaceRoot: home(parsed.workspaceRoot ?? DEFAULT_CONFIG.workspaceRoot),
   };
 }
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -182,7 +182,7 @@ function expandHome(value: string): string {
 export function loadConfigFrom(root: string, text: string): AmyConfig {
   const parsed = (yaml.parse(text) ?? {}) as Partial<AmyConfig>;
 
-  return fromParsed(root, parsed, () => root);
+  return fromParsed(root, parsed);
 }
 
 export function loadConfig(root: string): AmyConfig {
@@ -193,15 +193,18 @@ export function loadConfig(root: string): AmyConfig {
 
   const parsed = (yaml.parse(fs.readFileSync(file, "utf-8")) ?? {}) as Partial<AmyConfig>;
 
-  return fromParsed(root, parsed, expandHome);
+  return fromParsed(root, parsed);
 }
 
-/** The merge behind both readers, so there is exactly one. */
-function fromParsed(
-  root: string,
-  parsed: Partial<AmyConfig>,
-  home: (value: string) => string,
-): AmyConfig {
+/**
+ * The merge behind both readers, so there is exactly one.
+ *
+ * No reader gets to bend a field on its way through: `loadConfigFrom` exists
+ * to read the same words the same way `loadConfig` does, and a `workspaceRoot`
+ * expanded here and substituted there would make the boot check prove a config
+ * no install has.
+ */
+function fromParsed(root: string, parsed: Partial<AmyConfig>): AmyConfig {
   return {
     ...DEFAULT_CONFIG,
     ...parsed,
@@ -214,7 +217,7 @@ function fromParsed(
     agent: { ...DEFAULT_CONFIG.agent, ...(parsed.agent ?? {}) },
     plans: plansFrom(parsed.plans),
     errands: { policy: parsed.errands?.policy ?? {} },
-    workspaceRoot: home(parsed.workspaceRoot ?? DEFAULT_CONFIG.workspaceRoot),
+    workspaceRoot: expandHome(parsed.workspaceRoot ?? DEFAULT_CONFIG.workspaceRoot),
   };
 }
 

--- a/packages/cli/tests/config-template.test.ts
+++ b/packages/cli/tests/config-template.test.ts
@@ -60,13 +60,15 @@ async function assembleTemplate(text: string): Promise<{ ok: boolean; problems: 
   const root = mkdtempSync(path.join(os.tmpdir(), "amy-template-"));
   const state = mkdtempSync(path.join(os.tmpdir(), "amy-template-state-"));
 
-  try {
-    // What a fresh install starts without is the operator's first errand —
-    // `amy doctor` says FAIL and names the key — not a fault in the text
-    // `amy init` wrote. A credential this machine has not been given yet is
-    // stood in for rather than reported as a template bug.
-    process.env.LINEAR_API_KEY ??= "lin_api_boot-check";
+  // What a fresh install starts without is the operator's first errand —
+  // `amy doctor` says FAIL and names the key — not a fault in the text
+  // `amy init` wrote. A credential this machine has not been given yet is
+  // stood in for rather than reported as a template bug, and given back below
+  // so the next case in this file inherits the machine it was run on.
+  const priorKey = process.env.LINEAR_API_KEY;
+  process.env.LINEAR_API_KEY ??= "lin_api_boot-check";
 
+  try {
     const config = loadConfigFrom(root, text);
     const profile = profiles(config)[config.defaultWorkflow] ?? Object.values(profiles(config))[0]!;
 
@@ -96,6 +98,8 @@ async function assembleTemplate(text: string): Promise<{ ok: boolean; problems: 
   } finally {
     rmSync(root, { recursive: true, force: true });
     rmSync(state, { recursive: true, force: true });
+    if (priorKey === undefined) delete process.env.LINEAR_API_KEY;
+    else process.env.LINEAR_API_KEY = priorKey;
   }
 }
 
@@ -104,10 +108,33 @@ describe("the machine the template describes", () => {
   // claim `checkConfigTemplate` could not make: that what `amy init` writes
   // runs — not that the file parses and names every setting.
   it("mounts with no problems", async () => {
-    const boot = await checkConfigBoots(mkdtempSync(path.join(os.tmpdir(), "amy-boot-")));
+    const root = mkdtempSync(path.join(os.tmpdir(), "amy-boot-"));
 
-    expect(boot.problems).toEqual([]);
-    expect(boot.ok).toBe(true);
+    try {
+      const boot = await checkConfigBoots(root);
+
+      expect(boot.problems).toEqual([]);
+      expect(boot.ok).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  // The check runs inside `amy doctor` and inside this suite, so it has to be
+  // an observation rather than a mutation: the stand-in credential it needs to
+  // mount is given back, and a machine that never had the key does not end up
+  // holding one.
+  it("leaves the environment as it found it", async () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "amy-boot-env-"));
+    const before = process.env.LINEAR_API_KEY;
+
+    try {
+      await checkConfigBoots(root);
+
+      expect(process.env.LINEAR_API_KEY).toBe(before);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it("turns red when the template's own budget window is one nothing meters", async () => {

--- a/packages/cli/tests/config-template.test.ts
+++ b/packages/cli/tests/config-template.test.ts
@@ -1,10 +1,19 @@
 import { describe, it, expect } from "vitest";
 import yaml from "yaml";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { mount, NodeCommandRunner } from "@amykit/core";
+import { FileEventLog } from "@amykit/plugin-file-log";
 import { DEFAULT_POLICY as ERRAND_POLICY } from "@amykit/workflow-errand";
 import { DEFAULT_POLICY as PLAN_POLICY } from "@amykit/workflow-note-to-plan";
-import { DEFAULT_POLICY as TICKET_POLICY } from "@amykit/workflow-ticket-to-qa";
-import { DEFAULT_CONFIG, EXAMPLE_CONFIG } from "../src/config.js";
-import { SettingsSurface, checkConfigTemplate } from "../src/config-template.js";
+import { DEFAULT_POLICY as TICKET_POLICY, Roster } from "@amykit/workflow-ticket-to-qa";
+import { DEFAULT_CONFIG, EXAMPLE_CONFIG, loadConfigFrom } from "../src/config.js";
+import { checkConfigBoots, SettingsSurface, checkConfigTemplate } from "../src/config-template.js";
+import { hostPlugin } from "../src/hostPlugin.js";
+import { load } from "../src/loader.js";
+import { profiles } from "../src/profiles.js";
+import { hostPaths, pluginList, pluginSlices } from "../src/slices.js";
 
 interface TemplateShape {
   policy?: object;
@@ -36,6 +45,88 @@ describe("the config amy init writes", () => {
 
   it("names the backoff a poke exists to collapse", () => {
     expect(EXAMPLE_CONFIG).toContain("pollBackoffMs");
+  });
+});
+
+/**
+ * The boot half, against the real plugins, over a text the caller controls.
+ *
+ * `checkConfigBoots` reads the shipped constant; the negative cases need the
+ * same assembly over a mutated one. One duplication, deliberate: going
+ * through the production function would mean production growing a second
+ * entry point that only a test ever passes text to.
+ */
+async function assembleTemplate(text: string): Promise<{ ok: boolean; problems: string[] }> {
+  const root = mkdtempSync(path.join(os.tmpdir(), "amy-template-"));
+  const state = mkdtempSync(path.join(os.tmpdir(), "amy-template-state-"));
+
+  try {
+    // What a fresh install starts without is the operator's first errand —
+    // `amy doctor` says FAIL and names the key — not a fault in the text
+    // `amy init` wrote. A credential this machine has not been given yet is
+    // stood in for rather than reported as a template bug.
+    process.env.LINEAR_API_KEY ??= "lin_api_boot-check";
+
+    const config = loadConfigFrom(root, text);
+    const profile = profiles(config)[config.defaultWorkflow] ?? Object.values(profiles(config))[0]!;
+
+    const loaded = await load(pluginList(config, profile));
+    if (loaded.problems.length > 0) return { ok: false, problems: loaded.problems };
+
+    // The roster `amy init` writes beside the config, handed over unread:
+    // this check mounts the machine, it does not judge the roster.
+    const roster: Roster = {
+      confirmedOn: "1970-01-01",
+      reviewers: [],
+      qa: { tracker: "", host: "", available: false },
+    };
+
+    const outcome = await mount(
+      [...loaded.plugins, hostPlugin(() => roster)],
+      pluginSlices(config, profile),
+      {
+        runner: new NodeCommandRunner(),
+        now: () => new Date(),
+        log: new FileEventLog(path.join(state, "events"), () => new Date()),
+        paths: hostPaths(config, state),
+      },
+    );
+
+    return outcome.ok ? { ok: true, problems: [] } : { ok: false, problems: outcome.problems };
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+    rmSync(state, { recursive: true, force: true });
+  }
+}
+
+describe("the machine the template describes", () => {
+  // The shipped example, assembled against the plugins it names. This is the
+  // claim `checkConfigTemplate` could not make: that what `amy init` writes
+  // runs — not that the file parses and names every setting.
+  it("mounts with no problems", async () => {
+    const boot = await checkConfigBoots(mkdtempSync(path.join(os.tmpdir(), "amy-boot-")));
+
+    expect(boot.problems).toEqual([]);
+    expect(boot.ok).toBe(true);
+  });
+
+  it("turns red when the template's own budget window is one nothing meters", async () => {
+    // The shape a rename across packages takes: a window this build's relay
+    // has never heard of. Parsed, named, well-formed — and refused at mount.
+    const boot = await assembleTemplate(EXAMPLE_CONFIG.replace("perFiveHours", "perDay"));
+
+    expect(boot.ok).toBe(false);
+    expect(boot.problems.join("\n")).toContain("perDay");
+  });
+
+  it("turns red when the ladder names a harness nothing contributes", async () => {
+    // A harness name is a mount decision — naming `claude` is what mounts
+    // the claude plugin's rungs — so a harness that is not one is refused
+    // rather than quietly dropped, ladder shorter than the operator believes.
+    const boot = await assembleTemplate(EXAMPLE_CONFIG.replace("claude:sonnet", "clade:sonnet"));
+
+    expect(boot.ok).toBe(false);
+    expect(boot.problems.join("\n")).toContain("clade:sonnet");
   });
 });
 

--- a/scripts/check-config-template.mjs
+++ b/scripts/check-config-template.mjs
@@ -52,3 +52,23 @@ if (problems.length > 0) {
 }
 
 console.log("config template: parses, and names every setting");
+
+// The second half of the claim, and the one that matters most: assembling the
+// config `amy init` writes, against the plugins it names, boots. The syntax
+// half above can pass while the machine it describes is refused at mount —
+// which is how the shipped template's own ladder example was found, on a real
+// install, after the file had been provably well-formed for its whole life.
+const { checkConfigBoots } = await built("packages/cli/dist/config-template.js");
+const boot = await checkConfigBoots(repo);
+
+if (!boot.ok) {
+  console.error("\nThe config `amy init` writes does not boot:\n");
+  for (const problem of boot.problems) console.error(`  ${problem}`);
+  console.error(
+    "\nA fresh install would be refused at its first command. " +
+      "Fix the template in packages/cli/src/config.ts, or the mount that refuses it.",
+  );
+  process.exit(1);
+}
+
+console.log("config template: the machine it writes mounts");


### PR DESCRIPTION
Implements [plans/the-config-amy-writes-must-boot.md](plans/the-config-amy-writes-must-boot.md).

EXAMPLE_CONFIG shipped `claude:opus` in the default ladder and again in a step's own. `everyLadderEntry` unions them without deduping, so `contributeTiers` contributed a second agent named `claude:opus` and the collection's one-name rule refused the mount: `amy init` wrote a config its own first `amy doctor` refused.

- `contributeTiers` dedupes the models it is given, keeping first-seen order, so a rung named twice mounts once
- `check:config` grows the claim it was always about: it now assembles the config `amy init` writes — the same load, pluginList and mount a real boot runs — and refuses a template whose machine does not start (`checkConfigBoots`, beside the syntax half it extends)
- the unit tests prove both directions: the shipped example mounts, and a template whose budget window nothing meters, or whose ladder names a harness nothing contributes, turns the check red
- the relay's gate carries the proof against the built plugins: `relay.a_rung_named_twice_mounts_once` and `relay.the_first_mention_sets_the_order`
- e2e scenarios re-run and evidence resealed (digests had drifted with the machine they ran on)

Verification: 1020 unit tests green, `npm run gate` green (33/33 rules), `npm run e2e` green across all seven scenarios.