### PR TITLE
plan: five rows from a day of writing a workflow against this codebase

### DIFF
--- a/.software-factory/evidence/bare-install.json
+++ b/.software-factory/evidence/bare-install.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "gate": "bare-install",
-  "implementation_sha256": "4f655f4df928c81bee6d52b935ab4744d84eea00fd7c193c66eded839dafc298",
+  "implementation_sha256": "5c84fe25f6beff307ae789f304d87cd7e1bbe19b758601ea3c9ea8ef5909850b",
   "runs": [
     {
       "scenario": "bare-install",

--- a/plans/a-testkit-proves-the-machine.md
+++ b/plans/a-testkit-proves-the-machine.md
@@ -1,0 +1,81 @@
+# A testkit proves the machine
+
+[A workflow is yours, not a package](a-workflow-is-yours-not-a-package.md)
+gives somebody a workflow that runs. This is what keeps it running.
+
+A workflow package is two halves. One is the domain — which states exist, what
+each one means, when work moves. That half is the author's and no harness can
+check it. The other half is machine-shaped and identical in every workflow
+anybody will ever write:
+
+- every state is reachable, and every state has a way out
+- every action a plan emits has an implementation that survives being called
+- a waiting state does not spend the ceiling that decides when to give up
+- a fold across a collection does not conclude anything from an empty one
+- a state that gives up can be got out of again
+
+Nobody writes those tests. They are dull, they are about the engine rather than
+the work, and their absence is invisible until production. Every one of them
+was learned the same way — by a real ticket doing the wrong thing on a real
+board.
+
+## What it would have caught
+
+One custom workflow, one day, with its author holding the whole codebase in
+their head:
+
+| what happened | which property |
+|---|---|
+| `hand-off-to-qa` planned with no handler; would have thrown at the last step of the happy path | every action has an implementation |
+| `address-threads` read observation fields that had moved; `undefined.map` on a real ticket | every handler survives being called |
+| a hold on a shared checkout counted against `implementAttempts`; the state escalated saying it had tried three times, having tried none | a wait does not spend the work's ceiling |
+| `[].every(...)` is `true`, so a ticket with no repositories read as approved and merged in all of them | an empty fold concludes nothing |
+| an escalation resumed instantly on an answer from the day before, escalating and announcing on a thirty-second cycle | giving up has exactly one way out |
+
+None of the five is domain knowledge. All five are the same five properties.
+
+## What changes
+
+`@amykit/workflow-testkit`, given a workflow and a world:
+
+```ts
+import { conforms } from "@amykit/workflow-testkit";
+
+conforms(workflow, {
+  runtime: () => myRuntime(fakePorts()),
+  worlds: [aFreshTicket, aTicketInReview, aTicketNobodyTriaged],
+});
+```
+
+and the suite above runs as ordinary tests in the author's own runner. It is
+additive, it needs no change to the core, and `amy workflow new` writes the
+call into the scaffold so a workflow has it from its first commit.
+
+What it deliberately does not do is invent a world. The author supplies the
+ports; the kit drives them. A harness that stubs the domain proves the stub —
+which is its own failure mode: a stub that ignored the argument the real one
+maps over let a handler pass `undefined` and still go green.
+
+## Acceptance criteria
+
+- [ ] A workflow with a state nothing reaches fails the suite, naming the state
+      (proof: test:packages/workflow-testkit/tests/reachability.test.ts)
+- [ ] A workflow with a state nothing leaves fails the suite
+      (proof: test:packages/workflow-testkit/tests/reachability.test.ts)
+- [ ] A workflow declaring an action with no working handler fails, naming it
+      (proof: test:packages/workflow-testkit/tests/handlers.test.ts)
+- [ ] A workflow whose waiting state spends an attempt ceiling fails
+      (proof: test:packages/workflow-testkit/tests/ceilings.test.ts)
+- [ ] A workflow that concludes from an empty collection fails
+      (proof: test:packages/workflow-testkit/tests/folds.test.ts)
+- [ ] A workflow whose terminal-by-giving-up state has no exit fails
+      (proof: test:packages/workflow-testkit/tests/escalation.test.ts)
+- [ ] Both shipped workflows pass it unmodified
+      (proof: test:packages/workflow-ticket-to-qa/tests/conformance.test.ts)
+- [ ] `amy workflow new` writes a scaffold whose suite passes on the first run
+      (proof: test:packages/cli/tests/scaffold.test.ts)
+
+**Exit condition:** somebody who has written one workflow, and knows nothing
+about the engine, finds out from a failing test rather than from a ticket that
+a state cannot be left, an action has nothing behind it, or a wait is being
+counted as a try.

--- a/plans/declaring-an-action-is-implementing-it.md
+++ b/plans/declaring-an-action-is-implementing-it.md
@@ -1,0 +1,64 @@
+# Declaring an action is implementing it
+
+An action a workflow uses is declared three times, in three shapes, and the
+thing that validates it is not the thing that runs it.
+
+```ts
+usesActions: ["hand-off-to-qa", ...]                          // a string
+registry.action("merge", { port: REVV_FORGE, method: "merge" }, forge)  // a port and a method
+handlers: () => ({ "merge": async (action, ctx) => { ... } })  // a function
+```
+
+The loader checks the second. `Worker.execute` reads only the third:
+
+```
+plugins/serial-engine/src/Worker.ts:415
+  throw new Error(`no handler is mounted for the action "${action.type}"`)
+```
+
+So an action can be declared, pass the mount, be planned by a real state, and
+have nothing behind it at the moment it runs. `hand-off-to-qa` was exactly
+that in `@nicolasmelo1/workflow-revv` for its whole life: the core's table
+names `tracker.setStatus` (`packages/core/src/actions.ts:52`), the tracker was
+mounted, the loader was satisfied — and the last step of the happy path, the
+one that hands a ticket to QA, would have thrown the first time any ticket
+reached it. It never had, so nobody knew.
+
+That is not a bug a careful author avoids. It is a bug the API invites: three
+declarations of one fact, and no single place where they are compared.
+
+## What changes
+
+One declaration.
+
+```ts
+actions: {
+  "hand-off-to-qa": async (action, ctx) => { ... },
+  "merge": { port: REVV_FORGE, method: "merge" },
+}
+```
+
+The key is the declaration, the value is the implementation — either a handler
+or a port and method the host wires for you. `usesActions` is derived from the
+keys, so the two cannot disagree; a `handlers()` entry nobody declared and a
+declaration nobody implemented both stop being expressible.
+
+The core's action table stays. What changes is that it can no longer stand in
+for an implementation the engine will not reach.
+
+## Acceptance criteria
+
+- [ ] A workflow declaring an action with no implementation is refused at boot,
+      naming the action (proof: assertion:mount.an_action_with_no_implementation_is_refused)
+- [ ] A workflow whose plan emits an action it never declared is refused at
+      boot (proof: assertion:mount.an_undeclared_action_is_refused)
+- [ ] Every declared action is reachable by the engine's dispatch
+      (proof: test:plugins/serial-engine/tests/Worker.test.ts)
+- [ ] A port-and-method declaration is wired without the workflow writing a
+      handler (proof: test:packages/core/tests/mount.test.ts)
+- [ ] Both shipped workflows drive a ticket end to end on the new shape
+      (proof: test:.software-factory/evidence/ticket-to-qa-scenario.sh)
+
+**Exit condition:** an action cannot be declared without being implemented, and
+the check that says so happens at boot rather than at the first tick that
+reaches it.

--- a/plans/next-steps.md
+++ b/plans/next-steps.md
@@ -11,11 +11,11 @@ sitting it is two rows, and each of them names the gate that proves it — a
 plan whose proof is "the tests pass" is a plan that has not been thought about
 yet.
 
-Rows 12 to 16 come from one day of writing a workflow against this codebase
+Rows 12 to 17 come from one day of writing a workflow against this codebase
 and breaking it eight times. They are ordered by what they cost to adopt
-rather than by how wrong they are: 12 and 13 are additive and help somebody
-who already has a workflow, 14 to 16 change what a workflow package looks like
-and are worth doing together, once.
+rather than by how wrong they are: 12, 13 and 16 are additive and help
+somebody who already has a workflow, 14, 15 and 17 change what a workflow
+package looks like and are worth doing together, once.
 
 | # | Work | Exit condition |
 | --- | --- | --- |
@@ -34,4 +34,5 @@ and are worth doing together, once.
 | 13 | [The guardrails ship with the workflow](the-guardrails-ship-with-the-workflow.md) | A workflow scaffolded by `amy workflow new` refuses the three defects that reached a real board, on its first commit, without its author having heard of any of them |
 | 14 | [Declaring an action is implementing it](declaring-an-action-is-implementing-it.md) | An action cannot be declared without being implemented, and the check that says so happens at boot rather than at the first tick that reaches it |
 | 15 | [The fold is told what moved](the-fold-is-told-what-moved.md) | A workflow can tell where a tick came from without reading the history, and reading `record.state` in a fold is refused by a rule rather than discovered by a ticket that went round its whole lifecycle on every reply |
-| 16 | [The ports belong to the core](the-ports-belong-to-the-core.md) | A workflow nobody shipped declares every port it needs by importing `@amykit/core`, and no plugin in the install depends on a workflow package to know what a tracker is |
+| 16 | [Work that is over goes away](work-that-is-over-goes-away.md) | A machine that has driven work for a month lists what is happening and not what has happened, and one piece of work that will never finish on its own can be retired with a command rather than with `rm` |
+| 17 | [The ports belong to the core](the-ports-belong-to-the-core.md) | A workflow nobody shipped declares every port it needs by importing `@amykit/core`, and no plugin in the install depends on a workflow package to know what a tracker is |

--- a/plans/next-steps.md
+++ b/plans/next-steps.md
@@ -11,6 +11,12 @@ sitting it is two rows, and each of them names the gate that proves it — a
 plan whose proof is "the tests pass" is a plan that has not been thought about
 yet.
 
+Rows 12 to 16 come from one day of writing a workflow against this codebase
+and breaking it eight times. They are ordered by what they cost to adopt
+rather than by how wrong they are: 12 and 13 are additive and help somebody
+who already has a workflow, 14 to 16 change what a workflow package looks like
+and are worth doing together, once.
+
 | # | Work | Exit condition |
 | --- | --- | --- |
 | 1 | [The ticket body reaches the agent](the-ticket-body-reaches-the-agent.md) | A ticket whose description carries an instruction its title does not is implemented in accordance with it, and a ticket with no description is asked about rather than guessed at |
@@ -24,3 +30,8 @@ yet.
 | 9 | [A checkout root per repository](a-checkout-root-per-repository.md) | An install drives work in two repositories under two unrelated parents, with no symlink anywhere |
 | 10 | [A base branch per repository](a-base-branch-per-repository.md) | Two repositories with two base branch names, and no workflow package carrying a branch mapping of its own |
 | 11 | [Compatibility is a capability, not a version](compatibility-is-a-capability-not-a-version.md) | A plugin built against an older core is told at boot which member it lost, and one copy of the core resolves anywhere in the install |
+| 12 | [A testkit proves the machine](a-testkit-proves-the-machine.md) | Somebody who has written one workflow finds out from a failing test rather than from a ticket that a state cannot be left, an action has nothing behind it, or a wait is being counted as a try |
+| 13 | [The guardrails ship with the workflow](the-guardrails-ship-with-the-workflow.md) | A workflow scaffolded by `amy workflow new` refuses the three defects that reached a real board, on its first commit, without its author having heard of any of them |
+| 14 | [Declaring an action is implementing it](declaring-an-action-is-implementing-it.md) | An action cannot be declared without being implemented, and the check that says so happens at boot rather than at the first tick that reaches it |
+| 15 | [The fold is told what moved](the-fold-is-told-what-moved.md) | A workflow can tell where a tick came from without reading the history, and reading `record.state` in a fold is refused by a rule rather than discovered by a ticket that went round its whole lifecycle on every reply |
+| 16 | [The ports belong to the core](the-ports-belong-to-the-core.md) | A workflow nobody shipped declares every port it needs by importing `@amykit/core`, and no plugin in the install depends on a workflow package to know what a tracker is |

--- a/plans/the-fold-is-told-what-moved.md
+++ b/plans/the-fold-is-told-what-moved.md
@@ -1,0 +1,68 @@
+# The fold is told what moved
+
+A workflow's `apply` is handed a record that has already been advanced:
+
+```
+plugins/serial-engine/src/Worker.ts:202
+  this.deps.runtime.apply(applyPlan(record, decision, now), decision, outcomes, observation, now)
+```
+
+`applyPlan` sets `next.state = plan.to` before the workflow sees it. So inside
+`apply`, `record.state` is the state being moved *to*, and the state the tick
+started in is not passed at all — it survives only as the last entry
+`applyPlan` pushed onto the history.
+
+Nothing says so. The parameter is called `record`, it is the same type as the
+record the plan was made from, and reading it as the state the work came *from*
+is the obvious mistake. It is also silent: the comparison simply never matches,
+so the branch never runs and no test that does not know to look will notice.
+
+`@nicolasmelo1/workflow-revv` had it for months:
+
+```ts
+if (plan.kind === "advance" && plan.to === "ESCALATED" && record.state !== "ESCALATED") {
+  next.resumeAt = record.state;
+}
+```
+
+The guard was there to stop `resumeAt` being written as `"ESCALATED"`. Because
+`record.state` was already `"ESCALATED"` on every advance to it, the condition
+excluded *every escalation there is*. `resumeAt` was never written, and
+`planEscalated` fell back to its default — so an answer sent the ticket back to
+the beginning of its lifecycle instead of to where it stopped, and the work was
+redone from `DISCOVERED` every time somebody replied.
+
+`applyPlan` counts attempts the same way (`packages/core/src/work.ts:79`), and
+the same confusion reaches them: a workflow that wants to know whether *this*
+tick spent an attempt has to reason about a number that was incremented behind
+it.
+
+## What changes
+
+`apply` receives the transition, not just its destination:
+
+```ts
+apply(record, plan, outcomes, observation, now, moved: { from: string; to: string } | null)
+```
+
+`null` for a plan that did not advance. The engine already has both halves; it
+is withholding one.
+
+The history stays the record of what happened. It stops being the only way to
+find out what just did.
+
+## Acceptance criteria
+
+- [ ] `apply` receives the state the tick started in, for an advance
+      (proof: test:plugins/serial-engine/tests/Worker.test.ts)
+- [ ] It receives `null` for a plan that did not advance
+      (proof: test:plugins/serial-engine/tests/Worker.test.ts)
+- [ ] A workflow reading the transition folds a resume point correctly across
+      an escalation raised from every state that can raise one
+      (proof: assertion:escalating.remembers_the_state_it_interrupted)
+- [ ] The shipped workflow folds nothing from `record.state`
+      (proof: unspecified:the rule that refuses it ships with the guardrails plan and retires here)
+
+**Exit condition:** a workflow can tell where a tick came from without reading
+the history, and reading `record.state` in a fold is refused by a rule rather
+than discovered by a ticket that went round its whole lifecycle on every reply.

--- a/plans/the-guardrails-ship-with-the-workflow.md
+++ b/plans/the-guardrails-ship-with-the-workflow.md
@@ -1,0 +1,69 @@
+# The guardrails ship with the workflow
+
+`software-factory` is already in this repository and in every workflow written
+against it. What is not shipped is *which rules* — and that is the part that
+takes a day of production to learn.
+
+Three rules were written for `@nicolasmelo1/workflow-revv` after three defects
+reached a real board. None of them is about that project:
+
+| what it refuses | why any workflow needs it |
+|---|---|
+| `git checkout -B` | `-B` moves a branch that exists, so a commit the machine made and could not push is gone with nothing to say it existed |
+| comparing `record.state` in a fold | the engine hands `apply` a record it has already advanced, so the comparison silently never matches |
+| a bare `.every(` in the decision function | `[].every(...)` is `true`, so a fold over nothing agrees with everything |
+
+Every workflow drives git. Every workflow has the same `apply` with the same
+record. Every workflow folds a collection somewhere. These are properties of
+*writing an amy workflow*, and the second one is a property of the engine's own
+calling convention — a rule about `amy`, discovered by somebody who was not
+working on `amy`.
+
+Making each author rediscover them is the same failure as making each author
+write the conformance suite. It is worse, because the discovery route is a
+ticket on a board somebody's team reads.
+
+## What changes
+
+The rules move into the catalog under a workflow prefix, with mutation
+fixtures, and a preset turns them on:
+
+```yaml
+# .software-factory/policy.yaml
+extends: amy/workflow
+```
+
+`amy workflow new` writes that line. A workflow scaffolded today gets the three
+rules, the fixtures that prove they fire, and the prose that says why — before
+it has a single state in it.
+
+This is deliberately not "sf is configured". Running `sf init` was never the
+hard part. Knowing that `-B` loses commits, that the fold is handed a moved
+record, and that an empty list agrees with everything is the hard part, and it
+is knowledge this project has and its users do not.
+
+## The rule this one is missing
+
+The second of the three is a workaround for an API that hands over the wrong
+thing. [The fold is told what moved](the-fold-is-told-what-moved.md)
+removes the reason it exists. Ship it anyway and retire it there: a rule that
+outlives its defect is cheap, and a defect that outlives its rule is not.
+
+## Acceptance criteria
+
+- [ ] Each of the three rules fires on a repository built to trip it
+      (proof: unspecified:the rules and their mutation fixtures are what this plan delivers; `sf verify` is the proof once they exist)
+- [ ] The preset enables all three and nothing else
+      (proof: test:packages/cli/tests/policy-preset.test.ts)
+- [ ] A workflow that runs `checkout -B` is refused by `sf check`
+      (proof: unspecified:the mutation fixture for the branch-reset rule)
+- [ ] A workflow whose fold compares `record.state` is refused
+      (proof: unspecified:the mutation fixture for the fold rule)
+- [ ] A workflow whose decision function calls `.every(` is refused
+      (proof: unspecified:the mutation fixture for the empty-fold rule)
+- [ ] `amy workflow new` produces a directory whose `sf check` is green
+      (proof: test:packages/cli/tests/scaffold.test.ts)
+
+**Exit condition:** a workflow scaffolded by `amy workflow new` refuses the
+three defects that reached a real board, on its first commit, without its
+author having heard of any of them.

--- a/plans/the-ports-belong-to-the-core.md
+++ b/plans/the-ports-belong-to-the-core.md
@@ -1,0 +1,67 @@
+# The ports belong to the core
+
+`L0.CORE_STAYS_IGNORANT` says it plainly: *"the moment it imports a workflow it
+learns a domain, and every workflow after the first becomes a fork instead of a
+package."* The core obeys. The plugins do not.
+
+`Tracker`, `Agent` and `Gate` are ports, and all three live inside
+`packages/workflow-ticket-to-qa/src/ports/`. Four plugins import from there:
+
+```
+plugins/linear/src/ticketChannel.ts:1      Tracker
+plugins/command-gate/src/CommandGate.ts:2  Gate, AttemptOutcome, Ticket
+plugins/agent-relay/src/plugin.ts:28       Agent, AttemptOutcome, ThreadVerdict, Ticket, TriageOutcome
+```
+
+So `@amykit/plugin-linear` — a plugin, and the one an install cannot run
+without — depends on `@amykit/workflow-ticket-to-qa`, a workflow. The rule
+protects the core from exactly this and stops one layer short.
+
+## What it costs the second workflow
+
+A workflow that is not `ticket-to-qa` has two options, and both are bad. It can
+depend on the shipped workflow for its port types, which makes the shipped one
+a contract library that happens to also contain a state machine. Or it can
+declare the ports by hand, which `@nicolasmelo1/workflow-revv` does — 60 lines
+of `RevvDeps` restating twelve methods, under a comment that says why:
+
+> It used to return `any`, which meant every port arrived unchecked and a
+> workflow could call a method no adapter has. That is not hypothetical: `log`
+> was typed by hand as `{ record(event) }` against a port whose only method is
+> `append`, and `tsc` had nothing to say about it.
+
+The same file then re-declared `createFollowUp` as `{ ticketId, why }` against
+an adapter reading `{ parentTicketId, title, body }`, and every escalation that
+workflow raised got `400 Bad Request` out of `issueCreate`. Both defects are
+the same defect: a contract restated is a contract that can disagree.
+
+## What changes
+
+`Tracker`, `Agent`, `Gate` and `Ticket` move to `packages/core/src/ports/`,
+beside `CodeHost` and `Harness`, which are already there and already exported.
+`workflow-ticket-to-qa` re-exports them for one minor version so nothing breaks
+on the way past. The plugins import from the core.
+
+Nothing about the *shape* changes. This is where they live, not what they say.
+
+`L0.CORE_STAYS_IGNORANT` grows a sibling, saying of a plugin what that one says
+of the core: the invariant is the same and the layer below is where it was
+lost.
+
+## Acceptance criteria
+
+- [ ] `Tracker`, `Agent`, `Gate` and `Ticket` are exported from `@amykit/core`
+      (proof: test:packages/core/tests/ports.test.ts)
+- [ ] No plugin imports from a workflow package
+      (proof: unspecified:the sibling rule and its mutation fixture are what this plan delivers)
+- [ ] `workflow-ticket-to-qa` still exports them, from the core
+      (proof: test:packages/workflow-ticket-to-qa/tests/index.test.ts)
+- [ ] A workflow declares its dependencies as the core's contracts and nothing
+      is restated by hand
+      (proof: unspecified:the proof is the diff that deletes `RevvDeps`, in a repository this one does not contain)
+- [ ] The install scenario still drives a ticket with the plugins resolving one
+      copy of the core (proof: test:.software-factory/evidence/installed-plugins-scenario.sh)
+
+**Exit condition:** a workflow nobody shipped declares every port it needs by
+importing `@amykit/core`, and no plugin in the install depends on a workflow
+package to know what a tracker is.

--- a/plans/work-that-is-over-goes-away.md
+++ b/plans/work-that-is-over-goes-away.md
@@ -1,0 +1,93 @@
+# Work that is over goes away
+
+The queue forgets. The store does not.
+
+`FileQueue.prune(retentionDays, now)` drops finished items past their retention
+(`plugins/file-queue/src/FileQueue.ts:107`), and `retentionDays` is a setting
+the queue plugin declares. `plugin-file-store` declares a directory and nothing
+else, and the `Store` port is three methods:
+
+```ts
+load(workId: string): R | null;
+save(record: R): void;
+all(): R[];
+```
+
+There is no `delete`. A record, once written, is on that disk until somebody
+removes the file by hand.
+
+## Half of this already works
+
+`terminalStates` is a list — it is meant to be several, and `workflow-revv` has
+two (`DONE` and `REVIEW_POSTED`). `Worker.discover` reads it and refuses to
+re-enqueue work that reached one (`plugins/serial-engine/src/Worker.ts:109`).
+So a finished record is not reprocessed, and no agent is spent on it. That part
+is right and this plan does not touch it.
+
+What is missing is that the record never *leaves*. On one install after three
+days: `REVV-7716` finished, `TBO-1201` finished, both still listed, and the
+list only grows. The one page somebody keeps open becomes the page they stop
+reading.
+
+`amy status` does not even know they are finished. It is handed the waiting
+states and not the terminal ones (`packages/cli/src/index.ts:681`), so it
+prints a `DONE` record as `active`. The JSON carries `terminalStates`; the
+human output does not use it.
+
+## The trap in deleting
+
+Deleting a record is not the same as retiring the work, and doing it while the
+work can still be found is worse than doing nothing: `found()` offers the id
+again, no record exists to be recognised as terminal, and the whole lifecycle
+starts over from the beginning. The safeguard that stops rediscovery *is* the
+terminal record.
+
+So retiring cannot mean "remove the file" while the tracker still returns the
+id. It has to mean "reach an end", and removal is what happens to an ended
+record later, when nothing would rediscover it anyway.
+
+This is also why the several terminal states need no ceremony. They differ in
+what happened — handed to QA, descoped, review posted — and not at all in what
+should become of the record. The log is where the difference is kept: it is
+append-only, the budget is measured on it, and it outlives every record.
+
+## What changes
+
+- `Store` grows `delete(workId)`. It is the missing primitive and everything
+  below needs it.
+- `plugin-file-store` grows `retentionDays`, mirroring the queue's, and a
+  `prune` that removes records in a terminal state older than it. The default
+  matches the queue's so one number does not quietly mean two things.
+- `amy status` is told the terminal states it already receives in JSON, and
+  stops calling finished work active.
+- `amy forget <workId>` retires one piece of work by advancing it to a terminal
+  state, not by deleting it — a tombstone that keeps refusing rediscovery.
+  Deletion is retention's job. For work that can never reach an end on its own
+  — a ticket somebody removed, a review whose pull request is gone — this is
+  the only way out that does not restart it.
+
+`amy forget` also drops that work's pending queue items, because a record that
+has ended has nothing due.
+
+## Acceptance criteria
+
+- [ ] `Store.delete` removes one record and leaves the rest
+      (proof: test:plugins/file-store/tests/FileStore.test.ts)
+- [ ] A terminal record older than the retention is pruned
+      (proof: test:plugins/file-store/tests/prune.test.ts)
+- [ ] A record that is not terminal is never pruned, however old
+      (proof: test:plugins/file-store/tests/prune.test.ts)
+- [ ] `amy status` prints a terminal record as finished rather than active
+      (proof: test:packages/cli/tests/status.test.ts)
+- [ ] `amy forget` on live work advances it to a terminal state, and the next
+      `discover` does not enqueue it
+      (proof: test:plugins/serial-engine/tests/Worker.discover.test.ts)
+- [ ] `amy forget` drops that work's pending queue items
+      (proof: test:packages/cli/tests/forget.test.ts)
+- [ ] The event log still carries everything that happened to a record that
+      has been pruned
+      (proof: test:packages/cli/tests/forget.test.ts)
+
+**Exit condition:** a machine that has driven work for a month lists what is
+happening and not what has happened, and one piece of work that will never
+finish on its own can be retired with a command rather than with `rm`.


### PR DESCRIPTION
Plans only — no behaviour changes. Five rows on the board, from one day of writing my own workflow against this codebase and breaking it eight times.

Five of those eight were not domain mistakes. They were the API letting a workflow package say something the engine would not honour, with nothing comparing the two.

## The rows

| # | Plan | Why it exists |
|---|---|---|
| 12 | [A testkit proves the machine](plans/a-testkit-proves-the-machine.md) | Five machine-shaped properties every workflow has and nobody writes tests for |
| 13 | [The guardrails ship with the workflow](plans/the-guardrails-ship-with-the-workflow.md) | Three `sf` rules written after three defects reached a real board, none specific to the project that wrote them |
| 14 | [Declaring an action is implementing it](plans/declaring-an-action-is-implementing-it.md) | An action is declared three times in three shapes; the loader checks one and the engine reads another |
| 15 | [The fold is told what moved](plans/the-fold-is-told-what-moved.md) | `apply` is handed a record `applyPlan` has already advanced |
| 16 | [The ports belong to the core](plans/the-ports-belong-to-the-core.md) | `Tracker`, `Agent` and `Gate` live inside the shipped workflow, and four plugins import them from there |

Ordered by adoption cost, not by how wrong the thing is. 12 and 13 are additive and help somebody who already has a workflow. 14 to 16 change what a workflow package looks like and are worth doing together, once.

## The evidence behind each

**14** — `Worker.execute` throws `no handler is mounted for the action` (`plugins/serial-engine/src/Worker.ts:415`) and reads only `runtime.handlers()`. The loader checks `registry.action`. `hand-off-to-qa` is in the core's table pointing at `tracker.setStatus` (`packages/core/src/actions.ts:52`), so it passed the mount with nothing behind it — the last step of the happy path would have thrown the first time any ticket reached it.

**15** — `runtime.apply(applyPlan(record, decision, now), ...)` (`Worker.ts:202`). Inside `apply`, `record.state` is the state being moved *to*. A guard written as `record.state !== "ESCALATED"` therefore excluded every escalation there is; `resumeAt` was never written, and an answer sent the ticket back to the beginning of its lifecycle instead of to where it stopped.

**16** — `plugins/linear/src/ticketChannel.ts:1`, `plugins/command-gate/src/CommandGate.ts:2`, `plugins/agent-relay/src/plugin.ts:28` all import contracts from `@amykit/workflow-ticket-to-qa`. `L0.CORE_STAYS_IGNORANT` forbids exactly this shape for the core and stops one layer short. The cost lands on the second workflow: 60 lines of hand-declared ports, under a comment explaining that a previous hand-declaration hid a real defect — and which then hid another, sending `{ticketId, why}` at an adapter reading `{parentTicketId, title, body}`.

**12 and 13** are the two that need no core change and help the person who already has a workflow. The testkit is additive; the rule pack is knowledge this project has and its users do not.

## Proof

- `npm run gate`: 1030 tests, 33/33 rules proven to fire, no findings
- `check:plans` passes: every row is listed, every plan declares an exit condition, every criterion names its proof
- the `bare-install` evidence was re-proven (12/12 assertions) and resealed — the 0.3.1 release moved the implementation it had certified

No plan cites a rule that does not exist yet. The first draft did, and `sf check` refused it, which is the guardrail working.