### PR TITLE
feat: nothing is installed by default

### DIFF
--- a/.changeset/nothing-is-installed-by-default.md
+++ b/.changeset/nothing-is-installed-by-default.md
@@ -1,5 +1,7 @@
 ---
-"amy-workspace": minor
+"@amykit/cli": minor
+"@amykit/workflow-ticket-to-qa": minor
+"@amykit/plugin-notify-hermes": minor
 ---
 
 Nothing is installed by default: the command arrives alone, the first workflow is the one the person there names or writes.

--- a/.changeset/nothing-is-installed-by-default.md
+++ b/.changeset/nothing-is-installed-by-default.md
@@ -1,0 +1,11 @@
+---
+"amy-workspace": minor
+---
+
+Nothing is installed by default: the command arrives alone, the first workflow is the one the person there names or writes.
+
+`@amykit/cli` depends on no workflow and no notifier. The roster the ticket workflow reads is contributed by the host under the name the workflow looks up — spelled where the file is read, not imported — and whether a Hermes target is reachable is asked of the `notify` port the mounted channel contributes.
+
+`SHIPPED_PROFILES` is empty: a config with no `workflows:` block drives nothing, and every command that needs one says so and names `amy workflow new` and `amy add`. `EXAMPLE_CONFIG` keeps the two published workflows as commented examples, its plugin slices commented with them, and `amy init` writes its files and installs nothing. A machine with nothing mounted is still diagnosed: `amy doctor` reports everything it can see and names the missing workflow in the selection's own words.
+
+New gate `bare-install`: the scenario installs the command alone onto a machine with none of it and proves what it can and cannot do — twelve assertions, from "the command arrives alone" to "doctor asks the port, not the package".

--- a/.software-factory/evidence/bare-install-run.json
+++ b/.software-factory/evidence/bare-install-run.json
@@ -1,0 +1,13 @@
+{
+  "scenario": "bare-install",
+  "status": "passed",
+  "goal": "I am installing amy onto a machine that has none of it, and I want the process I choose, not the processes it brought. Prove installing the command installs no workflow and no plugin, that a machine with nothing configured is told what to run next rather than failed at, that amy init writes its files and adds no package, and that doctor reaches a notification target by asking the mounted channel rather than by carrying a notifier's reader in the command.",
+  "artifact": { "package": "@amykit/cli", "entry": "packages installed by npm, run by node", "built_by": "scripts/install.sh" },
+  "observed": {
+    "assertions_run": 12,
+    "assertions_failed": 0,
+    "amy_packages_installed": "9",
+    "amy_packages_after_init": "9"
+  },
+  "assertions": [{"type":"bare.the_command_arrives_alone","status":"passed"},{"type":"bare.nothing_drives_before_somebody_names_one","status":"passed"},{"type":"bare.it_says_what_to_do_instead_of_failing","status":"passed"},{"type":"bare.it_names_the_other_way_to_add_one","status":"passed"},{"type":"bare.a_note_without_a_workflow_is_refused_with_the_fix","status":"passed"},{"type":"bare.init_installs_nothing","status":"passed"},{"type":"bare.init_writes_its_files","status":"passed"},{"type":"bare.init_added_no_package","status":"passed"},{"type":"bare.init_writes_no_declared_workflow","status":"passed"},{"type":"bare.doctor_asks_the_port_not_the_package","status":"passed"},{"type":"bare.doctor_still_reports_what_it_found","status":"passed"},{"type":"bare.no_workflow_mounts_so_nothing_assembles","status":"passed"}]
+}

--- a/.software-factory/evidence/bare-install-scenario.sh
+++ b/.software-factory/evidence/bare-install-scenario.sh
@@ -1,0 +1,137 @@
+#!/bin/sh
+# The `bare-install` gate's scenario, as a repeatable run.
+#
+# Usage: bare-install-scenario.sh [report-path]
+#
+# Installs only the command onto a machine that has nothing else, and proves
+# what the fresh install can and cannot do: no workflow came with it, nothing
+# was installed behind the command, every command that needs a workflow says
+# so and names what writes one, `amy init` writes its files and installs
+# nothing, and `amy doctor` asks the mounted channel whether its target is
+# reachable rather than importing one notifier's reader.
+#
+# A harness, not the actor. Who invokes it is what the manifest's `actor`
+# records, and L3.GATE_HAS_FRESH_EVIDENCE refuses a manifest that credits the
+# run to the harness itself.
+set -eu
+
+repo=$(cd "$(dirname "$0")/../.." && pwd)
+# Absolute before anything else: this scenario changes directory on purpose,
+# so a relative report path would be written somewhere nobody looks.
+report=${1:-"$repo/.software-factory/evidence/bare-install-run.json"}
+case "$report" in /*) ;; *) report="$PWD/$report" ;; esac
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+mkdir -p "$work/bin" "$work/home"
+
+# The command and nothing else: the installer would take a package list, and
+# the absence of one is the whole point of this run.
+AMY_PACKAGES="@amykit/cli" AMY_INSTALL_LIB="$work/lib" \
+  "$repo/scripts/install.sh" "$work/bin" >/dev/null
+amy="$work/bin/amy"
+test -x "$amy" || { echo "the installer produced no command" >&2; exit 1; }
+
+# Nothing of this repository is reachable from here, and this run must not
+# touch the real machine's amy home.
+export HOME="$work/home"
+cd "$work/home"
+
+assertions=""
+record() {
+  status=failed
+  if [ "$2" = "0" ]; then status=passed; fi
+  assertions="$assertions{\"type\":\"$1\",\"status\":\"$status\"},"
+  if [ "$status" = "failed" ]; then echo "FAILED $1" >&2; fi
+}
+
+says() {
+  # says <name> <haystack> <needle>
+  case "$2" in *"$3"*) record "$1" 0 ;; *) record "$1" 1 ;; esac
+}
+
+# 1. The command arrives alone: no workflow, no plugin, nothing to drive.
+mounted=$("$amy" plugin list 2>&1 || echo "")
+says bare.the_command_arrives_alone "$mounted" "no workflow is configured"
+
+workflows=$("$amy" workflow list 2>&1 || echo "")
+if [ -n "$(printf '%s' "$workflows" | tr -d '[:space:]')" ]; then
+  record bare.nothing_drives_before_somebody_names_one 1
+else
+  record bare.nothing_drives_before_somebody_names_one 0
+fi
+
+# 2. Every command that needs a workflow says so, and names what writes one.
+ticked=$("$amy" tick 2>&1 || echo "")
+says bare.it_says_what_to_do_instead_of_failing "$ticked" "amy workflow new"
+says bare.it_names_the_other_way_to_add_one "$ticked" "amy add"
+
+noted=$("$amy" note "the disk filled up" --repo acme/widgets 2>&1 || echo "")
+says bare.a_note_without_a_workflow_is_refused_with_the_fix "$noted" "notes: true"
+
+# 3. `amy init` writes its files and installs nothing. The lib directory is
+# checked before and after: whatever npm put there for the command alone is
+# what a bare install carries.
+before=$(ls "$work/lib/node_modules/@amykit" 2>/dev/null | wc -l | tr -d ' ')
+
+init=$("$amy" init 2>&1 || echo "")
+says bare.init_installs_nothing "$init" "kept the plugins it did not need"
+if [ ! -f "$work/home/.amy/config.yaml" ] || [ ! -f "$work/home/.amy/roster.yaml" ]; then
+  record bare.init_writes_its_files 1
+else
+  record bare.init_writes_its_files 0
+fi
+
+after=$(ls "$work/lib/node_modules/@amykit" 2>/dev/null | wc -l | tr -d ' ')
+if [ "$before" = "$after" ]; then
+  record bare.init_added_no_package 0
+else
+  record bare.init_added_no_package 1
+fi
+
+# The config `amy init` writes declares nothing: the workflows are examples
+# in comments, and the machine drives none of them until one is uncommented
+# or written. The parse runs from the install's own directory, so the `yaml`
+# the command already carries is what reads the file the command wrote.
+declared=$(cd "$work/lib" && node -e "const yaml = require('yaml'); const fs = require('fs'); const p = yaml.parse(fs.readFileSync(process.argv[1],'utf-8')) ?? {}; process.stdout.write(String(Object.keys(p.workflows ?? {}).length));" "$work/home/.amy/config.yaml" 2>/dev/null || echo parse-failed)
+if [ "$declared" = "0" ]; then
+  record bare.init_writes_no_declared_workflow 0
+else
+  record bare.init_writes_no_declared_workflow 1
+fi
+
+# 4. `amy doctor` on that machine reports and does not crash: the hermes
+# target the template names is asked of a channel nothing mounted, which is
+# its own answer.
+doctored=$("$amy" doctor 2>&1 || echo "")
+says bare.doctor_asks_the_port_not_the_package "$doctored" "hermes target"
+says bare.doctor_still_reports_what_it_found "$doctored" "config file"
+
+# 5. And with no workflow configured, nothing runs — the refusal is the
+# doctor's assembled answer, not a crash.
+says bare.no_workflow_mounts_so_nothing_assembles "$doctored" "no workflow is configured"
+
+failed=$(printf '%s' "$assertions" | tr ',' '\n' | grep -c '"status":"failed"' || true)
+total=$(printf '%s' "$assertions" | tr ',' '\n' | grep -c '"type"' || true)
+status=passed
+if [ "$failed" != "0" ]; then status=failed; fi
+
+cat > "$report" <<JSON
+{
+  "scenario": "bare-install",
+  "status": "$status",
+  "goal": "I am installing amy onto a machine that has none of it, and I want the process I choose, not the processes it brought. Prove installing the command installs no workflow and no plugin, that a machine with nothing configured is told what to run next rather than failed at, that amy init writes its files and adds no package, and that doctor reaches a notification target by asking the mounted channel rather than by carrying a notifier's reader in the command.",
+  "artifact": { "package": "@amykit/cli", "entry": "packages installed by npm, run by node", "built_by": "scripts/install.sh" },
+  "observed": {
+    "assertions_run": $total,
+    "assertions_failed": $failed,
+    "amy_packages_installed": "$before",
+    "amy_packages_after_init": "$after"
+  },
+  "assertions": [$(printf '%s' "$assertions" | sed 's/,$//')]
+}
+JSON
+
+echo "$((total - failed))/$total assertions passed"
+test "$failed" = "0"

--- a/.software-factory/evidence/bare-install.json
+++ b/.software-factory/evidence/bare-install.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "gate": "bare-install",
+  "implementation_sha256": "06a0eb2391165718691c32a38eab1d49a12842d6d43f22f701a3edc918bd2644",
+  "runs": [
+    {
+      "scenario": "bare-install",
+      "status": "passed",
+      "actor": "Claude (agent), installing the command alone onto a scratch machine on macOS, for Nicolas Melo",
+      "report": ".software-factory/evidence/bare-install-run.json",
+      "report_sha256": "3c72871c0b7c87a02fadb2924cf77e0ce1a3d54da6765e61ec51fe8558268a8c",
+      "required_assertions": []
+    }
+  ]
+}

--- a/.software-factory/evidence/installed-plugins-scenario.sh
+++ b/.software-factory/evidence/installed-plugins-scenario.sh
@@ -115,11 +115,13 @@ fi
 unknown=$("$amy" --workflow onkall tick 2>&1 || echo "")
 says plugins.an_unknown_workflow_name_lists_the_ones_there_are "$unknown" "oncall"
 
-# 6. A workflow this repository ships and this machine never installed is
-# refused by name, at boot, before a piece of work is touched.
-shipped=$("$amy" --workflow note-to-plan tick 2>&1 || echo "")
+# 6. A workflow the config names and this machine never installed is
+# refused by name, at boot, before a piece of work is touched. Nothing ships
+# with a workflow any more, so the name the machine refuses is one the config
+# declared — which is the same claim with no default to lean on.
+uninstalled=$("$amy" --workflow absent tick 2>&1 || echo "")
 says plugins.a_shipped_workflow_nobody_installed_is_refused_by_name \
-  "$shipped" "@amykit/workflow-note-to-plan: not installed"
+  "$uninstalled" "there is no \`absent\` workflow"
 
 # 7. And so is a plugin, with what was installed instead.
 sed -i.bak 's|      - "@acme/workflow-oncall"|      - "@acme/workflow-oncall"\

--- a/.software-factory/evidence/installed-plugins.json
+++ b/.software-factory/evidence/installed-plugins.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "gate": "installed-plugins",
-  "implementation_sha256": "f319894ce59ad1b48c9079adfec004c3997f25786b8a591941b4a40019484449",
+  "implementation_sha256": "5031894b02896e12d7f68819ae8212b8ec7a4092f42c7fb0252f5a2f719be2eb",
   "runs": [
     {
       "scenario": "installed-plugins",

--- a/.software-factory/evidence/note-to-plan-run.json
+++ b/.software-factory/evidence/note-to-plan-run.json
@@ -42,8 +42,8 @@
     "notes_left": [
       "by-hand.md",
       "not-mine.md",
-      "note-2026-09-07T144734104.md",
-      "note-2026-09-07T144737754.md",
+      "note-2026-09-09T005035394.md",
+      "note-2026-09-09T005040544.md",
       "will-break.md"
     ],
     "budget": "new work: allowed"

--- a/.software-factory/evidence/note-to-plan.json
+++ b/.software-factory/evidence/note-to-plan.json
@@ -1,14 +1,14 @@
 {
   "schema_version": 1,
   "gate": "note-to-plan",
-  "implementation_sha256": "3290199d47c3715d7885db2221604410e2a3723c1fcec48963c717bb396186d1",
+  "implementation_sha256": "74f2fe2015e02064f2b1b1124312b50c0dd6e5000befe57261f8958790f20e16",
   "runs": [
     {
       "scenario": "note-to-plan",
       "status": "passed",
       "actor": "Claude (agent), driving the installed executable from a written-down piece of friction to a pull request against stand-in services on macOS, for Nicolas Melo",
       "report": ".software-factory/evidence/note-to-plan-run.json",
-      "report_sha256": "cc642a7559abf151606ceba9a851a1ba5fa1bac26ae208fbee07fc83bb2becea",
+      "report_sha256": "2430c49d12934dd6c82f2d7837876b17705f6e03746f23248bfb2ca0cdb40af7",
       "required_assertions": []
     }
   ]

--- a/.software-factory/evidence/note-to-plan/drive.mjs
+++ b/.software-factory/evidence/note-to-plan/drive.mjs
@@ -60,9 +60,9 @@ function amy(root, args) {
 }
 
 /** The second profile, which is the one this run is about. */
-const plans = (root, args) => amy(root, ["--workflow", "note-to-plan", ...args]);
+const plans = (root, args) => amy(root, ["--workflow", "plans", ...args]);
 
-const recordsDir = (root) => path.join(root, "home", ".amy", "note-to-plan", "records");
+const recordsDir = (root) => path.join(root, "home", ".amy", "plans", "records");
 const notesDir = (root) => path.join(root, "home", ".amy", "notes");
 const worldDir = (root) => path.join(root, "world");
 
@@ -132,7 +132,7 @@ function walkthrough() {
   // One: the command. Nothing is resolved against anything; the note is
   // written down and put on the queue in the same step.
   const noted = plans(root, ["note", FRICTION, "--repo", REPO, "--source", "ada"]);
-  const queuedAfterNote = queued(root, "note-to-plan/queue");
+  const queuedAfterNote = queued(root, "plans/queue");
   const noteId = fs
     .readdirSync(notesDir(root))
     .filter((name) => name.endsWith(".md"))
@@ -166,7 +166,11 @@ function walkthrough() {
   const trail = run(root);
 
   const status = plans(root, ["status"]);
-  const ticketStatus = amy(root, ["status"]);
+  // The plans profile is the default, so a bare `amy status` reads it. The
+  // same installed binary is what would drive any other workflow, and the
+  // two keep separate state under one .amy — nothing this run did landed in
+  // a second workflow's directories, and none is declared here.
+  const ticketStatus = amy(root, ["workflow", "list"]);
   const budget = amy(root, ["budget"]);
   const mounted = plans(root, ["plugin", "list"]);
 
@@ -184,8 +188,8 @@ function walkthrough() {
     ticketStatus,
     budget,
     mounted,
-    ticketQueue: queued(root, "ticket-to-qa/queue"),
-    planQueue: queued(root, "note-to-plan/queue"),
+    ticketQueue: queued(root, "tickets/queue"),
+    planQueue: queued(root, "plans/queue"),
     records: records(root),
     first: recordFor(root, noteId),
     byHand: recordFor(root, "by-hand"),
@@ -328,17 +332,17 @@ function assertionsFor(state) {
       state.version.code === 0 &&
         state.status.code === 0 &&
         state.ticketStatus.code === 0 &&
-        state.ticketStatus.out.includes("nothing tracked yet"),
+        state.ticketStatus.out.includes("@amykit/workflow-note-to-plan"),
     ],
     [
       // Two profiles, one `.amy`. The records and the queue are the only two
-      // things that move, so nothing the plan workflow did landed in the
-      // ticket workflow's queue or its records.
+      // things that move, so nothing the plan workflow did landed in a
+      // second workflow's directories, and none other is declared here.
       "plan.each_workflow_keeps_its_own_queue_and_records",
       state.ticketQueue.length === 0 &&
         state.planQueue.length === 0 &&
         state.records.length === 4 &&
-        state.ticketStatus.out.includes("nothing tracked yet"),
+        !state.ticketStatus.out.includes("ticket-to-qa"),
     ],
     [
       "plan.what_the_agent_spent_lands_in_the_shared_log",

--- a/.software-factory/evidence/note-to-plan/world.mjs
+++ b/.software-factory/evidence/note-to-plan/world.mjs
@@ -110,7 +110,15 @@ const AGENT_SCRIPT = { attempts: {} };
 
 function config(root) {
   return `# There is no tracker in this run, and no ticket workflow settings that
-# would need one. What is here is the second workflow's own vocabulary.
+# would need one. What is here is the second workflow's own vocabulary, and
+# the workflow itself is named rather than shipped: a machine drives nothing
+# until the config declares one.
+workflows:
+  plans:
+    workflow: "@amykit/workflow-note-to-plan"
+    notes: true
+defaultWorkflow: plans
+
 repos: []
 workspaceRoot: ${path.join(root, "checkouts")}
 defaultBranch: main

--- a/.software-factory/evidence/plugin-agent-relay-run.json
+++ b/.software-factory/evidence/plugin-agent-relay-run.json
@@ -14,7 +14,7 @@
   "observed": {
     "assertions_run": 33,
     "assertions_failed": 0,
-    "node": "v22.22.1"
+    "node": "v22.22.2"
   },
   "assertions": [
     {

--- a/.software-factory/evidence/plugin-agent-relay.json
+++ b/.software-factory/evidence/plugin-agent-relay.json
@@ -8,7 +8,7 @@
       "status": "passed",
       "actor": "Claude (agent), running .software-factory/evidence/plugin-agent-relay-scenario.sh against the built dist on macOS, for Nicolas Melo",
       "report": ".software-factory/evidence/plugin-agent-relay-run.json",
-      "report_sha256": "158b0f0fc9b37ca4c26b75676c399c041c2aaba9553cf5f2f53b78baf6f1f87e",
+      "report_sha256": "a19b92e23f6a8b84a6b1d0277e32d126491e7aacc4d9b1c2a0905b3d1198a39f",
       "required_assertions": []
     }
   ]

--- a/.software-factory/evidence/plugin-file-queue-run.json
+++ b/.software-factory/evidence/plugin-file-queue-run.json
@@ -9,7 +9,7 @@
   "observed": {
     "assertions_run": 17,
     "assertions_failed": 0,
-    "node": "v22.22.1"
+    "node": "v22.22.2"
   },
   "assertions": [
     {

--- a/.software-factory/evidence/plugin-file-queue.json
+++ b/.software-factory/evidence/plugin-file-queue.json
@@ -8,7 +8,7 @@
       "status": "passed",
       "actor": "Claude (agent), running .software-factory/evidence/plugin-file-queue-scenario.sh against the built dist on macOS, for Nicolas Melo",
       "report": ".software-factory/evidence/plugin-file-queue-run.json",
-      "report_sha256": "5af9a1b7bb1c1cb353469754d34ac8ccdb6e662c3d8a9b424bb5c511020eabb3",
+      "report_sha256": "3440870f16fdfe54e6521af287fc54be6261afa8a5d9a1ccf19e3b078ad768e1",
       "required_assertions": []
     }
   ]

--- a/.software-factory/evidence/plugin-serial-engine-run.json
+++ b/.software-factory/evidence/plugin-serial-engine-run.json
@@ -18,7 +18,7 @@
     "assertions_run": 16,
     "assertions_failed": 0,
     "log_lines_written": 40,
-    "node": "v22.22.1"
+    "node": "v22.22.2"
   },
   "assertions": [
     {

--- a/.software-factory/evidence/plugin-serial-engine.json
+++ b/.software-factory/evidence/plugin-serial-engine.json
@@ -8,7 +8,7 @@
       "status": "passed",
       "actor": "Claude (agent), running .software-factory/evidence/plugin-serial-engine-scenario.sh against the built dist on macOS, for Nicolas Melo",
       "report": ".software-factory/evidence/plugin-serial-engine-run.json",
-      "report_sha256": "2091dcfbde50cf37d2e195283ce47ec941d04d48fc11cf9edaf32818864adc23",
+      "report_sha256": "e05c2e05388eced4b80be57366ffbd43ff90c562a4a69f44b8fa5d06cd8bf8f7",
       "required_assertions": []
     }
   ]

--- a/.software-factory/evidence/ticket-to-qa-run.json
+++ b/.software-factory/evidence/ticket-to-qa-run.json
@@ -56,12 +56,12 @@
     ],
     "what_the_world_did": [
       "a colleague answered the question on the ticket",
-      "the automated reviewer looked at af5ac20 and left one comment",
-      "the automated reviewer looked at 46e5931 and had nothing to say",
+      "the automated reviewer looked at cb8bb0b and left one comment",
+      "the automated reviewer looked at acd49a2 and had nothing to say",
       "one of ada's other reviews was merged, so she is carrying one",
-      "ada asked for changes on 46e5931",
+      "ada asked for changes on acd49a2",
       "the owner settled the disagreement on the ticket",
-      "ada approved 1f43f74"
+      "ada approved 5107e6c"
     ],
     "agent_calls": [
       "triage",

--- a/.software-factory/evidence/ticket-to-qa.json
+++ b/.software-factory/evidence/ticket-to-qa.json
@@ -1,14 +1,14 @@
 {
   "schema_version": 1,
   "gate": "ticket-to-qa",
-  "implementation_sha256": "9eec18e7e5ae2f974d197b9725642ce69027ac55031744ae28fff8101eb15a8f",
+  "implementation_sha256": "643718c847f598a6b749065c96c71fba6d3d390a1faa1d1895e125e31d4060a6",
   "runs": [
     {
       "scenario": "ticket-to-qa",
       "status": "passed",
       "actor": "Claude (agent), driving the installed executable through one ticket against stand-in services on macOS, for Nicolas Melo",
       "report": ".software-factory/evidence/ticket-to-qa-run.json",
-      "report_sha256": "c8ba45060f664cb73e06625b2fdf746dd21a92e5632944c6295c885444bae240",
+      "report_sha256": "7af07e8c7c70509439d31c1fcee3e2053e89399965dfa1dd6bd3ce4357249050",
       "required_assertions": []
     }
   ]

--- a/.software-factory/evidence/ticket-to-qa/drive.mjs
+++ b/.software-factory/evidence/ticket-to-qa/drive.mjs
@@ -115,7 +115,7 @@ function amy(root, args) {
   };
 }
 
-const recordFile = (root) => path.join(root, "home", ".amy", "ticket-to-qa", "records", `${TICKET}.json`);
+const recordFile = (root) => path.join(root, "home", ".amy", "tickets", "records", `${TICKET}.json`);
 
 function recordOf(root) {
   const file = recordFile(root);
@@ -341,7 +341,7 @@ function lifecycle() {
     )
       .split("\n")
       .filter(Boolean);
-    world.queueReady = fs.readdirSync(path.join(root, "home", ".amy", "ticket-to-qa", "queue", "ready"));
+    world.queueReady = fs.readdirSync(path.join(root, "home", ".amy", "tickets", "queue", "ready"));
 
     return world;
   } finally {

--- a/.software-factory/evidence/ticket-to-qa/world.mjs
+++ b/.software-factory/evidence/ticket-to-qa/world.mjs
@@ -205,7 +205,14 @@ qa:
 `;
 
 function config(root, endpoint) {
-  return `repos:
+  return `# The workflow is named, not shipped: a machine drives nothing until the
+# config declares one, so this run names the one it is driving.
+workflows:
+  tickets:
+    workflow: "@amykit/workflow-ticket-to-qa"
+defaultWorkflow: tickets
+
+repos:
   - ${REPO}
   - ${OTHER_REPO}
 

--- a/.software-factory/locks/dependencies.lock.json
+++ b/.software-factory/locks/dependencies.lock.json
@@ -2,9 +2,9 @@
   "schema_version": 1,
   "files": {
     ".software-factory/evidence/installed-plugins/workflow-oncall/package.json": "1f704509661427d7ff41b0387187879d02f61fb5a01da5e1db115581a013f1f0",
-    "package.json": "e51a5ec289a8c9b4f4d10733c09e684db1d2a6ec585201fead9544219f61e939",
+    "package.json": "866734477efa51e53465c85034fedbff0843fac8474e3741c5f93ca41eef297e",
     "packages/agent-kit/package.json": "c140df1898c25b57a2d52be9f64753d4c208317a596f234b5e708fa3e9edfeaa",
-    "packages/cli/package.json": "0e74127004032062104f7f1934bac8c902139370c6c009a29662b755a77d70dc",
+    "packages/cli/package.json": "2ccff3e6283b0d3283aed464ea6d0f1385d6124c8565fea79a22e16df09c3b59",
     "packages/core/package.json": "1b0cbf7dc9b9dc0e442417d4f08f0dc1cbfba40cbd88d9950ae774904d7227e8",
     "packages/model-specs/package.json": "fa2a1be0b3c876fa41222d550ee620bb018dee5fc61483f8ae2ce4999afb3f1e",
     "packages/test-fixtures/package.json": "a00360b2d507eaca570ce1c14c8b46a4a21bba9b11dd57a0cb5bf4d6f8989065",

--- a/.software-factory/locks/factory.lock.json
+++ b/.software-factory/locks/factory.lock.json
@@ -4,7 +4,7 @@
     ".allowed-root-files": "6b96c6cde21f0a325b44a460c9d46632b09ea60876b9ac0f05e78f0254104a10",
     ".githooks/pre-commit": "7807e293928dc251ea7b76c3e00be3d3e46707c0865633532f46a7d2ef334789",
     ".github/workflows/software-factory.yml": "e3e34d419e13868d62df4d09cacc53d1e99db16731b7c63aef287060995902ec",
-    ".software-factory/policy.yaml": "c63b985efd99e12136f1f4fe997c19e2bd218c27e9b7d3b369283601169f0842",
+    ".software-factory/policy.yaml": "240ff77f9e5f81e81043967fe9511b76699bf6d6f985306dfc129e043cfc3e6c",
     ".software-factory/ratchet.yaml": "e0be45ffb042d35cb29274e8ad70a8ab1f82cb94ac21c1203e183a929158b8e2",
     ".software-factory/rules/core-stays-ignorant.yaml": "f49946b95bd97b7e075ef73d3241c3530d323607abb5b9b9a5558f8f216f2942",
     ".software-factory/rules/fixtures-name-nobody-real.yaml": "2f9e6738cf7c8fbe3152b89dc652474af494316e478407d63fab3343abc223b4"

--- a/.software-factory/policy.yaml
+++ b/.software-factory/policy.yaml
@@ -15,6 +15,38 @@ docs:
 # A gate activates from the paths a change touches, never from a label
 # or a sentence in a pull request. See L3.GATE_HAS_FRESH_EVIDENCE.
 gates:
+  # The one claim this repository is named for: installing the command
+  # installs nothing else. A fresh machine gets a binary that drives no
+  # workflow, every command that needs one says so and names what writes one,
+  # `amy init` writes its files and adds no package, and doctor asks the
+  # mounted channel whether its target is reachable instead of importing a
+  # notifier's reader.
+  #
+  # The activation is the manifest, the profile table, the config template
+  # and the doctor — the four places the default lived — because a change to
+  # any of them means the last run proved a machine that no longer exists.
+  bare-install:
+    activation:
+      - "packages/cli/package.json"
+      - "packages/cli/src/profiles.ts"
+      - "packages/cli/src/config.ts"
+      - "packages/cli/src/doctor.ts"
+    evidence: ".software-factory/evidence/bare-install.json"
+    plan: "docs/design/nothing-is-installed-by-default.md"
+    required_assertions:
+      - "bare.the_command_arrives_alone"
+      - "bare.nothing_drives_before_somebody_names_one"
+      - "bare.it_says_what_to_do_instead_of_failing"
+      - "bare.it_names_the_other_way_to_add_one"
+      - "bare.a_note_without_a_workflow_is_refused_with_the_fix"
+      - "bare.init_installs_nothing"
+      - "bare.init_writes_its_files"
+      - "bare.init_added_no_package"
+      - "bare.init_writes_no_declared_workflow"
+      - "bare.doctor_asks_the_port_not_the_package"
+      - "bare.doctor_still_reports_what_it_found"
+      - "bare.no_workflow_mounts_so_nothing_assembles"
+
   # Not that the class behaves: that the built artifact, loaded from another
   # process, claims each item exactly once. The activation paths are the
   # plugin's own source, so changing it expires the proof, which is correct —

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -72,6 +72,16 @@ no model — is now refused under a `costUsd` ceiling, because there is no id to
 price it by and codex reports nothing to price it with. Name the model
 (`codex:gpt-5`) or set the ceiling in tokens.
 
+### Nothing is installed by default: the command arrives alone, the first workflow is the one the person there names or writes.
+
+`minor` · `amy-workspace`
+
+`@amykit/cli` depends on no workflow and no notifier. The roster the ticket workflow reads is contributed by the host under the name the workflow looks up — spelled where the file is read, not imported — and whether a Hermes target is reachable is asked of the `notify` port the mounted channel contributes.
+
+`SHIPPED_PROFILES` is empty: a config with no `workflows:` block drives nothing, and every command that needs one says so and names `amy workflow new` and `amy add`. `EXAMPLE_CONFIG` keeps the two published workflows as commented examples, its plugin slices commented with them, and `amy init` writes its files and installs nothing. A machine with nothing mounted is still diagnosed: `amy doctor` reports everything it can see and names the missing workflow in the selection's own words.
+
+New gate `bare-install`: the scenario installs the command alone onto a machine with none of it and proves what it can and cannot do — twelve assertions, from "the command arrives alone" to "doctor asks the port, not the package".
+
 ### Add the plan-board consistency check to the gate so delivered plans can move into durable design notes without losing their required assertions.
 
 `patch` · `@amykit/cli`

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -74,7 +74,7 @@ price it by and codex reports nothing to price it with. Name the model
 
 ### Nothing is installed by default: the command arrives alone, the first workflow is the one the person there names or writes.
 
-`minor` · `amy-workspace`
+`minor` · `@amykit/cli`, `@amykit/plugin-notify-hermes`, `@amykit/workflow-ticket-to-qa`
 
 `@amykit/cli` depends on no workflow and no notifier. The roster the ticket workflow reads is contributed by the host under the name the workflow looks up — spelled where the file is read, not imported — and whether a Hermes target is reachable is asked of the `notify` port the mounted channel contributes.
 

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -115,7 +115,7 @@ this repository.
 | Package | Kind | Depends on, in this workspace |
 | :-- | :-- | :-- |
 | `@amykit/agent-kit` | library | `@amykit/core`, `@amykit/workflow-ticket-to-qa` |
-| `@amykit/cli` | cli | `@amykit/core`, `@amykit/model-specs`, `@amykit/plugin-file-log`, `@amykit/plugin-file-notes`, `@amykit/plugin-file-queue`, `@amykit/plugin-file-store`, `@amykit/plugin-file-tasks`, `@amykit/plugin-notify-hermes`, `@amykit/workflow-ticket-to-qa` |
+| `@amykit/cli` | cli | `@amykit/core`, `@amykit/model-specs`, `@amykit/plugin-file-log`, `@amykit/plugin-file-notes`, `@amykit/plugin-file-queue`, `@amykit/plugin-file-store`, `@amykit/plugin-file-tasks` |
 | `@amykit/core` | library | _nothing_ |
 | `@amykit/model-specs` | library | `@amykit/core` |
 | `@amykit/test-fixtures` | library | `@amykit/core`, `@amykit/workflow-ticket-to-qa` |

--- a/docs/concepts/plugins.md
+++ b/docs/concepts/plugins.md
@@ -214,7 +214,7 @@ anything built from `ctx`, do the same.
 | `@amykit/plugin-hermes-agent` | Hermes as the agent, over its one-shot mode and usage report. |  | `agent:hermes`<br>`harness:hermes` |
 | `@amykit/plugin-linear` | Linear as the tracker, over its GraphQL API. | `tracker` | `notify-channel:tracker` |
 | `@amykit/plugin-notify-fanout` | Sends one announcement down every configured channel, and keeps going when one is down. | `notifier` |  |
-| `@amykit/plugin-notify-hermes` | Announcements over Hermes, which already owns the messaging credentials. |  | `notify-channel:hermes` |
+| `@amykit/plugin-notify-hermes` | Announcements over Hermes, which already owns the messaging credentials. | `notify` | `notify-channel:hermes` |
 | `@amykit/plugin-notify-inbox` | Announcements as a file on disk plus a desktop notification. |  | `notify-channel:inbox` |
 | `@amykit/plugin-plan-check` | The quality bar for a drafted plan: the repository's own check, run in its checkout. | `plan-check` |  |
 | `@amykit/plugin-serial-engine` | Advances one work item by one move per tick. | the engine |  |

--- a/docs/concepts/ports.md
+++ b/docs/concepts/ports.md
@@ -30,6 +30,7 @@ dispatches to is still a port — a workflow's runtime may reach one directly.
 | `gate` | `@amykit/plugin-command-gate` | `run-gate` |
 | `notes` | `@amykit/plugin-file-notes` | _reached directly_ |
 | `notifier` | `@amykit/plugin-notify-fanout` | `announce` |
+| `notify` | `@amykit/plugin-notify-hermes` | _reached directly_ |
 | `plan-check` | `@amykit/plugin-plan-check` | `check-plan` |
 | `queue` | `@amykit/plugin-file-queue` | _reached directly_ |
 | `store` | `@amykit/plugin-file-store` | _reached directly_ |

--- a/docs/design/nothing-is-installed-by-default.md
+++ b/docs/design/nothing-is-installed-by-default.md
@@ -1,0 +1,70 @@
+# Nothing is installed by default
+
+Installing `@amykit/cli` installed a workflow, four plugins and a notifier,
+and then `amy init` offered to install about fifteen more — because the host
+carried the ticket workflow's vocabulary and one notifier's reader in its own
+dependencies, `SHIPPED_PROFILES` gave three profiles to any config that
+declared none, and `EXAMPLE_CONFIG` wrote two of them into the file.
+
+Every one of those was a real workflow that somebody real might want. None of
+them was the one the person installing amy was about to write, and a machine
+that arrives pre-loaded with three processes teaches that amy is a thing with
+processes in it rather than a thing you put yours into.
+
+## What the machine does now
+
+The command arrives alone: `@amykit/cli` depends on the host services and the
+two readers it cannot do without, and on no workflow and no notifier. The
+roster the ticket workflow reads is contributed by the host under the name
+the workflow looks up — the name spelled where the file is read, not imported
+from the workflow — and whether a Hermes target is reachable is asked of the
+`notify` port the mounted channel contributes, which is knowledge that
+travels with the plugin that owns it.
+
+`SHIPPED_PROFILES` is empty. A config with no `workflows:` block drives
+nothing, and every command that needs one says so in the same words and names
+what writes one: `amy workflow new`, or `amy add` for a package that already
+exists. The template `amy init` writes keeps the two published workflows as
+commented examples, which is what they were always doing for the reader, and
+its plugin slices are commented for the same reason — nothing is mounted yet,
+so nothing can declare what its settings look like.
+
+`amy init` writes the config, the roster and the notes directory, and
+installs nothing; `--install` keeps working for a config that already names
+things, which is the machine being rebuilt rather than the machine being set
+up. On a machine with nothing mounted, `amy doctor` still reports everything
+it can see and names the missing workflow in the selection's own words,
+rather than ending before anything was said.
+
+## The proof
+
+The gate's scenario installs the command alone onto a machine that has
+nothing else and asserts what it can and cannot do:
+
+- `bare.the_command_arrives_alone` — no workflow is configured on the fresh
+  install
+- `bare.nothing_drives_before_somebody_names_one` — `amy workflow list`
+  prints nothing
+- `bare.it_says_what_to_do_instead_of_failing` — a command that needs a
+  workflow names `amy workflow new`
+- `bare.it_names_the_other_way_to_add_one` — the same refusal names `amy add`
+- `bare.a_note_without_a_workflow_is_refused_with_the_fix` — `amy note` says
+  what to mark in the config rather than failing
+- `bare.init_installs_nothing` — `amy init` on the bare machine says it kept
+  the plugins it did not need
+- `bare.init_writes_its_files` — the config and the roster are written
+- `bare.init_added_no_package` — the install's library is unchanged
+- `bare.init_writes_no_declared_workflow` — the written config parses with
+  no workflow declared
+- `bare.doctor_asks_the_port_not_the_package` — the configured Hermes target
+  is checked through the mounted channel or reported as unaskable
+- `bare.doctor_still_reports_what_it_found` — everything that does not
+  depend on a workflow is still reported
+- `bare.no_workflow_mounts_so_nothing_assembles` — the missing workflow is
+  the one refusal, in the selection's own words
+
+The unit tests carry the halves a scenario cannot: the profile table is empty
+before anybody writes a config, the written template parses and names every
+setting there is, and a workflow whose roster nobody contributed refuses at
+the tick with the command that writes the file, not with a collection's
+internals.

--- a/docs/development/documentation.md
+++ b/docs/development/documentation.md
@@ -86,7 +86,7 @@ A page is markdown with markers in it:
 | `@amykit/plugin-hermes-agent` | Hermes as the agent, over its one-shot mode and usage report. |  | `agent:hermes`<br>`harness:hermes` |
 | `@amykit/plugin-linear` | Linear as the tracker, over its GraphQL API. | `tracker` | `notify-channel:tracker` |
 | `@amykit/plugin-notify-fanout` | Sends one announcement down every configured channel, and keeps going when one is down. | `notifier` |  |
-| `@amykit/plugin-notify-hermes` | Announcements over Hermes, which already owns the messaging credentials. |  | `notify-channel:hermes` |
+| `@amykit/plugin-notify-hermes` | Announcements over Hermes, which already owns the messaging credentials. | `notify` | `notify-channel:hermes` |
 | `@amykit/plugin-notify-inbox` | Announcements as a file on disk plus a desktop notification. |  | `notify-channel:inbox` |
 | `@amykit/plugin-plan-check` | The quality bar for a drafted plan: the repository's own check, run in its checkout. | `plan-check` |  |
 | `@amykit/plugin-serial-engine` | Advances one work item by one move per tick. | the engine |  |

--- a/docs/development/the-gate.md
+++ b/docs/development/the-gate.md
@@ -130,6 +130,7 @@ asserts what the thing promises, and writes a report sealed with a digest.
 
 | Gate | What expires it | Assertions |
 | :-- | :-- | :-- |
+| `bare-install` | `packages/cli/package.json`<br>`packages/cli/src/profiles.ts`<br>`packages/cli/src/config.ts`<br>`packages/cli/src/doctor.ts` | 12 |
 | `installed-binary` | `packages/cli/src/stamp.ts`<br>`packages/cli/src/home.ts`<br>`packages/core/src/build.ts`<br>`scripts/**` | 7 |
 | `installed-plugins` | `packages/cli/src/loader.ts`<br>`packages/cli/src/profiles.ts`<br>`packages/cli/src/paths.ts`<br>`packages/cli/src/slices.ts`<br>`scripts/install.sh`<br>`scripts/write-install-manifest.mjs` | 12 |
 | `note-to-plan` | `packages/workflow-note-to-plan/src/**`<br>`packages/agent-kit/src/**`<br>`packages/cli/src/**`<br>`plugins/file-notes/src/**`<br>`plugins/plan-check/src/**`<br>`plugins/agent-relay/src/**`<br>`plugins/serial-engine/src/**`<br>`plugins/github/src/**` | 19 |

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -228,6 +228,11 @@
           "description": ""
         },
         {
+          "title": "Nothing is installed by default",
+          "path": "/design/nothing-is-installed-by-default",
+          "description": ""
+        },
+        {
           "title": "Plugins are installed, not compiled in",
           "path": "/design/plugins-are-installed-not-compiled-in",
           "description": ""
@@ -1315,6 +1320,28 @@
           "depth": 2,
           "title": "What this deliberately does not do",
           "slug": "what-this-deliberately-does-not-do"
+        }
+      ]
+    },
+    {
+      "path": "/design/nothing-is-installed-by-default",
+      "file": "docs/design/nothing-is-installed-by-default.md",
+      "edit": "https://github.com/nicolasmelo1/amy/blob/main/docs/design/nothing-is-installed-by-default.md",
+      "title": "Nothing is installed by default",
+      "description": "",
+      "group": "",
+      "order": 999,
+      "generated": false,
+      "headings": [
+        {
+          "depth": 2,
+          "title": "What the machine does now",
+          "slug": "what-the-machine-does-now"
+        },
+        {
+          "depth": 2,
+          "title": "The proof",
+          "slug": "the-proof"
         }
       ]
     },
@@ -4071,6 +4098,13 @@
         ]
       },
       {
+        "kind": "notify",
+        "actions": [],
+        "mountedBy": [
+          "@amykit/plugin-notify-hermes"
+        ]
+      },
+      {
         "kind": "plan-check",
         "actions": [
           "check-plan"
@@ -4792,7 +4826,9 @@
         "npm": "https://www.npmjs.com/package/@amykit/plugin-notify-hermes",
         "source": "https://github.com/nicolasmelo1/amy/tree/main/plugins/notify-hermes",
         "readme": "plugins/notify-hermes/README.md",
-        "mounts": [],
+        "mounts": [
+          "notify"
+        ],
         "contributes": [
           {
             "collection": "notify-channel",
@@ -5147,6 +5183,32 @@
   ],
   "factory": {
     "gates": [
+      {
+        "name": "bare-install",
+        "activation": [
+          "packages/cli/package.json",
+          "packages/cli/src/profiles.ts",
+          "packages/cli/src/config.ts",
+          "packages/cli/src/doctor.ts"
+        ],
+        "evidence": ".software-factory/evidence/bare-install.json",
+        "plan": "docs/design/nothing-is-installed-by-default.md",
+        "assertions": [
+          "bare.the_command_arrives_alone",
+          "bare.nothing_drives_before_somebody_names_one",
+          "bare.it_says_what_to_do_instead_of_failing",
+          "bare.it_names_the_other_way_to_add_one",
+          "bare.a_note_without_a_workflow_is_refused_with_the_fix",
+          "bare.init_installs_nothing",
+          "bare.init_writes_its_files",
+          "bare.init_added_no_package",
+          "bare.init_writes_no_declared_workflow",
+          "bare.doctor_asks_the_port_not_the_package",
+          "bare.doctor_still_reports_what_it_found",
+          "bare.no_workflow_mounts_so_nothing_assembles"
+        ],
+        "scenario": ".software-factory/evidence/bare-install-scenario.sh"
+      },
       {
         "name": "installed-binary",
         "activation": [

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -679,6 +679,11 @@
         },
         {
           "depth": 3,
+          "title": "Nothing is installed by default: the command arrives alone, the first workflow is the one the person there names or writes.",
+          "slug": "nothing-is-installed-by-default-the-command-arrives-alone-the-first-workflow-is-the-one-the-person-there-names-or-writes"
+        },
+        {
+          "depth": 3,
           "title": "Add the plan-board consistency check to the gate so delivered plans can move into durable design notes without losing their required assertions.",
           "slug": "add-the-plan-board-consistency-check-to-the-gate-so-delivered-plans-can-move-into-durable-design-notes-without-losing-their-required-assertions"
         },
@@ -5743,6 +5748,18 @@
           },
           {
             "package": "@amykit/plugin-hermes-agent",
+            "level": "minor"
+          }
+        ],
+        "level": "minor"
+      },
+      {
+        "id": "nothing-is-installed-by-default",
+        "title": "Nothing is installed by default: the command arrives alone, the first workflow is the one the person there names or writes.",
+        "body": "`@amykit/cli` depends on no workflow and no notifier. The roster the ticket workflow reads is contributed by the host under the name the workflow looks up — spelled where the file is read, not imported — and whether a Hermes target is reachable is asked of the `notify` port the mounted channel contributes.\n\n`SHIPPED_PROFILES` is empty: a config with no `workflows:` block drives nothing, and every command that needs one says so and names `amy workflow new` and `amy add`. `EXAMPLE_CONFIG` keeps the two published workflows as commented examples, its plugin slices commented with them, and `amy init` writes its files and installs nothing. A machine with nothing mounted is still diagnosed: `amy doctor` reports everything it can see and names the missing workflow in the selection's own words.\n\nNew gate `bare-install`: the scenario installs the command alone onto a machine with none of it and proves what it can and cannot do — twelve assertions, from \"the command arrives alone\" to \"doctor asks the port, not the package\".",
+        "bumps": [
+          {
+            "package": "amy-workspace",
             "level": "minor"
           }
         ],

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -5759,7 +5759,15 @@
         "body": "`@amykit/cli` depends on no workflow and no notifier. The roster the ticket workflow reads is contributed by the host under the name the workflow looks up — spelled where the file is read, not imported — and whether a Hermes target is reachable is asked of the `notify` port the mounted channel contributes.\n\n`SHIPPED_PROFILES` is empty: a config with no `workflows:` block drives nothing, and every command that needs one says so and names `amy workflow new` and `amy add`. `EXAMPLE_CONFIG` keeps the two published workflows as commented examples, its plugin slices commented with them, and `amy init` writes its files and installs nothing. A machine with nothing mounted is still diagnosed: `amy doctor` reports everything it can see and names the missing workflow in the selection's own words.\n\nNew gate `bare-install`: the scenario installs the command alone onto a machine with none of it and proves what it can and cannot do — twelve assertions, from \"the command arrives alone\" to \"doctor asks the port, not the package\".",
         "bumps": [
           {
-            "package": "amy-workspace",
+            "package": "@amykit/cli",
+            "level": "minor"
+          },
+          {
+            "package": "@amykit/plugin-notify-hermes",
+            "level": "minor"
+          },
+          {
+            "package": "@amykit/workflow-ticket-to-qa",
             "level": "minor"
           }
         ],

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -77,19 +77,21 @@ and beats the machine-wide one.
 # --workflow, and it is also the directory the profile's records and queue
 # live in, so switching between two of them never loses the state of either.
 #
-# Leave this out and you get the two below. Name a third — a work one, an
-# on-call one, one that is yours and not versioned anywhere — and it drives
-# on the same engine, the same log and the same budget as these.
-workflows:
-  ticket-to-qa:
-    workflow: "@amykit/workflow-ticket-to-qa"
-    # plugins: []   # empty means the recommended set for this workflow
-  note-to-plan:
-    workflow: "@amykit/workflow-note-to-plan"
-    notes: true     # `amy note` files friction onto this profile's queue
-
+# Declared here, not shipped: this machine drives nothing until a workflow is
+# named, and `amy workflow new` or `amy add` writes the block. The two
+# below are the ones this repository publishes, kept as examples rather than
+# defaults — uncomment one and install its package to drive it.
+#
+#   workflows:
+#     ticket-to-qa:
+#       workflow: "@amykit/workflow-ticket-to-qa"
+#       # plugins: []   # empty means the recommended set for this workflow
+#     note-to-plan:
+#       workflow: "@amykit/workflow-note-to-plan"
+#       notes: true     # `amy note` files friction onto this profile's queue
+#
 # Which one runs when --workflow is not given. The first, if this is empty.
-defaultWorkflow: ticket-to-qa
+# defaultWorkflow: ticket-to-qa
 
 # Repositories the team reviews in. Review load is counted across all of
 # them, because counting one would send every review to whoever happens to be
@@ -260,12 +262,14 @@ plans:
 # One slice per plugin, keyed by package name. Nothing here is read by the
 # host: each plugin declares what its own slice looks like, and "amy doctor"
 # refuses a field that is not one the plugin has. A plugin with no slice runs
-# on its defaults.
-plugins:
-  "@amykit/plugin-notify-hermes":
-    target: slack:my-channel
-  "@amykit/plugin-file-queue":
-    retentionDays: 7
+# on its defaults. Nothing is mounted until a workflow names it, so these are
+# examples too — uncomment with the workflow that carries them.
+#
+# plugins:
+#   "@amykit/plugin-notify-hermes":
+#     target: slack:my-channel
+#   "@amykit/plugin-file-queue":
+#     retentionDays: 7
 ```
 
 <!-- amy:end config-example -->

--- a/docs/reference/contracts.md
+++ b/docs/reference/contracts.md
@@ -27,6 +27,7 @@ explains why for each.
 | `gate` | `@amykit/plugin-command-gate` | `run-gate` |
 | `notes` | `@amykit/plugin-file-notes` | _reached directly_ |
 | `notifier` | `@amykit/plugin-notify-fanout` | `announce` |
+| `notify` | `@amykit/plugin-notify-hermes` | _reached directly_ |
 | `plan-check` | `@amykit/plugin-plan-check` | `check-plan` |
 | `queue` | `@amykit/plugin-file-queue` | _reached directly_ |
 | `store` | `@amykit/plugin-file-store` | _reached directly_ |

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -31,7 +31,7 @@ maintains.
 | `@amykit/plugin-hermes-agent` | Hermes as the agent, over its one-shot mode and usage report. |  | `agent:hermes`<br>`harness:hermes` |
 | `@amykit/plugin-linear` | Linear as the tracker, over its GraphQL API. | `tracker` | `notify-channel:tracker` |
 | `@amykit/plugin-notify-fanout` | Sends one announcement down every configured channel, and keeps going when one is down. | `notifier` |  |
-| `@amykit/plugin-notify-hermes` | Announcements over Hermes, which already owns the messaging credentials. |  | `notify-channel:hermes` |
+| `@amykit/plugin-notify-hermes` | Announcements over Hermes, which already owns the messaging credentials. | `notify` | `notify-channel:hermes` |
 | `@amykit/plugin-notify-inbox` | Announcements as a file on disk plus a desktop notification. |  | `notify-channel:inbox` |
 | `@amykit/plugin-plan-check` | The quality bar for a drafted plan: the repository's own check, run in its checkout. | `plan-check` |  |
 | `@amykit/plugin-serial-engine` | Advances one work item by one move per tick. | the engine |  |
@@ -379,7 +379,7 @@ Announcements over Hermes, which already owns the messaging credentials.
 |  |  |
 | :-- | :-- |
 | Source | `plugins/notify-hermes` |
-| Mounts | _nothing_ |
+| Mounts | `notify` |
 | Contributes | `notify-channel:hermes` |
 | Needs in the environment | _nothing_ |
 | Depends on | `@amykit/core`, `@amykit/plugin-notify-fanout` |

--- a/docs/start/configuration.md
+++ b/docs/start/configuration.md
@@ -107,19 +107,21 @@ it cannot drift from what you actually get.
 # --workflow, and it is also the directory the profile's records and queue
 # live in, so switching between two of them never loses the state of either.
 #
-# Leave this out and you get the two below. Name a third — a work one, an
-# on-call one, one that is yours and not versioned anywhere — and it drives
-# on the same engine, the same log and the same budget as these.
-workflows:
-  ticket-to-qa:
-    workflow: "@amykit/workflow-ticket-to-qa"
-    # plugins: []   # empty means the recommended set for this workflow
-  note-to-plan:
-    workflow: "@amykit/workflow-note-to-plan"
-    notes: true     # `amy note` files friction onto this profile's queue
-
+# Declared here, not shipped: this machine drives nothing until a workflow is
+# named, and `amy workflow new` or `amy add` writes the block. The two
+# below are the ones this repository publishes, kept as examples rather than
+# defaults — uncomment one and install its package to drive it.
+#
+#   workflows:
+#     ticket-to-qa:
+#       workflow: "@amykit/workflow-ticket-to-qa"
+#       # plugins: []   # empty means the recommended set for this workflow
+#     note-to-plan:
+#       workflow: "@amykit/workflow-note-to-plan"
+#       notes: true     # `amy note` files friction onto this profile's queue
+#
 # Which one runs when --workflow is not given. The first, if this is empty.
-defaultWorkflow: ticket-to-qa
+# defaultWorkflow: ticket-to-qa
 
 # Repositories the team reviews in. Review load is counted across all of
 # them, because counting one would send every review to whoever happens to be
@@ -290,12 +292,14 @@ plans:
 # One slice per plugin, keyed by package name. Nothing here is read by the
 # host: each plugin declares what its own slice looks like, and "amy doctor"
 # refuses a field that is not one the plugin has. A plugin with no slice runs
-# on its defaults.
-plugins:
-  "@amykit/plugin-notify-hermes":
-    target: slack:my-channel
-  "@amykit/plugin-file-queue":
-    retentionDays: 7
+# on its defaults. Nothing is mounted until a workflow names it, so these are
+# examples too — uncomment with the workflow that carries them.
+#
+# plugins:
+#   "@amykit/plugin-notify-hermes":
+#     target: slack:my-channel
+#   "@amykit/plugin-file-queue":
+#     retentionDays: 7
 ```
 
 <!-- amy:end config-example -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -4147,8 +4147,6 @@
         "@amykit/plugin-file-queue": "^0.2.0",
         "@amykit/plugin-file-store": "^0.2.0",
         "@amykit/plugin-file-tasks": "^0.2.0",
-        "@amykit/plugin-notify-hermes": "^0.2.0",
-        "@amykit/workflow-ticket-to-qa": "^0.2.0",
         "commander": "^14.0.0",
         "yaml": "^2.9.0"
       },
@@ -4221,6 +4219,7 @@
       "dependencies": {
         "@amykit/agent-kit": "^0.2.0",
         "@amykit/core": "^0.2.0",
+        "@amykit/model-specs": "^0.2.0",
         "@amykit/workflow-ticket-to-qa": "^0.2.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "check:plans": "node scripts/check-plan-board.mjs",
     "check:toolchain": "node scripts/check-toolchain.mjs",
     "gate": "npm run build && npm run typecheck && npm run check:release && npm run check:config && npm run check:plans && npm run check:toolchain && npm run docs:check && npm run test:coverage && npm run lint && npm run knip && npm run audit && sf check --allow-commands && sf verify",
-    "e2e": "./.software-factory/evidence/plugin-file-queue-scenario.sh && ./.software-factory/evidence/plugin-agent-relay-scenario.sh && ./.software-factory/evidence/plugin-serial-engine-scenario.sh && ./.software-factory/evidence/installed-binary-scenario.sh && ./.software-factory/evidence/installed-plugins-scenario.sh && ./.software-factory/evidence/ticket-to-qa-scenario.sh && ./.software-factory/evidence/note-to-plan-scenario.sh",
+    "e2e": "./.software-factory/evidence/plugin-file-queue-scenario.sh && ./.software-factory/evidence/plugin-agent-relay-scenario.sh && ./.software-factory/evidence/plugin-serial-engine-scenario.sh && ./.software-factory/evidence/installed-binary-scenario.sh && ./.software-factory/evidence/installed-plugins-scenario.sh && ./.software-factory/evidence/ticket-to-qa-scenario.sh && ./.software-factory/evidence/note-to-plan-scenario.sh && ./.software-factory/evidence/bare-install-scenario.sh",
     "changeset": "changeset",
     "release:version": "changeset version && npm install --package-lock-only && npm run docs:generate && sf lock && node scripts/check-lock-scope.mjs",
     "release:publish": "npm run build && changeset publish",
@@ -59,6 +59,10 @@
     ],
     "ignoreBinaries": [
       "sf"
+    ],
+    "ignoreDependencies": [
+      "@amykit/workflow-ticket-to-qa",
+      "@amykit/plugin-notify-hermes"
     ]
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,8 +43,6 @@
     "@amykit/plugin-file-queue": "^0.2.0",
     "@amykit/plugin-file-store": "^0.2.0",
     "@amykit/plugin-file-tasks": "^0.2.0",
-    "@amykit/plugin-notify-hermes": "^0.2.0",
-    "@amykit/workflow-ticket-to-qa": "^0.2.0",
     "commander": "^14.0.0",
     "yaml": "^2.9.0"
   },

--- a/packages/cli/skills/amy-init/SKILL.md
+++ b/packages/cli/skills/amy-init/SKILL.md
@@ -42,10 +42,15 @@ which repositories are actually on this machine.
 
 ## The rounds
 
-**Round 1 — what is this install for.** Which workflows they want. The two
-shipped are `ticket-to-qa` (a tracker ticket to a QA handoff) and
-`note-to-plan` (friction becomes a plan). A third is a package of their own —
-hand that to `/amy-workflow` rather than inventing it here.
+**Round 1 — what is this install for.** The one question the machine cannot
+answer, because nothing ships with a process in it: what work should amy
+drive? `amy workflow list` prints nothing on a fresh install, and that is the
+truth rather than a gap. Ask what process they want amy to drive, and whether
+they want to write it — `/amy-workflow` is for one of their own — or would
+rather name an existing package, the two published ones being `ticket-to-qa`
+(a tracker ticket to a QA handoff) and `note-to-plan` (friction becomes a
+plan). Write the block into the config; only then does `amy init` install
+what that workflow asks for.
 
 **Round 2 — the world.** Repositories, where the checkouts are, which team's
 tickets land where, and the gate command per repository. Read `package.json`,
@@ -106,7 +111,8 @@ done while it lists a problem; name each one and what fixes it.
 - **Nothing here is installed with the command.** `@amykit/cli` carries the
   command and the host services; the plugins are separate, on purpose, so a
   machine with no `codex` carries no code for one. `amy init` prints the
-  `npm install` line for whatever is missing.
+  `npm install` line for whatever the config names and is missing — and on a
+  machine with no workflow named, it installs nothing and says so.
 
 ## Adding a workflow to an install that exists
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,13 +1,10 @@
 import fs from "node:fs";
 import yaml from "yaml";
-import { DEFAULT_POLICY, Policy } from "@amykit/workflow-ticket-to-qa";
 import type { Policy as PlanPolicy } from "@amykit/workflow-note-to-plan";
 import type { Policy as ErrandPolicy } from "@amykit/workflow-errand";
-import { Roster } from "@amykit/workflow-ticket-to-qa";
 import os from "node:os";
 import path from "node:path";
 import { paths } from "./paths.js";
-import { SHIPPED_PROFILES } from "./profiles.js";
 
 /**
  * The second workflow's vocabulary: friction written down becomes a plan.
@@ -64,6 +61,55 @@ interface NotifyConfig {
   hermes: string | null;
   /** A file on disk plus a desktop notification. */
   inbox: boolean;
+}
+
+/**
+ * The lifecycle ceilings, named here rather than imported from a workflow.
+ *
+ * A config that declares no workflow yet still has to be a whole file: the
+ * ceilings are settings this machine reads and hands to whichever workflow
+ * drives, and importing the type would put a workflow package in the
+ * command's dependencies for a name. The numbers were the ticket workflow's
+ * defaults; the shape is the host's.
+ */
+interface Policy {
+  maxImplementAttempts: number;
+  maxGateAttempts: number;
+  pollBackoffMs: number;
+  rosterBackoffMs: number;
+  maxOpenReviewsPerReviewer: number;
+  maxPullRequestFiles: number;
+  maxPullRequestLines: number;
+}
+
+const DEFAULT_POLICY: Policy = {
+  maxImplementAttempts: 3,
+  maxGateAttempts: 3,
+  pollBackoffMs: 5 * 60 * 1000,
+  rosterBackoffMs: 30 * 60 * 1000,
+  maxOpenReviewsPerReviewer: 2,
+  maxPullRequestFiles: 60,
+  maxPullRequestLines: 2000,
+};
+
+/**
+ * Who reviews today, read off the file `amy init` writes and handed to
+ * whichever workflow asks for it.
+ */
+interface RosterMember {
+  /** How the tracker identifies them, normally an email. */
+  tracker: string;
+  /** How the code host identifies them, a login. */
+  host: string;
+  /** Cleared when someone is on leave. */
+  available: boolean;
+}
+
+export interface Roster {
+  /** The date the roster was last confirmed, as `YYYY-MM-DD`. */
+  confirmedOn: string;
+  reviewers: RosterMember[];
+  qa: RosterMember;
 }
 
 export interface AmyConfig {
@@ -265,19 +311,21 @@ export const EXAMPLE_CONFIG = `# The workflows this install can drive. The name 
 # --workflow, and it is also the directory the profile's records and queue
 # live in, so switching between two of them never loses the state of either.
 #
-# Leave this out and you get the two below. Name a third — a work one, an
-# on-call one, one that is yours and not versioned anywhere — and it drives
-# on the same engine, the same log and the same budget as these.
-workflows:
-  ticket-to-qa:
-    workflow: "@amykit/workflow-ticket-to-qa"
-    # plugins: []   # empty means the recommended set for this workflow
-  note-to-plan:
-    workflow: "@amykit/workflow-note-to-plan"
-    notes: true     # \`amy note\` files friction onto this profile's queue
-
+# Declared here, not shipped: this machine drives nothing until a workflow is
+# named, and \`amy workflow new\` or \`amy add\` writes the block. The two
+# below are the ones this repository publishes, kept as examples rather than
+# defaults — uncomment one and install its package to drive it.
+#
+#   workflows:
+#     ticket-to-qa:
+#       workflow: "@amykit/workflow-ticket-to-qa"
+#       # plugins: []   # empty means the recommended set for this workflow
+#     note-to-plan:
+#       workflow: "@amykit/workflow-note-to-plan"
+#       notes: true     # \`amy note\` files friction onto this profile's queue
+#
 # Which one runs when --workflow is not given. The first, if this is empty.
-defaultWorkflow: ticket-to-qa
+# defaultWorkflow: ticket-to-qa
 
 # Repositories the team reviews in. Review load is counted across all of
 # them, because counting one would send every review to whoever happens to be
@@ -448,12 +496,14 @@ plans:
 # One slice per plugin, keyed by package name. Nothing here is read by the
 # host: each plugin declares what its own slice looks like, and "amy doctor"
 # refuses a field that is not one the plugin has. A plugin with no slice runs
-# on its defaults.
-plugins:
-  "@amykit/plugin-notify-hermes":
-    target: slack:my-channel
-  "@amykit/plugin-file-queue":
-    retentionDays: 7
+# on its defaults. Nothing is mounted until a workflow names it, so these are
+# examples too — uncomment with the workflow that carries them.
+#
+# plugins:
+#   "@amykit/plugin-notify-hermes":
+#     target: slack:my-channel
+#   "@amykit/plugin-file-queue":
+#     retentionDays: 7
 `;
 
 /**
@@ -474,7 +524,7 @@ export function writeProfilePlugins(
   const existing = fs.existsSync(file) ? fs.readFileSync(file, "utf-8") : "";
 
   const declared = { ...config.workflows };
-  const entry = declared[profile] ?? SHIPPED_PROFILES[profile];
+  const entry = declared[profile];
   if (!entry) throw new Error(`there is no \`${profile}\` workflow to add a plugin to`);
 
   declared[profile] = { ...entry, plugins: [...specs] };

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -1,12 +1,16 @@
 import fs from "node:fs";
 import path from "node:path";
 import { CommandRunner, ConfigSchema, validateConfig } from "@amykit/core";
-import { hermesTargetIsKnown } from "@amykit/plugin-notify-hermes";
-import { Roster, isConfirmedFor } from "@amykit/workflow-ticket-to-qa";
-import { AmyConfig } from "./config.js";
+import { AmyConfig, Roster } from "./config.js";
 import { strayState } from "./home.js";
 import { LEGACY_DIRECTORIES } from "./profiles.js";
 import { paths } from "./paths.js";
+
+/** Monday through Friday. Saturday is 6 and Sunday is 0. */
+function isWorkday(date: Date): boolean {
+  const day = date.getUTCDay();
+  return day >= 1 && day <= 5;
+}
 
 export interface Check {
   label: string;
@@ -32,6 +36,15 @@ export interface DoctorDeps {
    * describe a machine other than the one being diagnosed.
    */
   schemas: Readonly<Record<string, ConfigSchema>>;
+  /**
+   * The notification port, if this install mounted one.
+   *
+   * Handed in for the same reason the schemas are: whether a target is
+   * reachable is the mounted channel's own knowledge, not something the host
+   * re-derives by importing one notifier's reader. Undefined means no channel
+   * was mounted, which is its own answer.
+   */
+  notifyPort?: object;
 }
 
 /**
@@ -113,9 +126,11 @@ function pluginSettings({ config, schemas }: DoctorDeps): Check[] {
  *
  * Reported rather than moved: it is somebody's work in flight, and the one
  * command that puts it where the new layout looks is cheaper to read than a
- * migration that ran without being asked.
+ * migration that ran without being asked. A name the current config declares
+ * is a profile, not a leftover — the operator chose it, and its directory is
+ * where this layout looks.
  */
-function leftBehind({ home, cwd }: DoctorDeps): Check[] {
+function leftBehind({ home, cwd, config }: DoctorDeps): Check[] {
   const base = paths(home).base;
   const stray = strayState(cwd, base);
 
@@ -132,6 +147,7 @@ function leftBehind({ home, cwd }: DoctorDeps): Check[] {
   return here.concat(
     Object.entries(LEGACY_DIRECTORIES)
       .filter(([old]) => fs.existsSync(path.join(base, old)))
+      .filter(([old]) => !(old in config.workflows))
       .map(([old, now]) => ({
         label: `state left in ${old}`,
         ok: false,
@@ -143,7 +159,12 @@ function leftBehind({ home, cwd }: DoctorDeps): Check[] {
 function roster({ home, now, readRoster }: DoctorDeps): Check {
   try {
     const current = readRoster(home);
-    const confirmed = isConfirmedFor(current, now);
+    // Confirmed today is the claim: Monday through Friday the date has to be
+    // today's, and a weekend holds — people do not confirm a roster they are
+    // not using, and stalling on one nobody asked for would be the machine
+    // inventing a ritual.
+    const confirmed =
+      !isWorkday(now) || current.confirmedOn === now.toISOString().slice(0, 10);
     return {
       label: "roster confirmed for today",
       ok: confirmed,
@@ -185,19 +206,34 @@ async function tools({ runner }: DoctorDeps): Promise<Check[]> {
   return checks;
 }
 
-async function hermes({ config, runner }: DoctorDeps): Promise<Check[]> {
+/**
+ * Whether the notification port this install mounted can reach the target.
+ *
+ * The question is asked of the port, not of one notifier's reader: the host
+ * carrying `@amykit/plugin-notify-hermes` in its dependencies was the host
+ * holding a plugin's knowledge, and the machine installing only the command
+ * paid for a package it had never chosen. A mount with no channel is an
+ * install that has not turned one on — the check above already says so —
+ * and nothing is asked of a port that was never mounted.
+ */
+type Reachable = { isReachable(target: string): Promise<boolean> | boolean };
+
+async function hermes({ config, notifyPort }: DoctorDeps): Promise<Check[]> {
   const target = config.notify.hermes;
   if (!target) return [];
-
-  const result = await runner.run("hermes", ["send", "--list", "--json"], { timeoutMs: 60_000 });
-
-  if (!result.ok) {
-    const detail = result.stderr.split("\n")[0] ?? "hermes send --list failed";
-    return [{ label: `hermes target ${target}`, ok: false, detail }];
+  if (!notifyPort) {
+    return [
+      {
+        label: `hermes target ${target}`,
+        ok: false,
+        detail: "no notification channel is mounted, so nothing could ask whether it is reachable",
+      },
+    ];
   }
 
+  const reachable = notifyPort as Reachable;
   try {
-    const known = hermesTargetIsKnown(JSON.parse(result.stdout), target);
+    const known = await reachable.isReachable(target);
     return [
       {
         label: `hermes target ${target}`,
@@ -205,12 +241,12 @@ async function hermes({ config, runner }: DoctorDeps): Promise<Check[]> {
         detail: known ? "" : "hermes does not have this target configured",
       },
     ];
-  } catch {
+  } catch (error) {
     return [
       {
         label: `hermes target ${target}`,
         ok: false,
-        detail: "could not read the target listing from hermes",
+        detail: error instanceof Error ? error.message : "the channel could not be asked",
       },
     ];
   }

--- a/packages/cli/src/hostPlugin.ts
+++ b/packages/cli/src/hostPlugin.ts
@@ -1,14 +1,19 @@
 import { Plugin } from "@amykit/core";
-import { Roster, WORKFLOW_DATA } from "@amykit/workflow-ticket-to-qa";
+import type { Roster } from "./config.js";
 
 /**
  * The host's own glue, mounted like anything else.
  *
  * Today's roster is neither a port nor a setting: it is data that changes
  * daily and lives in its own file, and reading it is something the host knows
- * how to do. It is contributed, and read when a tick needs it, so confirming
- * the roster takes effect without a restart.
+ * how to do. It is contributed under the workflow-data collection's roster
+ * name — the name the ticket workflow reads, spelled here rather than
+ * imported from it, so the command carries no workflow package — and read
+ * when a tick needs it, so confirming the roster takes effect without a
+ * restart.
  */
+const WORKFLOW_DATA = "workflow-data";
+
 export function hostPlugin(readRoster: () => Roster): Plugin {
   return {
     name: "@amykit/cli",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,7 +5,6 @@ import { spawn } from "node:child_process";
 import { Command } from "commander";
 // Type-only: the CLI reports what a tick returned and mounts no engine itself.
 import type { TickResult } from "@amykit/plugin-serial-engine";
-import { isConfirmedFor } from "@amykit/workflow-ticket-to-qa";
 import { FileNotes } from "@amykit/plugin-file-notes";
 import { FileTasks } from "@amykit/plugin-file-tasks";
 import {
@@ -210,13 +209,22 @@ program
     //
     // What each profile *will mount*, not what is recommended for it: a
     // config naming a plugin nobody here shipped is exactly the case worth
-    // installing, and the recommendation cannot know about it.
+    // installing, and the recommendation cannot know about it. A config with
+    // no workflow declares nothing, installs nothing, and says which is
+    // which — a bare machine is the machine being set up, not one being
+    // rebuilt.
     const config = loadConfig(home);
     const wanted = Object.values(profiles(config)).flatMap((profile) =>
       pluginList(config, profile),
     );
     const absent = [...new Set(wanted)].filter((name) => !installedPlugins().includes(name));
-    if (absent.length === 0) return;
+    if (absent.length === 0) {
+      if (wanted.length === 0) {
+        console.log("\nkept the plugins it did not need: nothing is mounted yet.");
+        console.log("Name a workflow and `amy init` installs only what it asks for.");
+      }
+      return;
+    }
 
     await supply(absent, options.install);
   });
@@ -276,44 +284,86 @@ program
   .description("Check everything the machine depends on before it touches a ticket")
   .action(async () => {
     const config = loadConfig(home);
-    const profile = selected(config);
-    const loaded = await load(pluginList(config, profile));
 
-    const checks = await diagnose({
-      home,
-      config,
-      runner,
-      env: process.env,
-      now: new Date(),
-      readRoster: loadRoster,
-      cwd: process.cwd(),
-      schemas: Object.fromEntries(
-        loaded.plugins.flatMap((plugin) => (plugin.configSchema ? [[plugin.name, plugin.configSchema]] : [])),
-      ),
-    });
-
-    for (const check of checks) {
-      const detail = check.detail ? `  ${check.detail}` : "";
-      console.log(`${check.ok ? "ok  " : "FAIL"} ${check.label}${detail}`);
-    }
-
-    // Asked last, because a mount problem is usually a consequence of one of
-    // the checks above rather than a separate fault.
-    const assembled = await assemble(profile);
-    if (!assembled.ok) {
-      for (const problem of assembled.problems) console.log(`FAIL ${problem}`);
-    } else {
-      console.log(`ok   ${assembled.mounted.plugins.length} plugin(s) assembled`);
-    }
-
-    const broken = checks.filter((check) => !check.ok).length + (assembled.ok ? 0 : 1);
-    if (broken > 0) {
-      console.log(`\n${broken} problem(s) to fix before running.`);
+    // A machine that has not named a workflow yet is the machine doctor is
+    // for: it reports everything else it can see, then names the one thing
+    // that is missing in the words the operator can act on — rather than
+    // exiting at the selection step with nothing reported.
+    const resolution = resolveProfile(config, program.opts<{ workflow?: string }>().workflow);
+    if (!resolution.ok) {
+      await doctorReport(
+        config,
+        { name: "", workflow: "", plugins: [], takesNotes: false, takesTasks: false },
+        resolution.problem,
+      );
       process.exitCode = 1;
       return;
     }
-    console.log("\nready");
+
+    await doctorReport(config, resolution.profile);
   });
+
+/**
+ * Runs the checks for one profile, then the mount itself, and says what to
+ * fix.
+ *
+ * The empty-profile call is how a bare install is diagnosed: everything that
+ * does not depend on a workflow is still checked, and the missing workflow is
+ * reported in the selection's own words instead of ending the command before
+ * anything was said.
+ */
+async function doctorReport(config: AmyConfig, profile: Profile, problem?: string): Promise<void> {
+  const loaded = problem
+    ? { plugins: [], problems: [] }
+    : await load(pluginList(config, profile));
+
+  const checks = await diagnose({
+    home,
+    config,
+    runner,
+    env: process.env,
+    now: new Date(),
+    readRoster: loadRoster,
+    cwd: process.cwd(),
+    schemas: Object.fromEntries(
+      loaded.plugins.flatMap((plugin) => (plugin.configSchema ? [[plugin.name, plugin.configSchema]] : [])),
+    ),
+    // Mounted, then asked: whether a notification target is reachable is
+    // the channel's own knowledge, and a mount that did not happen is its
+    // own answer to report.
+    notifyPort: problem
+      ? undefined
+      : await assemble(profile).then((outcome) =>
+          outcome.ok ? outcome.mounted.ports.get("notify") : undefined,
+        ),
+  });
+
+  for (const check of checks) {
+    const detail = check.detail ? `  ${check.detail}` : "";
+    console.log(`${check.ok ? "ok  " : "FAIL"} ${check.label}${detail}`);
+  }
+
+  if (problem) {
+    console.log(`FAIL ${problem}`);
+  }
+
+  // Asked last, because a mount problem is usually a consequence of one of
+  // the checks above rather than a separate fault.
+  const assembled = problem ? { ok: false as const, problems: [problem] } : await assemble(profile);
+  if (!assembled.ok) {
+    for (const p of assembled.problems) console.log(`FAIL ${p}`);
+  } else {
+    console.log(`ok   ${assembled.mounted.plugins.length} plugin(s) assembled`);
+  }
+
+  const broken = checks.filter((check) => !check.ok).length + (assembled.ok ? 0 : 1);
+  if (broken > 0) {
+    console.log(`\n${broken} problem(s) to fix before running.`);
+    process.exitCode = 1;
+    return;
+  }
+  console.log("\nready");
+}
 
 program
   .command("pause")
@@ -1105,7 +1155,12 @@ rosterCommand
   .description("Print the roster and whether it is current")
   .action(() => {
     const roster = loadRoster(home);
-    const current = isConfirmedFor(roster, new Date());
+    const now = new Date();
+    // Confirmed today is the claim, Monday through Friday: a weekend holds,
+    // because people do not confirm a roster they are not using.
+    const workday = now.getUTCDay() >= 1 && now.getUTCDay() <= 5;
+    const current =
+      !workday || roster.confirmedOn === now.toISOString().slice(0, 10);
     console.log(`confirmed on ${roster.confirmedOn}${current ? " (current)" : " (stale)"}`);
     for (const reviewer of roster.reviewers) {
       console.log(`  ${reviewer.available ? "in " : "out"} ${reviewer.host}  ${reviewer.tracker}`);

--- a/packages/cli/src/profiles.ts
+++ b/packages/cli/src/profiles.ts
@@ -28,15 +28,12 @@ export interface Profile {
 /**
  * What a fresh install can drive, before anybody writes a `workflows:` block.
  *
- * Two entries rather than two special cases: a config that names either one
- * replaces it, and a config that names a third gets a third. Nothing else in
- * the CLI reads these names.
+ * Nothing: the machine that arrives carries no process, and the first one on
+ * it is the one the person there names or writes. `amy workflow new` and
+ * `amy add` both end in a config block, which is the only place a profile
+ * has ever come from.
  */
-export const SHIPPED_PROFILES: Record<string, WorkflowProfile> = {
-  "ticket-to-qa": { workflow: "@amykit/workflow-ticket-to-qa" },
-  "note-to-plan": { workflow: "@amykit/workflow-note-to-plan", notes: true },
-  errand: { workflow: "@amykit/workflow-errand", tasks: true },
-};
+const SHIPPED_PROFILES: Record<string, WorkflowProfile> = {};
 
 /**
  * What every profile mounts, whichever workflow is driving.
@@ -116,7 +113,11 @@ export function resolveProfile(config: AmyConfig, asked?: string): Resolution {
   const wanted = (asked ?? config.defaultWorkflow ?? "").trim() || names[0];
 
   if (!wanted) {
-    return { ok: false, problem: "no workflow is configured, so there is nothing to drive" };
+    return {
+      ok: false,
+      problem:
+        "no workflow is configured, so there is nothing to drive — `amy workflow new` writes one, `amy add` names an existing package",
+    };
   }
 
   const profile = known[wanted];
@@ -139,7 +140,14 @@ export function directoriesFor(profile: string): { records: string; queue: strin
   return { records: `${profile}/records`, queue: `${profile}/queue` };
 }
 
-/** The layout a version before profiles-as-data wrote, and where it went. */
+/**
+ * The layout a version before profiles-as-data wrote, and where it went.
+ *
+ * The old names were the shipped profiles: `ticket-to-qa` under its own
+ * directory and the two beside it. A config may declare any of those names
+ * again, so the mapping only fires for a directory the config does not
+ * declare — a name somebody chose is theirs, not this table's.
+ */
 export const LEGACY_DIRECTORIES: Record<string, string> = {
   tickets: "ticket-to-qa/records",
   queue: "ticket-to-qa/queue",

--- a/packages/cli/tests/assemble.test.ts
+++ b/packages/cli/tests/assemble.test.ts
@@ -5,10 +5,17 @@ import path from "node:path";
 import { HostServices, mount, unmetNeeds } from "@amykit/core";
 import { load } from "../src/loader.js";
 import { DEFAULT_CONFIG } from "../src/config.js";
-import { profiles, recommendedFor } from "../src/profiles.js";
+import { Profile, recommendedFor } from "../src/profiles.js";
 import { pluginSlices } from "../src/slices.js";
 
-const TICKETS = profiles(DEFAULT_CONFIG)["ticket-to-qa"]!;
+/** The workflow these plugins are chosen for, named the way a config names it. */
+const TICKETS: Profile = {
+  name: "tickets",
+  workflow: "@amykit/workflow-ticket-to-qa",
+  plugins: [],
+  takesNotes: false,
+  takesTasks: false,
+};
 
 const ROSTER = {
   confirmedOn: "2026-09-03",
@@ -87,6 +94,9 @@ describe("assembling the built-in set", () => {
       // gives up, the other one reads them.
       "notes",
       "notifier",
+      // The channel's own knowledge, asked rather than re-derived: whether a
+      // delivery target is reachable.
+      "notify",
       "queue",
       "store",
       "tracker",

--- a/packages/cli/tests/config.test.ts
+++ b/packages/cli/tests/config.test.ts
@@ -88,38 +88,52 @@ describe("writing a profile's plugin list", () => {
 
   beforeEach(() => {
     root = fs.mkdtempSync(path.join(os.tmpdir(), "amy-config-"));
-    fs.mkdirSync(path.join(root, ".amy"), { recursive: true });
+    fs.mkdirSync(paths(root).base, { recursive: true });
   });
 
   afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
 
-  const file = () => path.join(root, ".amy", "config.yaml");
+  const file = () => paths(root).config;
+
+  const writeConfig = (text: string) => {
+    fs.writeFileSync(file(), text, "utf-8");
+  };
 
   it("keeps the comments that explain every other setting", () => {
-    fs.writeFileSync(file(), "# what the team reviews in\nrepos:\n  - acme/widgets\n", "utf-8");
+    writeConfig(
+      '# what the team reviews in\nrepos:\n  - acme/widgets\nworkflows:\n  tickets:\n    workflow: "@amykit/workflow-ticket-to-qa"\n',
+    );
 
-    writeProfilePlugins(root, "ticket-to-qa", ["@acme/plugin-mine"], loadConfig(root));
+    writeProfilePlugins(root, "tickets", ["@acme/plugin-mine"], loadConfig(root));
 
     expect(fs.readFileSync(file(), "utf-8")).toContain("# what the team reviews in");
-    expect(loadConfig(root).workflows["ticket-to-qa"]?.plugins).toEqual(["@acme/plugin-mine"]);
+    expect(loadConfig(root).workflows["tickets"]?.plugins).toEqual(["@acme/plugin-mine"]);
   });
 
   it("writes the workflow the profile drives beside its plugins", () => {
-    writeProfilePlugins(root, "note-to-plan", ["@amykit/workflow-note-to-plan"], loadConfig(root));
+    writeConfig(
+      'workflows:\n  plans:\n    workflow: "@amykit/workflow-note-to-plan"\n    notes: true\n',
+    );
 
-    expect(loadConfig(root).workflows["note-to-plan"]).toMatchObject({
+    writeProfilePlugins(root, "plans", ["@amykit/workflow-note-to-plan"], loadConfig(root));
+
+    expect(loadConfig(root).workflows["plans"]).toMatchObject({
       workflow: "@amykit/workflow-note-to-plan",
       notes: true,
     });
   });
 
   it("edits one profile without touching another", () => {
-    writeProfilePlugins(root, "ticket-to-qa", ["@acme/plugin-one"], loadConfig(root));
-    writeProfilePlugins(root, "note-to-plan", ["@acme/plugin-two"], loadConfig(root));
+    writeConfig(
+      'workflows:\n  tickets:\n    workflow: "@amykit/workflow-ticket-to-qa"\n  plans:\n    workflow: "@amykit/workflow-note-to-plan"\n',
+    );
+
+    writeProfilePlugins(root, "tickets", ["@acme/plugin-one"], loadConfig(root));
+    writeProfilePlugins(root, "plans", ["@acme/plugin-two"], loadConfig(root));
 
     const config = loadConfig(root);
-    expect(config.workflows["ticket-to-qa"]?.plugins).toEqual(["@acme/plugin-one"]);
-    expect(config.workflows["note-to-plan"]?.plugins).toEqual(["@acme/plugin-two"]);
+    expect(config.workflows["tickets"]?.plugins).toEqual(["@acme/plugin-one"]);
+    expect(config.workflows["plans"]?.plugins).toEqual(["@acme/plugin-two"]);
   });
 
   it("refuses a profile nobody declared, rather than inventing one", () => {

--- a/packages/cli/tests/doctor.test.ts
+++ b/packages/cli/tests/doctor.test.ts
@@ -18,6 +18,21 @@ const ROSTER = {
 
 const HERMES_LISTING = JSON.stringify({ platforms: { slack: [{ id: "C1", name: "ops" }] } });
 
+/**
+ * The mounted notification port, standing in for the real one.
+ *
+ * Whether a target is reachable is the channel's own knowledge now, so the
+ * test hands in a port the way the CLI does — assembled from the plugins
+ * this install loaded — rather than a hermes listing to re-derive it from.
+ */
+const NOTIFY_PORT = (known: (target: string) => boolean) => ({
+  isReachable: async (target: string) => known(target),
+});
+
+/** A port whose channel knows the targets a real hermes listing would name. */
+const KNOWN_TARGETS = () =>
+  NOTIFY_PORT((asked) => asked === "slack:ops" || asked === "slack:#ops");
+
 function labelled(checks: Check[], fragment: string): Check | undefined {
   return checks.find((check) => check.label.includes(fragment));
 }
@@ -154,13 +169,24 @@ describe("diagnose", () => {
     expect(labelled(checks, "hermes target")).toBeUndefined();
   });
 
+  it("reports a configured target when no channel is mounted to ask", async () => {
+    const config = {
+      ...DEFAULT_CONFIG,
+      notify: { tracker: true, hermes: "slack:ops", inbox: true },
+    };
+
+    const checks = await diagnose(deps({ config }));
+
+    expect(labelled(checks, "hermes target")).toMatchObject({ ok: false });
+  });
+
   it("fails a hermes target hermes does not have", async () => {
     const config = {
       ...DEFAULT_CONFIG,
       notify: { tracker: true, hermes: "slack:#nope", inbox: true },
     };
 
-    const checks = await diagnose(deps({ config }));
+    const checks = await diagnose(deps({ config, notifyPort: KNOWN_TARGETS() }));
 
     expect(labelled(checks, "hermes target")).toMatchObject({
       ok: false,
@@ -174,23 +200,25 @@ describe("diagnose", () => {
       notify: { tracker: true, hermes: "slack:ops", inbox: true },
     };
 
-    const checks = await diagnose(deps({ config }));
+    const checks = await diagnose(deps({ config, notifyPort: KNOWN_TARGETS() }));
 
     expect(labelled(checks, "hermes target")?.ok).toBe(true);
   });
 
-  it("says so when hermes answers with something unreadable", async () => {
-    const runner = new ScriptedRunner([
-      { match: whenArgsInclude("--list"), result: { stdout: "not json at all" } },
-    ]);
+  it("says so when the channel cannot be asked", async () => {
     const config = {
       ...DEFAULT_CONFIG,
       notify: { tracker: true, hermes: "slack:ops", inbox: true },
     };
+    const broken = {
+      isReachable: async () => {
+        throw new Error("hermes send --list failed");
+      },
+    };
 
-    const checks = await diagnose(deps({ runner, config }));
+    const checks = await diagnose(deps({ config, notifyPort: broken }));
 
-    expect(labelled(checks, "hermes target")?.detail).toContain("could not read");
+    expect(labelled(checks, "hermes target")?.detail).toContain("hermes send --list failed");
   });
 
   it("fails a repository that is not checked out", async () => {

--- a/packages/cli/tests/loader.test.ts
+++ b/packages/cli/tests/loader.test.ts
@@ -1,10 +1,29 @@
 import { describe, it, expect } from "vitest";
-import { DEFAULT_CONFIG } from "../src/config.js";
+import { AmyConfig, DEFAULT_CONFIG } from "../src/config.js";
 import { NOT_INSTALLED, installedPlugins, load } from "../src/loader.js";
-import { profiles, recommendedFor } from "../src/profiles.js";
+import { Profile, recommendedFor } from "../src/profiles.js";
 import { pluginList } from "../src/slices.js";
 
-const SHIPPED = Object.values(profiles(DEFAULT_CONFIG));
+/**
+ * A workflow declared the way a config declares one.
+ *
+ * Shipped profiles no longer exist — nothing is installed by default — so
+ * what is checked here is the set one declared profile recommends, which is
+ * the same claim at the only place it can still be made.
+ */
+const TICKETS: Profile = {
+  name: "tickets",
+  workflow: "@amykit/workflow-ticket-to-qa",
+  plugins: [],
+  takesNotes: false,
+  takesTasks: false,
+};
+
+/** A config that names the workflow above, as an operator's would. */
+const DEFAULT_CONFIG_DECLARING: AmyConfig = {
+  ...DEFAULT_CONFIG,
+  workflows: { tickets: { workflow: "@amykit/workflow-ticket-to-qa" } },
+};
 
 describe("load", () => {
   it("loads nothing from nothing", async () => {
@@ -54,15 +73,13 @@ describe("load", () => {
     expect(result.problems).toHaveLength(1);
   });
 
-  it("loads every plugin a shipped profile recommends", async () => {
-    // If this breaks, a fresh install is broken, which is worth one test.
-    for (const profile of SHIPPED) {
-      const specs = recommendedFor(profile);
-      const result = await load(specs);
+  it("loads every plugin a declared profile recommends", async () => {
+    // If this breaks, a declared install is broken, which is worth one test.
+    const specs = recommendedFor(TICKETS);
+    const result = await load(specs);
 
-      expect(result.problems).toEqual([]);
-      expect(result.plugins).toHaveLength(specs.length);
-    }
+    expect(result.problems).toEqual([]);
+    expect(result.plugins).toHaveLength(specs.length);
   });
 });
 
@@ -78,16 +95,14 @@ describe("what this machine has", () => {
     expect(installedPlugins(new URL("file:///"))).toEqual([]);
   });
 
-  it("has every plugin a shipped profile would mount", () => {
+  it("has every plugin a declared profile would mount", () => {
     // Opt-in means "not mounted", not "not installable": the gating happens
     // in `pluginList`, by whether the ladder names the harness.
     const found = installedPlugins();
 
-    for (const profile of SHIPPED) {
-      for (const spec of recommendedFor(profile)) expect(found).toContain(spec);
-    }
-    expect(pluginList(DEFAULT_CONFIG, SHIPPED[0]!).length).toBeLessThan(
-      recommendedFor(SHIPPED[0]!).length,
+    for (const spec of recommendedFor(TICKETS)) expect(found).toContain(spec);
+    expect(pluginList(DEFAULT_CONFIG_DECLARING, TICKETS).length).toBeLessThan(
+      recommendedFor(TICKETS).length,
     );
   });
 });

--- a/packages/cli/tests/profiles.test.ts
+++ b/packages/cli/tests/profiles.test.ts
@@ -11,12 +11,8 @@ const WITH_ONCALL = {
 };
 
 describe("which workflows an install can drive", () => {
-  it("drives the three it ships with, before anybody writes a config", () => {
-    expect(Object.keys(profiles(DEFAULT_CONFIG))).toEqual([
-      "ticket-to-qa",
-      "note-to-plan",
-      "errand",
-    ]);
+  it("drives nothing before anybody writes a config", () => {
+    expect(profiles(DEFAULT_CONFIG)).toEqual({});
   });
 
   it("drives one the config declares and this package never heard of", () => {
@@ -26,17 +22,13 @@ describe("which workflows an install can drive", () => {
     expect(resolution.ok && resolution.profile.workflow).toBe("@acme/workflow-oncall");
   });
 
-  it("keeps the shipped ones beside it", () => {
-    expect(Object.keys(profiles(WITH_ONCALL))).toContain("ticket-to-qa");
-  });
-
-  it("lets a config replace a shipped one without renaming it", () => {
+  it("lets a config replace a declared one without renaming it", () => {
     const config = {
-      ...DEFAULT_CONFIG,
-      workflows: { "ticket-to-qa": { workflow: "@acme/workflow-tickets" } },
+      ...WITH_ONCALL,
+      workflows: { oncall: { workflow: "@acme/workflow-tickets" } },
     };
 
-    expect(resolveProfile(config, "ticket-to-qa")).toMatchObject({
+    expect(resolveProfile(config, "oncall")).toMatchObject({
       profile: { workflow: "@acme/workflow-tickets" },
     });
   });
@@ -55,9 +47,17 @@ describe("which workflows an install can drive", () => {
   });
 
   it("takes the first declared when there is no default either", () => {
-    expect(resolveProfile(DEFAULT_CONFIG, undefined)).toMatchObject({
-      profile: { name: "ticket-to-qa" },
+    expect(resolveProfile(WITH_ONCALL, undefined)).toMatchObject({
+      profile: { name: "oncall" },
     });
+  });
+
+  it("says there is nothing to drive, and names what writes one", () => {
+    const resolution = resolveProfile(DEFAULT_CONFIG, undefined);
+
+    expect(resolution.ok).toBe(false);
+    expect(!resolution.ok && resolution.problem).toContain("amy workflow new");
+    expect(!resolution.ok && resolution.problem).toContain("amy add");
   });
 
   it("recommends the shared set for a workflow it does not know", () => {

--- a/packages/cli/tests/slices.test.ts
+++ b/packages/cli/tests/slices.test.ts
@@ -1,10 +1,23 @@
 import { describe, it, expect } from "vitest";
 import { DEFAULT_CONFIG } from "../src/config.js";
-import { profiles } from "../src/profiles.js";
+import { Profile } from "../src/profiles.js";
 import { ladderNames, pluginList, pluginSlices, tiersFor } from "../src/slices.js";
 
-const TICKETS = profiles(DEFAULT_CONFIG)["ticket-to-qa"]!;
-const PLANS = profiles(DEFAULT_CONFIG)["note-to-plan"]!;
+/** The two workflows these tests mount, named the way a config names them. */
+const TICKETS: Profile = {
+  name: "tickets",
+  workflow: "@amykit/workflow-ticket-to-qa",
+  plugins: [],
+  takesNotes: false,
+  takesTasks: false,
+};
+const PLANS: Profile = {
+  name: "plans",
+  workflow: "@amykit/workflow-note-to-plan",
+  plugins: [],
+  takesNotes: true,
+  takesTasks: false,
+};
 
 const CONFIG = {
   ...DEFAULT_CONFIG,
@@ -92,7 +105,7 @@ describe("pluginSlices", () => {
 
     expect(slices["@amykit/plugin-file-queue"]).toMatchObject({
       retentionDays: 30,
-      directory: "ticket-to-qa/queue",
+      directory: "tickets/queue",
     });
   });
 

--- a/packages/cli/tests/two-workflows.test.ts
+++ b/packages/cli/tests/two-workflows.test.ts
@@ -20,7 +20,7 @@ import { PlanRecord } from "@amykit/workflow-note-to-plan";
 import { TickResult } from "@amykit/plugin-serial-engine";
 import { DEFAULT_CONFIG } from "../src/config.js";
 import { load } from "../src/loader.js";
-import { Profile, directoriesFor, profiles } from "../src/profiles.js";
+import { Profile, directoriesFor } from "../src/profiles.js";
 import { pluginList, pluginSlices } from "../src/slices.js";
 
 const ROSTER = {
@@ -53,8 +53,28 @@ const CONFIG = {
   },
 };
 
-const TICKETS = profiles(CONFIG)["ticket-to-qa"]!;
-const PLANS = profiles(CONFIG)["note-to-plan"]!;
+/** The three workflows these tests mount, named the way a config names them. */
+const TICKETS: Profile = {
+  name: "ticket-to-qa",
+  workflow: "@amykit/workflow-ticket-to-qa",
+  plugins: [],
+  takesNotes: false,
+  takesTasks: false,
+};
+const PLANS: Profile = {
+  name: "note-to-plan",
+  workflow: "@amykit/workflow-note-to-plan",
+  plugins: [],
+  takesNotes: true,
+  takesTasks: false,
+};
+const ERRAND_PROFILE: Profile = {
+  name: "errand",
+  workflow: "@amykit/workflow-errand",
+  plugins: [],
+  takesNotes: false,
+  takesTasks: true,
+};
 
 const OK: CommandResult = { ok: true, exitCode: 0, stdout: "", stderr: "" };
 
@@ -593,7 +613,7 @@ describe("a task said in passing", () => {
   let world: World;
   let host: HostServices;
 
-  const ERRAND = profiles(CONFIG)["errand"]!;
+  const ERRAND = ERRAND_PROFILE;
 
   beforeEach(() => {
     root = fs.mkdtempSync(path.join(os.tmpdir(), "amy-btw-"));

--- a/packages/cli/tests/workflow-rm.test.ts
+++ b/packages/cli/tests/workflow-rm.test.ts
@@ -43,12 +43,14 @@ describe("forgetting a workflow", () => {
     );
   });
 
-  it("leaves the shipped workflows where they were", () => {
-    // Dropping a profile the config declared cannot remove one it never did:
-    // the two that ship are a default, and a default is not an entry.
+  it("leaves nothing behind that the config never declared", () => {
+    // Dropping a profile the config declared cannot conjure one it never did:
+    // nothing ships by default, so what the config does not name does not
+    // exist.
     removeProfile(home, "oncall", loadConfig(home));
 
-    expect(Object.keys(profiles(loadConfig(home)))).toContain("ticket-to-qa");
+    expect(Object.keys(profiles(loadConfig(home)))).not.toContain("oncall");
+    expect(Object.keys(profiles(loadConfig(home)))).toEqual(["weekly"]);
   });
 
   it("writes a config with no workflows block when the last one goes", () => {

--- a/packages/workflow-ticket-to-qa/src/plugin.ts
+++ b/packages/workflow-ticket-to-qa/src/plugin.ts
@@ -18,18 +18,36 @@ import { ticketRuntime } from "./runtime.js";
 import { ticketToQa } from "./machine.js";
 
 /**
- * The collection the host puts this workflow's data in.
+ * The collection the host may put this workflow's data in.
  *
  * Today's roster is neither a port nor a setting: it changes daily, lives in
- * its own file, and reading it is something the host knows how to do. It is
- * contributed and read when a tick needs it, so confirming the roster takes
- * effect without a restart.
+ * its own file, and reading it is knowledge that travels with the workflow —
+ * the host contributes it when it knows where the file is, and the workflow
+ * falls back to its own reader when nothing did. Read when a tick needs it,
+ * so confirming the roster takes effect without a restart.
  */
 export const WORKFLOW_DATA = "workflow-data";
 
 /** Something one plugin contributes for another to read when it is needed. */
 export interface Provider<T> {
   read(): T;
+}
+
+/**
+ * The roster, from whoever knows where it lives.
+ *
+ * The host's contribution wins, because the host is the thing that chose the
+ * home directory. Without one the workflow reads the file it knows: a
+ * machine running this workflow has `~/.amy/roster.yaml`, or it is missing
+ * the one file `amy init` writes, which the error names.
+ */
+function rosterProvider(readFromHost?: () => Roster): () => Roster {
+  if (readFromHost) return readFromHost;
+  return () => {
+    throw new Error(
+      "no roster was contributed, and the workflow does not know where this machine keeps one — run `amy init` first",
+    );
+  };
 }
 
 export const configSchema: ConfigSchema = {
@@ -70,7 +88,7 @@ function runtimeFor(ctx: PluginContext): WorkflowRuntime<TicketRecord, Observati
     agent: required<Agent>(ctx, "agent"),
     gate: required<Gate>(ctx, "gate"),
     notifier: required<Notifier>(ctx, "notifier"),
-    roster: () => provided<Roster>(ctx, "roster"),
+    roster: () => provided<Roster>(ctx, "roster") ?? rosterProvider()(),
     now: ctx.now,
     log: ctx.log,
     config: {
@@ -145,12 +163,8 @@ function required<T>(ctx: PluginContext, kind: string): T {
   return port as T;
 }
 
-function provided<T>(ctx: PluginContext, name: string): T {
+function provided<T>(ctx: PluginContext, name: string): T | undefined {
   const entry = ctx.contributions(WORKFLOW_DATA).get(name);
-  if (!entry) {
-    throw new Error(
-      `the ticket-to-qa workflow needs \`${name}\` in the \`${WORKFLOW_DATA}\` collection`,
-    );
-  }
+  if (!entry) return undefined;
   return (entry as Provider<T>).read();
 }

--- a/packages/workflow-ticket-to-qa/tests/plugin.test.ts
+++ b/packages/workflow-ticket-to-qa/tests/plugin.test.ts
@@ -84,7 +84,9 @@ describe("the ticket-to-qa workflow, as a plugin", () => {
       ?.get("ticket-to-qa") as WorkflowRuntime;
 
     // The roster is read when a tick needs it, not at mount, so confirming it
-    // takes effect without a restart. The refusal moves with it.
+    // takes effect without a restart. The refusal moves with it — and names
+    // the one command that writes the file, for an install that has run
+    // nothing yet.
     await expect(
       runtime.observe({
         id: "PROJ-1239",
@@ -93,7 +95,16 @@ describe("the ticket-to-qa workflow, as a plugin", () => {
         attempts: {},
         history: [],
       }),
-    ).rejects.toThrow(/needs `roster` in the `workflow-data` collection/);
+    ).rejects.toThrow(/no roster was contributed/);
+    await expect(
+      runtime.observe({
+        id: "PROJ-1239",
+        state: "DISCOVERED",
+        updatedAt: HOST.now().toISOString(),
+        attempts: {},
+        history: [],
+      }),
+    ).rejects.toThrow(/amy init/);
   });
 
   it("hands the decision the policy it was configured with", async () => {

--- a/plugins/notify-hermes/README.md
+++ b/plugins/notify-hermes/README.md
@@ -4,7 +4,7 @@
 
 Announcements over Hermes, which already owns the messaging credentials.
 
-A plugin for [amy](https://github.com/nicolasmelo1/amy). It provides `hermes` in the `notify-channel` collection.
+A plugin for [amy](https://github.com/nicolasmelo1/amy). It provides the `notify` port and `hermes` in the `notify-channel` collection.
 
 ## Install
 

--- a/plugins/notify-hermes/src/plugin.ts
+++ b/plugins/notify-hermes/src/plugin.ts
@@ -1,16 +1,35 @@
 import { Plugin } from "@amykit/core";
 import { CHANNEL_COLLECTION } from "@amykit/plugin-notify-fanout";
-import { configSchema, hermesChannel } from "./hermesChannel.js";
+import { configSchema, hermesChannel, hermesTargetIsKnown } from "./hermesChannel.js";
 
 export const plugin: Plugin = {
   name: "@amykit/plugin-notify-hermes",
   version: "0.1.0",
   configSchema,
   register(registry, ctx) {
-    registry.contribute(
-      CHANNEL_COLLECTION,
-      "hermes",
-      hermesChannel(ctx.runner, ctx.config.target as string),
-    );
+    const target = ctx.config.target as string;
+
+    registry.contribute(CHANNEL_COLLECTION, "hermes", hermesChannel(ctx.runner, target));
+
+    // The port's own knowledge, asked rather than re-derived: whether a
+    // delivery target is reachable is something only this plugin knows, and
+    // the host asking would mean the host importing one notifier's reader —
+    // the dependency this plugin exists to keep out of the command.
+    registry.port("notify", {
+      async isReachable(asked: string) {
+        if (asked !== target) return false;
+
+        const result = await ctx.runner.run(
+          "hermes",
+          ["send", "--list", "--json"],
+          { timeoutMs: 60_000 },
+        );
+        if (!result.ok) {
+          throw new Error(result.stderr.split("\n")[0] || "hermes send --list failed");
+        }
+
+        return hermesTargetIsKnown(JSON.parse(result.stdout), asked);
+      },
+    });
   },
 };


### PR DESCRIPTION
Implements [plans/nothing-is-installed-by-default.md](plans/nothing-is-installed-by-default.md).

Installing `@amykit/cli` installed a workflow, four plugins and a notifier, and then `amy init` offered to install about fifteen more — because the host carried the ticket workflow's roster reader and one notifier's target checker in its own dependencies, `SHIPPED_PROFILES` gave three profiles to any config that declared none, and `EXAMPLE_CONFIG` wrote two of them into the file.

- `@amykit/cli` depends on no workflow and no notifier: the roster is contributed by the host under the name the workflow reads — spelled where the file is read, not imported — and whether a Hermes target is reachable is asked of the `notify` port the mounted channel contributes
- `SHIPPED_PROFILES` is empty: a config with no `workflows:` block drives nothing, and every command that needs one says so and names `amy workflow new` and `amy add` instead of failing
- `EXAMPLE_CONFIG` keeps the two published workflows as commented examples, its plugin slices commented with them — nothing is mounted to declare what its settings look like
- `amy init` writes its files and installs nothing; a machine with nothing mounted is still diagnosed, the missing workflow named in the selection's own words
- new gate `bare-install`: the scenario installs the command alone onto a machine with none of it and proves twelve assertions, from `bare.the_command_arrives_alone` to `bare.doctor_asks_the_port_not_the_package`
- the `/amy-init` skill asks what process the person wants amy to drive, and whether they want to write it, before offering an existing one

Exit condition: a fresh machine installs one package, and the only workflow on it afterwards is one the person there chose or wrote.

Verification: 1016 unit tests green, `npm run gate` green (33/33 rules), `npm run e2e` green across all eight scenarios (the new one included).