### PR TITLE
fix: the tracker stays quiet, and the budget counts what it spends

### DIFF
--- a/.changeset/quiet-trackers-and-honest-budgets.md
+++ b/.changeset/quiet-trackers-and-honest-budgets.md
@@ -1,0 +1,30 @@
+---
+"@amykit/plugin-linear": patch
+"@amykit/cli": patch
+"@amykit/core": patch
+---
+
+Stop commenting machine notices on the tracker, and stop counting cache reads
+against the token ceiling.
+
+Two defects that both made the machine lie to its operator, found on the same
+day on the same install.
+
+**`notify.tracker: false` was dead configuration.** `plugin-linear` contributed
+its notification channel unconditionally and never read the setting, so every
+engine notice was commented on the Linear ticket — under the operator's own
+name, because amy authenticates with a key issued to a person, and with no
+prefix or marker because the channel posted the raw announcement text. `REVV-7716
+is moving again in DONE after 2 failed attempt(s)` reached a real ticket and a
+colleague replied to it asking what it meant. The channel is now contributed
+only when asked for, the default is off, and what it writes says a machine
+wrote it on the first line.
+
+**One agent run could park the machine for five hours.** The token ceiling
+summed `input + output + cacheRead + cacheWrite`. A single implement run
+reported `input: 44, output: 17394, cacheRead: 1839757, cacheWrite: 92769` —
+1,949,964 against a 2,000,000 per-five-hours ceiling, from a run that cost
+$0.91 against a $20 ceiling in the same window. A cache read is the saving,
+not the spend, so the better prompt caching worked the sooner the machine
+locked itself out. The ceiling now counts billable tokens; `costUsd` remains
+the ceiling that knows what cache is worth.

--- a/.software-factory/evidence/bare-install.json
+++ b/.software-factory/evidence/bare-install.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "gate": "bare-install",
-  "implementation_sha256": "6696a5c6b60b0047f666bdb0374f7036fc8c15a1d0e0eb7e17e7619bcf44b56d",
+  "implementation_sha256": "4f655f4df928c81bee6d52b935ab4744d84eea00fd7c193c66eded839dafc298",
   "runs": [
     {
       "scenario": "bare-install",

--- a/.software-factory/evidence/installed-binary-run.json
+++ b/.software-factory/evidence/installed-binary-run.json
@@ -6,9 +6,9 @@
   "observed": {
     "assertions_run": 7,
     "assertions_failed": 0,
-    "version": "dev (running from source, not an installed build)",
-    "tree_was_dirty": "yes",
-    "build_on_log_line": "dev"
+    "version": "0.3.0 (4b54a6f, built 2026-09-09T16:48:43Z)",
+    "tree_was_dirty": "no",
+    "build_on_log_line": "0.3.0+4b54a6f"
   },
   "assertions": [{"type":"installed.runs_without_a_checkout","status":"passed"},{"type":"installed.keeps_state_in_its_own_home","status":"passed"},{"type":"installed.keeps_nothing_where_you_stand","status":"passed"},{"type":"installed.does_not_write_into_the_source_tree","status":"passed"},{"type":"installed.log_line_names_the_build","status":"passed"},{"type":"installed.says_dev_only_when_it_is_one","status":"passed"},{"type":"installed.log_build_matches_the_binary","status":"passed"}]
 }

--- a/.software-factory/evidence/installed-binary.json
+++ b/.software-factory/evidence/installed-binary.json
@@ -8,7 +8,7 @@
       "status": "passed",
       "actor": "Claude (agent), running .software-factory/evidence/installed-binary-scenario.sh against a freshly installed binary on macOS, for Nicolas Melo",
       "report": ".software-factory/evidence/installed-binary-run.json",
-      "report_sha256": "3bb59930a11d628f4e964f0c02d3d8f41dc3f50d13fc8b7cf29ec8545be15194",
+      "report_sha256": "a178f426f1acb53e62e37b98e1c0a63fe4081905f17758a04f543645b96364c2",
       "required_assertions": []
     }
   ]

--- a/.software-factory/evidence/installed-plugins.json
+++ b/.software-factory/evidence/installed-plugins.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "gate": "installed-plugins",
-  "implementation_sha256": "5031894b02896e12d7f68819ae8212b8ec7a4092f42c7fb0252f5a2f719be2eb",
+  "implementation_sha256": "150c05ef65b1f669258d7503ee627a08f1f522fc15761f513f39b62b798603c3",
   "runs": [
     {
       "scenario": "installed-plugins",

--- a/.software-factory/evidence/note-to-plan-run.json
+++ b/.software-factory/evidence/note-to-plan-run.json
@@ -42,8 +42,8 @@
     "notes_left": [
       "by-hand.md",
       "not-mine.md",
-      "note-2026-09-09T133416505.md",
-      "note-2026-09-09T133420272.md",
+      "note-2026-09-09T164906449.md",
+      "note-2026-09-09T164910082.md",
       "will-break.md"
     ],
     "budget": "new work: allowed"

--- a/.software-factory/evidence/note-to-plan-run.json
+++ b/.software-factory/evidence/note-to-plan-run.json
@@ -42,8 +42,8 @@
     "notes_left": [
       "by-hand.md",
       "not-mine.md",
-      "note-2026-09-09T023638798.md",
-      "note-2026-09-09T023642478.md",
+      "note-2026-09-09T133416505.md",
+      "note-2026-09-09T133420272.md",
       "will-break.md"
     ],
     "budget": "new work: allowed"

--- a/.software-factory/evidence/note-to-plan.json
+++ b/.software-factory/evidence/note-to-plan.json
@@ -1,14 +1,14 @@
 {
   "schema_version": 1,
   "gate": "note-to-plan",
-  "implementation_sha256": "6c8f3077257cfc615ff7edb8aa29f60a54e4671e9598fd39a2705fbd84c40d37",
+  "implementation_sha256": "342cf8400ac4b5ac6af5fe650fdae51a7dc05251cbf822fd323612636282d76f",
   "runs": [
     {
       "scenario": "note-to-plan",
       "status": "passed",
       "actor": "Claude (agent), driving the installed executable from a written-down piece of friction to a pull request against stand-in services on macOS, for Nicolas Melo",
       "report": ".software-factory/evidence/note-to-plan-run.json",
-      "report_sha256": "8a296a4b599b8fda181f606069804e9730062587340b6025642202a307b465b6",
+      "report_sha256": "9b596a7fddcab1a80fd11c1afd25ac94da92a270964f81d450dceed71e75eac8",
       "required_assertions": []
     }
   ]

--- a/.software-factory/evidence/note-to-plan.json
+++ b/.software-factory/evidence/note-to-plan.json
@@ -8,7 +8,7 @@
       "status": "passed",
       "actor": "Claude (agent), driving the installed executable from a written-down piece of friction to a pull request against stand-in services on macOS, for Nicolas Melo",
       "report": ".software-factory/evidence/note-to-plan-run.json",
-      "report_sha256": "9b596a7fddcab1a80fd11c1afd25ac94da92a270964f81d450dceed71e75eac8",
+      "report_sha256": "c63c8ee13e32c17f00a41666d976e64883457d45d246a71741caedb79e022d4c",
       "required_assertions": []
     }
   ]

--- a/.software-factory/evidence/ticket-to-qa-run.json
+++ b/.software-factory/evidence/ticket-to-qa-run.json
@@ -56,12 +56,12 @@
     ],
     "what_the_world_did": [
       "a colleague answered the question on the ticket",
-      "the automated reviewer looked at c5e8f06 and left one comment",
-      "the automated reviewer looked at e318c70 and had nothing to say",
+      "the automated reviewer looked at e7f7b5c and left one comment",
+      "the automated reviewer looked at 66cf1c6 and had nothing to say",
       "one of ada's other reviews was merged, so she is carrying one",
-      "ada asked for changes on e318c70",
+      "ada asked for changes on 66cf1c6",
       "the owner settled the disagreement on the ticket",
-      "ada approved 442148f"
+      "ada approved 25a8906"
     ],
     "agent_calls": [
       "triage",

--- a/.software-factory/evidence/ticket-to-qa-run.json
+++ b/.software-factory/evidence/ticket-to-qa-run.json
@@ -56,12 +56,12 @@
     ],
     "what_the_world_did": [
       "a colleague answered the question on the ticket",
-      "the automated reviewer looked at ea4ee13 and left one comment",
-      "the automated reviewer looked at 6bc0f30 and had nothing to say",
+      "the automated reviewer looked at c5e8f06 and left one comment",
+      "the automated reviewer looked at e318c70 and had nothing to say",
       "one of ada's other reviews was merged, so she is carrying one",
-      "ada asked for changes on 6bc0f30",
+      "ada asked for changes on e318c70",
       "the owner settled the disagreement on the ticket",
-      "ada approved c0ecf7e"
+      "ada approved 442148f"
     ],
     "agent_calls": [
       "triage",

--- a/.software-factory/evidence/ticket-to-qa.json
+++ b/.software-factory/evidence/ticket-to-qa.json
@@ -1,14 +1,14 @@
 {
   "schema_version": 1,
   "gate": "ticket-to-qa",
-  "implementation_sha256": "677e601125250cf02dfb00f5f64b91f96a927ddf03c6ef120b747c123888685e",
+  "implementation_sha256": "4564cc4d8a49b66d326ed7dbf54d40882eaed6100e816e9fa12d81bebfcaa1d7",
   "runs": [
     {
       "scenario": "ticket-to-qa",
       "status": "passed",
       "actor": "Claude (agent), driving the installed executable through one ticket against stand-in services on macOS, for Nicolas Melo",
       "report": ".software-factory/evidence/ticket-to-qa-run.json",
-      "report_sha256": "541aef1f846d95aea6852dce0dd073f09ca8b2a0635fb117254e75bc3b4a40b5",
+      "report_sha256": "00491327f4a4d3c14f926bb92e11915016d3cd84c9cb69d0491957e0e3069625",
       "required_assertions": []
     }
   ]

--- a/.software-factory/evidence/ticket-to-qa.json
+++ b/.software-factory/evidence/ticket-to-qa.json
@@ -8,7 +8,7 @@
       "status": "passed",
       "actor": "Claude (agent), driving the installed executable through one ticket against stand-in services on macOS, for Nicolas Melo",
       "report": ".software-factory/evidence/ticket-to-qa-run.json",
-      "report_sha256": "00491327f4a4d3c14f926bb92e11915016d3cd84c9cb69d0491957e0e3069625",
+      "report_sha256": "7e1669deedb37fd3d57a7f737560f46aad90c9c1ce346afedf20ee0a03120e31",
       "required_assertions": []
     }
   ]

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -22,7 +22,31 @@ npm run docs:changelog     # refresh the cache from GitHub
 
 <!-- amy:generated changelog-unreleased -->
 
-Nothing is pending. `.changeset/` is empty, which between releases is not a mistake.
+### Stop commenting machine notices on the tracker, and stop counting cache reads against the token ceiling.
+
+`patch` · `@amykit/cli`, `@amykit/core`, `@amykit/plugin-linear`
+
+Two defects that both made the machine lie to its operator, found on the same
+day on the same install.
+
+**`notify.tracker: false` was dead configuration.** `plugin-linear` contributed
+its notification channel unconditionally and never read the setting, so every
+engine notice was commented on the Linear ticket — under the operator's own
+name, because amy authenticates with a key issued to a person, and with no
+prefix or marker because the channel posted the raw announcement text. `REVV-7716
+is moving again in DONE after 2 failed attempt(s)` reached a real ticket and a
+colleague replied to it asking what it meant. The channel is now contributed
+only when asked for, the default is off, and what it writes says a machine
+wrote it on the first line.
+
+**One agent run could park the machine for five hours.** The token ceiling
+summed `input + output + cacheRead + cacheWrite`. A single implement run
+reported `input: 44, output: 17394, cacheRead: 1839757, cacheWrite: 92769` —
+1,949,964 against a 2,000,000 per-five-hours ceiling, from a run that cost
+$0.91 against a $20 ceiling in the same window. A cache read is the saving,
+not the spend, so the better prompt caching worked the sooner the machine
+locked itself out. The ceiling now counts billable tokens; `costUsd` remains
+the ceiling that knows what cache is worth.
 
 <!-- amy:end changelog-unreleased -->
 

--- a/docs/concepts/plugins.md
+++ b/docs/concepts/plugins.md
@@ -131,7 +131,7 @@ reach the fan-out without the core learning the word "channel".
 | :-- | :-- | :-- |
 | `agent` | `claude` — `@amykit/plugin-claude`<br>`codex` — `@amykit/plugin-codex`<br>`hermes` — `@amykit/plugin-hermes-agent` | `@amykit/agent-kit` |
 | `harness` | `claude` — `@amykit/plugin-claude`<br>`codex` — `@amykit/plugin-codex`<br>`hermes` — `@amykit/plugin-hermes-agent` | `@amykit/agent-kit` |
-| `notify-channel` | `hermes` — `@amykit/plugin-notify-hermes`<br>`inbox` — `@amykit/plugin-notify-inbox`<br>`tracker` — `@amykit/plugin-linear` | _whichever plugin reads it_ |
+| `notify-channel` | `hermes` — `@amykit/plugin-notify-hermes`<br>`inbox` — `@amykit/plugin-notify-inbox` | _whichever plugin reads it_ |
 | `workflow-runtime` | `errand` — `@amykit/workflow-errand`<br>`note-to-plan` — `@amykit/workflow-note-to-plan`<br>`ticket-to-qa` — `@amykit/workflow-ticket-to-qa` | `@amykit/agent-kit` |
 
 <!-- amy:end collections -->
@@ -212,7 +212,7 @@ anything built from `ctx`, do the same.
 | `@amykit/plugin-file-tasks` | Tasks as a directory of files: written by `amy btw`, by an editor, or by a hook. | `tasks` |  |
 | `@amykit/plugin-github` | GitHub as the code host, through the gh CLI. | `code-host` |  |
 | `@amykit/plugin-hermes-agent` | Hermes as the agent, over its one-shot mode and usage report. |  | `agent:hermes`<br>`harness:hermes` |
-| `@amykit/plugin-linear` | Linear as the tracker, over its GraphQL API. | `tracker` | `notify-channel:tracker` |
+| `@amykit/plugin-linear` | Linear as the tracker, over its GraphQL API. | `tracker` |  |
 | `@amykit/plugin-notify-fanout` | Sends one announcement down every configured channel, and keeps going when one is down. | `notifier` |  |
 | `@amykit/plugin-notify-hermes` | Announcements over Hermes, which already owns the messaging credentials. | `notify` | `notify-channel:hermes` |
 | `@amykit/plugin-notify-inbox` | Announcements as a file on disk plus a desktop notification. |  | `notify-channel:inbox` |

--- a/docs/development/documentation.md
+++ b/docs/development/documentation.md
@@ -84,7 +84,7 @@ A page is markdown with markers in it:
 | `@amykit/plugin-file-tasks` | Tasks as a directory of files: written by `amy btw`, by an editor, or by a hook. | `tasks` |  |
 | `@amykit/plugin-github` | GitHub as the code host, through the gh CLI. | `code-host` |  |
 | `@amykit/plugin-hermes-agent` | Hermes as the agent, over its one-shot mode and usage report. |  | `agent:hermes`<br>`harness:hermes` |
-| `@amykit/plugin-linear` | Linear as the tracker, over its GraphQL API. | `tracker` | `notify-channel:tracker` |
+| `@amykit/plugin-linear` | Linear as the tracker, over its GraphQL API. | `tracker` |  |
 | `@amykit/plugin-notify-fanout` | Sends one announcement down every configured channel, and keeps going when one is down. | `notifier` |  |
 | `@amykit/plugin-notify-hermes` | Announcements over Hermes, which already owns the messaging credentials. | `notify` | `notify-channel:hermes` |
 | `@amykit/plugin-notify-inbox` | Announcements as a file on disk plus a desktop notification. |  | `notify-channel:inbox` |

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -673,6 +673,11 @@
           "slug": "coming-next"
         },
         {
+          "depth": 3,
+          "title": "Stop commenting machine notices on the tracker, and stop counting cache reads against the token ceiling.",
+          "slug": "stop-commenting-machine-notices-on-the-tracker-and-stop-counting-cache-reads-against-the-token-ceiling"
+        },
+        {
           "depth": 2,
           "title": "Released",
           "slug": "released"
@@ -4186,10 +4191,6 @@
           {
             "name": "inbox",
             "package": "@amykit/plugin-notify-inbox"
-          },
-          {
-            "name": "tracker",
-            "package": "@amykit/plugin-linear"
           }
         ]
       },
@@ -4757,13 +4758,15 @@
         "mounts": [
           "tracker"
         ],
-        "contributes": [
-          {
-            "collection": "notify-channel",
-            "name": "tracker"
-          }
-        ],
+        "contributes": [],
         "settings": [
+          {
+            "name": "announceOnTicket",
+            "type": "boolean",
+            "required": false,
+            "default": false,
+            "description": "also comment every notification on the ticket. Off: the tracker is for questions and answers, and a progress notice is neither"
+          },
           {
             "name": "defaultRepo",
             "type": "string",
@@ -5704,7 +5707,28 @@
   },
   "changelog": {
     "releases": [],
-    "unreleased": [],
+    "unreleased": [
+      {
+        "id": "quiet-trackers-and-honest-budgets",
+        "title": "Stop commenting machine notices on the tracker, and stop counting cache reads against the token ceiling.",
+        "body": "Two defects that both made the machine lie to its operator, found on the same\nday on the same install.\n\n**`notify.tracker: false` was dead configuration.** `plugin-linear` contributed\nits notification channel unconditionally and never read the setting, so every\nengine notice was commented on the Linear ticket — under the operator's own\nname, because amy authenticates with a key issued to a person, and with no\nprefix or marker because the channel posted the raw announcement text. `REVV-7716\nis moving again in DONE after 2 failed attempt(s)` reached a real ticket and a\ncolleague replied to it asking what it meant. The channel is now contributed\nonly when asked for, the default is off, and what it writes says a machine\nwrote it on the first line.\n\n**One agent run could park the machine for five hours.** The token ceiling\nsummed `input + output + cacheRead + cacheWrite`. A single implement run\nreported `input: 44, output: 17394, cacheRead: 1839757, cacheWrite: 92769` —\n1,949,964 against a 2,000,000 per-five-hours ceiling, from a run that cost\n$0.91 against a $20 ceiling in the same window. A cache read is the saving,\nnot the spend, so the better prompt caching worked the sooner the machine\nlocked itself out. The ceiling now counts billable tokens; `costUsd` remains\nthe ceiling that knows what cache is worth.",
+        "bumps": [
+          {
+            "package": "@amykit/cli",
+            "level": "patch"
+          },
+          {
+            "package": "@amykit/core",
+            "level": "patch"
+          },
+          {
+            "package": "@amykit/plugin-linear",
+            "level": "patch"
+          }
+        ],
+        "level": "patch"
+      }
+    ],
     "changelogs": [
       {
         "name": "@amykit/agent-kit",

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -34,7 +34,7 @@ For what the two halves mean and why, see
 | `gate` | `Record<string, string[]>` | `{}` | Gate commands per repository, with a `default` fallback. |
 | `agent` | `{ model?: string; /** Model tiers offered to the relay, cheapest first. */ models?: string[]; /** * Which contributed agents to try, in order, such as * `[claude:sonnet, claude:opus, codex:gpt-5]`. Empty means every agent * that was contributed, in mounting order. * * Naming a harness here is also what mounts it, so a ladder is the one * place an operator says which harnesses they have. */ ladder?: string[]; /** * A ladder for one step, keyed by the workflow's action name, overriding * the one above. * * Reading a ticket to decide whether it is clear enough to start is not * the same job as writing the change, and one list for both means paying * the expensive model to do the cheap step. A name here mounts its * harness exactly as a name in `ladder` does. */ ladderByStep?: Record<string, string[]>; reviewerHints?: Record<string, string>; timeoutMs?: number; /** * What the agents may spend, per window. Read by the relay, which is the * only thing here that spends one. Shape checked at boot, not here. */ budget?: Record<string, unknown>; }` | `{}` |  |
 | `skills` | `Record<string, string[]>` | `{}` | Which skills answer for a step, in the order they are tried, keyed by the workflow's action name. A skill named here has to be installed. |
-| `notify` | `NotifyConfig` | `{ tracker: true, hermes: null, inbox: true }` |  |
+| `notify` | `NotifyConfig` | `{ tracker: false, hermes: null, inbox: true }` |  |
 | `plans` | `PlansConfig` | `{ repos: [], check: { default: ["sf check"] }, policy: {} }` |  |
 | `errands` | `ErrandsConfig` | `{ policy: {} }` |  |
 | `plugins` | `Record<string, unknown>` | `{}` | One slice per plugin, keyed by package name. |
@@ -219,8 +219,15 @@ gate:
 #   triage: [/logion]
 
 # Where the machine reaches you. It needs at least one of these.
+#
+# The tracker is off by default and worth leaving off. Announcements go to
+# every channel that is on — there is no routing one of them — so turning it
+# on comments each progress notice on the ticket, and "ACME-1 is failing in
+# IMPLEMENTING and I am retrying: ..." is a machine talking about itself where
+# a team talks to each other. It does not silence a question: a workflow that
+# needs an answer about a ticket comments on it directly.
 notify:
-  tracker: true      # comment on the ticket
+  tracker: false     # also comment every notification on the ticket
   hermes: slack:my-channel   # a Hermes delivery target, or null
   inbox: true        # a file in .amy/needs-input plus a desktop notification
 

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -29,7 +29,7 @@ maintains.
 | `@amykit/plugin-file-tasks` | Tasks as a directory of files: written by `amy btw`, by an editor, or by a hook. | `tasks` |  |
 | `@amykit/plugin-github` | GitHub as the code host, through the gh CLI. | `code-host` |  |
 | `@amykit/plugin-hermes-agent` | Hermes as the agent, over its one-shot mode and usage report. |  | `agent:hermes`<br>`harness:hermes` |
-| `@amykit/plugin-linear` | Linear as the tracker, over its GraphQL API. | `tracker` | `notify-channel:tracker` |
+| `@amykit/plugin-linear` | Linear as the tracker, over its GraphQL API. | `tracker` |  |
 | `@amykit/plugin-notify-fanout` | Sends one announcement down every configured channel, and keeps going when one is down. | `notifier` |  |
 | `@amykit/plugin-notify-hermes` | Announcements over Hermes, which already owns the messaging credentials. | `notify` | `notify-channel:hermes` |
 | `@amykit/plugin-notify-inbox` | Announcements as a file on disk plus a desktop notification. |  | `notify-channel:inbox` |
@@ -338,13 +338,14 @@ Linear as the tracker, over its GraphQL API.
 | :-- | :-- |
 | Source | `plugins/linear` |
 | Mounts | `tracker` |
-| Contributes | `notify-channel:tracker` |
+| Contributes | _nothing_ |
 | Needs in the environment | `LINEAR_API_KEY` |
 | Depends on | `@amykit/core`, `@amykit/plugin-notify-fanout`, `@amykit/workflow-ticket-to-qa` |
 
 ```yaml
 plugins:
   "@amykit/plugin-linear":
+    announceOnTicket: false
     defaultRepo: ""
     endpoint: https://api.linear.app/graphql
     repoByTeam: {}
@@ -353,6 +354,7 @@ plugins:
 
 | Setting | Type | Required | Default | What it is |
 | :-- | :-- | :-- | :-- | :-- |
+| `announceOnTicket` | `boolean` | no | `false` | also comment every notification on the ticket. Off: the tracker is for questions and answers, and a progress notice is neither |
 | `defaultRepo` | `string` | no | `""` | the repository used for a team that is not in repoByTeam |
 | `endpoint` | `string` | no | `https://api.linear.app/graphql` | the GraphQL endpoint to talk to. Linear's own by default, and the one thing that has to move for a stand-in tracker to take its place in an end-to-end run |
 | `repoByTeam` | `record` | no | `{}` | which repository a team's tickets land in, by team key |
@@ -482,7 +484,7 @@ plugins:
 | :-- | :-- | :-- |
 | `agent` | `claude` — `@amykit/plugin-claude`<br>`codex` — `@amykit/plugin-codex`<br>`hermes` — `@amykit/plugin-hermes-agent` | `@amykit/agent-kit` |
 | `harness` | `claude` — `@amykit/plugin-claude`<br>`codex` — `@amykit/plugin-codex`<br>`hermes` — `@amykit/plugin-hermes-agent` | `@amykit/agent-kit` |
-| `notify-channel` | `hermes` — `@amykit/plugin-notify-hermes`<br>`inbox` — `@amykit/plugin-notify-inbox`<br>`tracker` — `@amykit/plugin-linear` | _whichever plugin reads it_ |
+| `notify-channel` | `hermes` — `@amykit/plugin-notify-hermes`<br>`inbox` — `@amykit/plugin-notify-inbox` | _whichever plugin reads it_ |
 | `workflow-runtime` | `errand` — `@amykit/workflow-errand`<br>`note-to-plan` — `@amykit/workflow-note-to-plan`<br>`ticket-to-qa` — `@amykit/workflow-ticket-to-qa` | `@amykit/agent-kit` |
 
 <!-- amy:end collections -->

--- a/docs/start/configuration.md
+++ b/docs/start/configuration.md
@@ -45,7 +45,7 @@ amy doctor        # checks it, and exits non-zero when something is wrong
 | `gate` | `Record<string, string[]>` | `{}` | Gate commands per repository, with a `default` fallback. |
 | `agent` | `{ model?: string; /** Model tiers offered to the relay, cheapest first. */ models?: string[]; /** * Which contributed agents to try, in order, such as * `[claude:sonnet, claude:opus, codex:gpt-5]`. Empty means every agent * that was contributed, in mounting order. * * Naming a harness here is also what mounts it, so a ladder is the one * place an operator says which harnesses they have. */ ladder?: string[]; /** * A ladder for one step, keyed by the workflow's action name, overriding * the one above. * * Reading a ticket to decide whether it is clear enough to start is not * the same job as writing the change, and one list for both means paying * the expensive model to do the cheap step. A name here mounts its * harness exactly as a name in `ladder` does. */ ladderByStep?: Record<string, string[]>; reviewerHints?: Record<string, string>; timeoutMs?: number; /** * What the agents may spend, per window. Read by the relay, which is the * only thing here that spends one. Shape checked at boot, not here. */ budget?: Record<string, unknown>; }` | `{}` |  |
 | `skills` | `Record<string, string[]>` | `{}` | Which skills answer for a step, in the order they are tried, keyed by the workflow's action name. A skill named here has to be installed. |
-| `notify` | `NotifyConfig` | `{ tracker: true, hermes: null, inbox: true }` |  |
+| `notify` | `NotifyConfig` | `{ tracker: false, hermes: null, inbox: true }` |  |
 | `plans` | `PlansConfig` | `{ repos: [], check: { default: ["sf check"] }, policy: {} }` |  |
 | `errands` | `ErrandsConfig` | `{ policy: {} }` |  |
 | `plugins` | `Record<string, unknown>` | `{}` | One slice per plugin, keyed by package name. |
@@ -249,8 +249,15 @@ gate:
 #   triage: [/logion]
 
 # Where the machine reaches you. It needs at least one of these.
+#
+# The tracker is off by default and worth leaving off. Announcements go to
+# every channel that is on — there is no routing one of them — so turning it
+# on comments each progress notice on the ticket, and "ACME-1 is failing in
+# IMPLEMENTING and I am retrying: ..." is a machine talking about itself where
+# a team talks to each other. It does not silence a question: a workflow that
+# needs an answer about a ticket comments on it directly.
 notify:
-  tracker: true      # comment on the ticket
+  tracker: false     # also comment every notification on the ticket
   hermes: slack:my-channel   # a Hermes delivery target, or null
   inbox: true        # a file in .amy/needs-input plus a desktop notification
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -203,7 +203,11 @@ export const DEFAULT_CONFIG: AmyConfig = {
   gate: {},
   agent: {},
   skills: {},
-  notify: { tracker: true, hermes: null, inbox: true },
+  // `tracker: false`, and the default is the decision: an announcement
+  // carries no channel, so "on" comments every progress notice the engine
+  // emits on the ticket. A tracker carries questions and answers, and a
+  // workflow with a question comments directly whatever this says.
+  notify: { tracker: false, hermes: null, inbox: true },
   plans: { repos: [], check: { default: ["sf check"] }, policy: {} },
   errands: { policy: {} },
   plugins: {},
@@ -480,8 +484,15 @@ gate:
 #   triage: [/logion]
 
 # Where the machine reaches you. It needs at least one of these.
+#
+# The tracker is off by default and worth leaving off. Announcements go to
+# every channel that is on — there is no routing one of them — so turning it
+# on comments each progress notice on the ticket, and "ACME-1 is failing in
+# IMPLEMENTING and I am retrying: ..." is a machine talking about itself where
+# a team talks to each other. It does not silence a question: a workflow that
+# needs an answer about a ticket comments on it directly.
 notify:
-  tracker: true      # comment on the ticket
+  tracker: false     # also comment every notification on the ticket
   hermes: slack:my-channel   # a Hermes delivery target, or null
   inbox: true        # a file in .amy/needs-input plus a desktop notification
 

--- a/packages/cli/src/slices.ts
+++ b/packages/cli/src/slices.ts
@@ -18,6 +18,10 @@ export function pluginSlices(config: AmyConfig, profile: Profile): Record<string
       workingStatusName: config.workingStatusName,
       repoByTeam: config.repoByTeam,
       defaultRepo: config.repos[0] ?? "",
+      // `notify.tracker`, reaching the plugin that owns the channel. Without
+      // this line the plugin cannot see the setting at all, and contributed
+      // its channel whatever the operator had written.
+      announceOnTicket: config.notify.tracker,
     },
     "@amykit/plugin-claude": harnessSlice(config, "claude"),
     "@amykit/plugin-codex": harnessSlice(config, "codex"),

--- a/packages/cli/tests/slices.test.ts
+++ b/packages/cli/tests/slices.test.ts
@@ -39,6 +39,23 @@ describe("pluginSlices", () => {
     });
   });
 
+  /**
+   * The plugin owns the ticket channel, so it is the only thing that can
+   * decline to contribute it — and it cannot see `notify.tracker` unless this
+   * line hands it over. Without it the setting was dead: an operator turned
+   * commenting off, and every progress notice was still posted on the ticket.
+   */
+  it("tells the tracker whether announcements may be commented on the ticket", () => {
+    const off = pluginSlices(CONFIG, TICKETS) as Record<string, Record<string, unknown>>;
+    const on = pluginSlices(
+      { ...CONFIG, notify: { ...CONFIG.notify, tracker: true } },
+      TICKETS,
+    ) as Record<string, Record<string, unknown>>;
+
+    expect(off["@amykit/plugin-linear"]?.announceOnTicket).toBe(false);
+    expect(on["@amykit/plugin-linear"]?.announceOnTicket).toBe(true);
+  });
+
   it("gives the agent and the gate the branch new work is cut from", () => {
     const slices = pluginSlices(CONFIG, TICKETS) as Record<string, Record<string, unknown>>;
 

--- a/packages/core/src/agent-run.ts
+++ b/packages/core/src/agent-run.ts
@@ -92,3 +92,25 @@ export function totalTokens(tokens: TokenUsage): number {
 export function inputSideTokens(tokens: TokenUsage): number {
   return tokens.input + tokens.cacheRead + tokens.cacheWrite;
 }
+
+/**
+ * What a run actually spends, which is not what it reads.
+ *
+ * A cache read is the *saving*: it is the same context, already paid for,
+ * served at a fraction of the price. Counting it against a ceiling inverts
+ * the incentive — the better the cache works the bigger this number gets, and
+ * the sooner the machine locks itself out for having been efficient.
+ *
+ * That is not hypothetical. One implement run on this install reported
+ * `input: 44, output: 17394, cacheRead: 1839757, cacheWrite: 92769`, which
+ * `totalTokens` adds to 1,949,964 — 97.5% of a 2,000,000 per-five-hours
+ * ceiling, from a run that cost $0.91 against a $20 ceiling in the same
+ * window. One run, and the machine parked itself for five hours.
+ *
+ * `costUsd` is the ceiling that already knows what cache is worth, because
+ * the model specs price the four kinds separately. This one is the quota
+ * proxy, and quota is spent on what is generated and freshly sent.
+ */
+export function billableTokens(tokens: TokenUsage): number {
+  return tokens.input + tokens.output;
+}

--- a/packages/core/src/budget.ts
+++ b/packages/core/src/budget.ts
@@ -1,4 +1,4 @@
-import { totalTokens } from "./agent-run.js";
+import { billableTokens } from "./agent-run.js";
 import { ceilingFor } from "./budget-config.js";
 import {
   Budget,
@@ -168,7 +168,10 @@ function tokensIn(detail: Record<string, unknown>): number {
   const tokens = detail.tokens;
   if (!isRecord(tokens)) return 0;
 
-  return totalTokens({
+  // Billable, not total: a cache read is context already paid for, and
+  // counting it here parked this machine for five hours after a single run.
+  // See `billableTokens`.
+  return billableTokens({
     input: numberAt(tokens, "input"),
     output: numberAt(tokens, "output"),
     cacheRead: numberAt(tokens, "cacheRead"),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -59,7 +59,7 @@ export type {
   WindowLimit,
 } from "./ports/Budget.js";
 export type { StopSwitch } from "./ports/StopSwitch.js";
-export { NO_TOKENS, inputSideTokens, totalTokens } from "./agent-run.js";
+export { NO_TOKENS, billableTokens, inputSideTokens, totalTokens } from "./agent-run.js";
 export { describeBuild, stampFrom, stampId } from "./build.js";
 export type { BuildStamp } from "./build.js";
 export type {

--- a/packages/core/tests/budget.test.ts
+++ b/packages/core/tests/budget.test.ts
@@ -22,12 +22,40 @@ function limits(overrides: Partial<BudgetLimits> = {}): BudgetLimits {
 }
 
 describe("spendSince", () => {
-  it("adds up every part of a run's token usage", () => {
+  /**
+   * A cache read is the saving, not the spend: the same context, already paid
+   * for, served at a fraction of the price. Counting it here inverts the
+   * incentive — the better prompt caching works the bigger the number gets,
+   * and the sooner the machine locks itself out for having been efficient.
+   */
+  it("counts what a run generated and freshly sent, not what it re-read", () => {
     const events = [
       run(ago(1), { costSource: "reported", tokens: { input: 1, output: 2, cacheRead: 4, cacheWrite: 8 } }),
     ];
 
-    expect(spendSince(events, new Date(NOW.getTime() - 5 * HOUR)).tokens).toBe(15);
+    expect(spendSince(events, new Date(NOW.getTime() - 5 * HOUR)).tokens).toBe(3);
+  });
+
+  /**
+   * The run that made this a bug rather than an opinion, reported verbatim by
+   * the claude harness on 2026-09-09. Summed whole it is 1,949,964 — 97.5% of
+   * a 2,000,000 per-five-hours ceiling — from a run that cost $0.91 against a
+   * $20 ceiling in the same window. One ticket parked the machine for five
+   * hours.
+   */
+  it("does not park a machine for five hours over one cached run", () => {
+    const events = [
+      run(ago(1), {
+        costSource: "reported",
+        costUsd: 0.9130554,
+        tokens: { input: 44, output: 17394, cacheRead: 1839757, cacheWrite: 92769 },
+      }),
+    ];
+
+    const spent = spendSince(events, new Date(NOW.getTime() - 5 * HOUR));
+
+    expect(spent.tokens).toBe(17438);
+    expect(spent.tokens).toBeLessThan(2_000_000 * 0.9);
   });
 
   it("ignores anything that is not an agent run", () => {

--- a/plugins/linear/README.md
+++ b/plugins/linear/README.md
@@ -4,7 +4,7 @@
 
 Linear as the tracker, over its GraphQL API.
 
-A plugin for [amy](https://github.com/nicolasmelo1/amy). It provides the `tracker` port and `tracker` in the `notify-channel` collection.
+A plugin for [amy](https://github.com/nicolasmelo1/amy). It provides the `tracker` port.
 
 ## Install
 
@@ -26,6 +26,7 @@ workflows:
 ```yaml
 plugins:
   "@amykit/plugin-linear":
+    announceOnTicket: false
     defaultRepo: ""
     endpoint: "https://api.linear.app/graphql"
     repoByTeam: {}
@@ -34,6 +35,7 @@ plugins:
 
 | Setting | Type | Required | Default | What it is |
 | :-- | :-- | :-- | :-- | :-- |
+| `announceOnTicket` | `boolean` | no | `false` | also comment every notification on the ticket. Off: the tracker is for questions and answers, and a progress notice is neither |
 | `defaultRepo` | `string` | no | `""` | the repository used for a team that is not in repoByTeam |
 | `endpoint` | `string` | no | `https://api.linear.app/graphql` | the GraphQL endpoint to talk to. Linear's own by default, and the one thing that has to move for a stand-in tracker to take its place in an end-to-end run |
 | `repoByTeam` | `record` | no | `{}` | which repository a team's tickets land in, by team key |

--- a/plugins/linear/src/config.ts
+++ b/plugins/linear/src/config.ts
@@ -24,6 +24,28 @@ export const configSchema: ConfigSchema = {
     description: "the repository used for a team that is not in repoByTeam",
     default: "",
   },
+  /**
+   * Whether a notification is also commented on the ticket.
+   *
+   * Off, and the default is the decision. This plugin contributes a channel
+   * to the fan-out, and the fan-out reaches every contributed channel with no
+   * way to route one announcement — so "on" means every progress notice the
+   * engine emits becomes a public comment. `TBO-1241 is failing in COPILOT_FIX
+   * and I am retrying: git checkout ... Aborting` landed on a real ticket a
+   * team reads, which is a machine talking about itself where people talk to
+   * each other.
+   *
+   * Turning it off does not make amy quiet: a workflow that has a question
+   * about a ticket calls `tracker.comment` directly, and the hermes and inbox
+   * channels still carry everything else. Derived from `notify.tracker`, so
+   * the file the operator edits is still the one place it is said.
+   */
+  announceOnTicket: {
+    type: "boolean",
+    description:
+      "also comment every notification on the ticket. Off: the tracker is for questions and answers, and a progress notice is neither",
+    default: false,
+  },
   endpoint: {
     type: "string",
     description:

--- a/plugins/linear/src/plugin.ts
+++ b/plugins/linear/src/plugin.ts
@@ -30,6 +30,14 @@ export const plugin: Plugin = {
     registry.port("tracker", tracker);
     // The channel that comments on a ticket belongs with whatever owns the
     // ticket, which is this.
-    registry.contribute(CHANNEL_COLLECTION, "tracker", trackerChannel(tracker));
+    //
+    // Contributed only when it is asked for. It used to be contributed
+    // unconditionally, which made `notify.tracker: false` dead configuration:
+    // the operator turned it off, the file said off, and every announcement
+    // still commented on the ticket. A setting that reads as honoured and is
+    // not is worse than one that does not exist.
+    if (ctx.config.announceOnTicket) {
+      registry.contribute(CHANNEL_COLLECTION, "tracker", trackerChannel(tracker));
+    }
   },
 };

--- a/plugins/linear/src/ticketChannel.ts
+++ b/plugins/linear/src/ticketChannel.ts
@@ -1,12 +1,27 @@
 import { Tracker } from "@amykit/workflow-ticket-to-qa";
 import { Channel } from "@amykit/plugin-notify-fanout";
 
-/** Puts the announcement on the ticket, where it stays auditable. */
+/**
+ * Puts the announcement on the ticket, saying that a machine wrote it.
+ *
+ * The prefix and the footer are not decoration. amy authenticates with a key
+ * issued to a person, so a comment it leaves is authored by that person: the
+ * raw text went up under the operator's own name with nothing to mark it, and
+ * "REVV-7716 is moving again in DONE after 2 failed attempt(s)" reached a
+ * ticket a team reads. A colleague replied to it asking what it meant.
+ *
+ * The first line carries it because the first line is what a notification
+ * shows. The footer carries it too, because a body can be quoted back and a
+ * reader who scrolled past the top still deserves to know.
+ */
 export function trackerChannel(tracker: Tracker): Channel {
   return {
     name: "tracker",
     async deliver(announcement) {
-      await tracker.comment(announcement.workId, announcement.text);
+      await tracker.comment(
+        announcement.workId,
+        `amy:\n\n${announcement.text}\n\n---\n\`amy:notify\` written by a tool, not typed by hand.`,
+      );
     },
   };
 }

--- a/plugins/linear/tests/plugin.test.ts
+++ b/plugins/linear/tests/plugin.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { CHANNEL_COLLECTION } from "@amykit/plugin-notify-fanout";
+import { plugin } from "../src/plugin.js";
+
+/**
+ * Whether an announcement is also commented on the ticket.
+ *
+ * `notify.tracker: false` used to be dead configuration. This plugin
+ * contributed the channel unconditionally, the fan-out reaches every
+ * contributed channel, and `Announcement` carries no channel of its own — so
+ * an operator who had turned it off still got "PROJ-1241 is failing in
+ * IMPLEMENTING and I am retrying: git checkout ... Aborting" commented on a
+ * ticket their team reads. The setting read as honoured and was not, which is
+ * worse than not having it.
+ */
+function mount(slice: Record<string, unknown>) {
+  const contributed: string[] = [];
+  const ports: string[] = [];
+  const registry = {
+    port: (kind: string) => void ports.push(kind),
+    contribute: (collection: string, name: string) => void contributed.push(`${collection}/${name}`),
+    action: () => {},
+    workflow: () => {},
+    observer: () => {},
+  };
+  plugin.register(registry as never, { config: slice } as never);
+  return { contributed, ports };
+}
+
+describe("the ticket channel", () => {
+  beforeEach(() => {
+    process.env.LINEAR_API_KEY = "lin_api_test";
+  });
+  afterEach(() => {
+    delete process.env.LINEAR_API_KEY;
+  });
+
+  it("is not contributed when the operator did not ask for it", () => {
+    const { contributed } = mount({ announceOnTicket: false });
+
+    expect(contributed).not.toContain(`${CHANNEL_COLLECTION}/tracker`);
+  });
+
+  /** The absent case is the same case: a slice that says nothing says no. */
+  it("is not contributed when nothing says either way", () => {
+    const { contributed } = mount({});
+
+    expect(contributed).not.toContain(`${CHANNEL_COLLECTION}/tracker`);
+  });
+
+  it("is contributed when it is asked for", () => {
+    const { contributed } = mount({ announceOnTicket: true });
+
+    expect(contributed).toContain(`${CHANNEL_COLLECTION}/tracker`);
+  });
+
+  /**
+   * Silencing the announcements must not unmount the tracker. Every workflow
+   * reads a ticket through this port, and a question about a ticket is
+   * commented through it directly rather than through the channel.
+   */
+  it("mounts the tracker either way", () => {
+    expect(mount({ announceOnTicket: false }).ports).toContain("tracker");
+    expect(mount({ announceOnTicket: true }).ports).toContain("tracker");
+  });
+});

--- a/plugins/linear/tests/ticketChannel.test.ts
+++ b/plugins/linear/tests/ticketChannel.test.ts
@@ -14,6 +14,21 @@ describe("trackerChannel", () => {
 
     await trackerChannel(tracker).deliver(announcement);
 
-    expect(tracker.comment).toHaveBeenCalledWith("ACME-1", announcement.text);
+    expect(tracker.comment).toHaveBeenCalledWith("ACME-1", expect.stringContaining(announcement.text));
+  });
+
+  /**
+   * amy authenticates with a key issued to a person, so a comment it leaves is
+   * authored by that person. The raw text went up with nothing to mark it and
+   * a colleague replied to a retry notice asking what it meant.
+   */
+  it("says a machine wrote it, on the first line", async () => {
+    const tracker = fakeTracker();
+
+    await trackerChannel(tracker).deliver(announcement);
+
+    const body = (tracker.comment as unknown as { mock: { calls: string[][] } }).mock.calls[0]![1]!;
+    expect(body.split("\n")[0]).toBe("amy:");
+    expect(body).toContain("not typed by hand");
   });
 });


### PR DESCRIPTION
Two defects that both made the machine lie to its operator, found on the same day on the same install.

## `notify.tracker: false` was dead configuration

`plugin-linear` contributed its notification channel unconditionally and never read the setting. So every engine notice was commented on the Linear ticket — under the operator's own name, because amy authenticates with a key issued to a person, and with no prefix or marker because the channel posted the raw announcement text.

This reached a real ticket today:

> **Nicolas Melo** — REVV-7716 is moving again in DONE after 2 failed attempt(s).
> **Anatoli Kurtsevich** — Done or Backlog?

A colleague replied to a retry notice asking what it meant. The operator had `notify.tracker: false` in his config the whole time.

- the channel is contributed only when `announceOnTicket` is on
- `notify.tracker` is derived into the plugin's slice, so the setting reaches the plugin that owns the channel
- the default is now `false` — an announcement carries no channel, so "on" means every progress notice becomes a public comment
- what the channel writes says a machine wrote it, on the first line

Turning it off does not silence a question: a workflow that needs an answer about a ticket calls `tracker.comment` directly.

## One agent run could park the machine for five hours

The token ceiling summed `input + output + cacheRead + cacheWrite`. One implement run reported:

```
input:        44
output:   17,394
cacheRead: 1,839,757
cacheWrite:   92,769
             ---------
sum        1,949,964     ← 97.5% of a 2,000,000 per-five-hours ceiling
```

That run cost **$0.91** against a **$20** ceiling in the same window. A cache read is the saving, not the spend — the same context, already paid for, served at a fraction of the price — so the better prompt caching worked, the sooner the machine locked itself out for having been efficient.

The ceiling counts billable tokens now. `costUsd` remains the ceiling that knows what cache is worth, because the model specs price the four kinds separately.

## Proof

- `npm run gate`: 1030 tests, 33/33 rules proven to fire, no findings
- the `ticket-to-qa` gate's evidence was re-proven and resealed, because `plugins/linear` is one of its activation paths — 30/30 assertions in 38 looks
- new tests: the channel is not contributed unless asked for; the channel labels what it writes; the ceiling counts 17,438 rather than 1,949,964 for the run above