### PR TITLE
docs(plans): five rows from a day of driving real pull requests

### DIFF
--- a/plans/a-reply-inside-a-thread-reaches-the-agent.md
+++ b/plans/a-reply-inside-a-thread-reaches-the-agent.md
@@ -1,0 +1,98 @@
+# A reply inside a thread reaches the agent
+
+`ReviewThread` carries the first comment of a thread and nothing that
+followed it (`packages/core/src/ports/CodeHost.ts:13`). `GitHubCodeHost`
+asks for one comment per thread:
+
+```graphql
+reviewThreads(first: 100) {
+  nodes { id isResolved isOutdated comments(first: 1) { nodes { author { login } body } } }
+}
+```
+
+(`plugins/github/src/GitHubCodeHost.ts:56`) and maps `author: first.author.login,
+body: first.body` (`:326`). So a thread whose author replied twice, or whose
+*reviewer* replied to the machine's answer, reads exactly like one nobody
+has touched since it was opened.
+
+Three things follow, and each is a silent wrong answer rather than an error:
+
+- **An agent answering a thread never sees the correction inside it.** It is
+  handed the opening comment and told to address it, while the reply saying
+  "no, not like that" sits one field away.
+- **Whose turn it is is undecidable.** A workflow cannot tell a thread
+  nobody has answered from one it answered and is waiting on, because both
+  have the same first comment.
+- **Anything that tells the machine's own writing from a person's reads the
+  wrong comment** — it is asking about the opening one, whoever wrote the
+  rest.
+
+## How it was found
+
+Reviewing a machine's pull requests the way a person actually reviews: by
+replying inside the thread the machine opened rather than starting a new
+one. The reply never reached the agent, and could not have — the port does
+not carry it.
+
+The cost is not hypothetical. `address-threads` hands the agent each
+thread's `body` (`packages/agent-kit/src/HarnessAgent.ts:210`), so the agent
+answers what the thread *started* with; a correction arriving inside the
+thread is answered the same way the original was, or judged a disagreement
+it never was, and goes to the owner as noise.
+
+## What changes
+
+`ReviewThread` grows the conversation, oldest first:
+
+```ts
+export interface ReviewThread {
+  id: string;
+  author: string;          // the opening comment's, as today
+  body: string;            // the opening comment's, as today
+  isResolved: boolean;
+  isOutdated: boolean;
+  comments: { author: string; body: string; createdAt: string }[];
+}
+```
+
+`author` and `body` staying the opening comment's is what keeps every
+existing consumer working: `unresolvedThreads` decides what a thread is
+*about* by who opened it (`packages/workflow-ticket-to-qa/src/review.ts`),
+and that question has not changed.
+
+The query asks for `comments(first: 50)` with `createdAt` — the same node
+in the same request, so it costs nothing extra — and the adapter maps the
+list. `comments.at(-1).author` answers whose turn it is from the view alone,
+which today is a question the port cannot answer.
+
+The prompt half: `threadPrompt` renders the conversation, attributed, and
+says that a later comment in the same thread answers an earlier one. An
+agent handed a correction inside the thread is handed the correction.
+
+## The gate
+
+`plugins/github/tests/GitHubCodeHost.test.ts` already maps a real answer
+from a real pull request; its threads grow replies inside them, so the
+mapping is checked against what GitHub actually sends. `agent-kit` asserts
+the prompt: the fixture records what the fake harness was asked.
+
+## Acceptance criteria
+
+- [ ] A reply inside a thread reaches every consumer of the view
+      (proof: test:plugins/github/tests/GitHubCodeHost.test.ts)
+- [ ] `author` and `body` remain the opening comment's, so a consumer that
+      never asked for the conversation is unaffected
+      (proof: test:plugins/github/tests/GitHubCodeHost.test.ts)
+- [ ] The comments arrive oldest first
+      (proof: test:plugins/github/tests/GitHubCodeHost.test.ts)
+- [ ] The last comment's author answers who speaks next in a thread,
+      without fetching anything the view did not already carry
+      (proof: test:plugins/github/tests/GitHubCodeHost.test.ts)
+- [ ] The prompt an agent receives shows the whole conversation, attributed
+      (proof: test:packages/agent-kit/tests/HarnessAgent.test.ts)
+- [ ] A prompt never presents a reply as part of the original objection
+      (proof: test:packages/agent-kit/tests/HarnessAgent.test.ts)
+
+**Exit condition:** a reply written inside a thread is read by the agent
+answering that thread, and a workflow can tell whose turn a thread is from
+the view alone.

--- a/plans/an-escalation-can-be-withdrawn.md
+++ b/plans/an-escalation-can-be-withdrawn.md
@@ -1,0 +1,113 @@
+# An escalation can be withdrawn
+
+`ESCALATED` is left only when a person answers, and the per-state attempt
+counters that took the work there stay at the ceiling. So when the
+escalation was caused by a *defect* rather than by the work, the only
+recovery is editing the record JSON by hand while the daemon is not looking.
+Five records needed that in one evening.
+
+Three things are true together, and each is right on its own:
+
+- A workflow's escalation is withdrawn by an observation — a reply from the
+  person it named. Nothing else clears it, which is the correct default: a
+  machine that un-escalates itself is a machine you cannot trust to stop.
+- `attempts` is per state and folded by `applyPlan` before the workflow's
+  own `apply` ever runs (`packages/core/src/work.ts:80`). Nothing in the CLI
+  can clear it.
+- `amy poke` brings the next look forward
+  (`packages/cli/src/index.ts:493`). It re-reads the same ceiling and
+  escalates again, so it is not a recovery.
+
+Together: a defect that has since been fixed leaves records parked for
+ever, and the fix does not reach them. On that evening, three records were
+parked on a missing capability — automated threads nobody could close, now
+[planned](the-threads-close-when-they-are-answered.md) — and two on a
+counter that charged a branch checkout to the implementing state, so one
+real round was billed as three.
+
+## The repair, by hand, today
+
+Per record: stop the loop, copy the file aside, set `state` to where it
+actually stopped, empty `attempts`, drop the fields the workflow's own fold
+wrote, append a history entry, start the loop again.
+
+Two things make that worse than tedious. The daemon can rewrite the record
+in the same second — there is no lock and no "is this claimed" to ask — so
+the window is the whole risk. And knowing which fields are stale means
+reading the workflow's `apply`; they are not core fields, and an operator
+has no way to enumerate them.
+
+## What changes
+
+```sh
+amy resume <workId> [--to <state>]
+amy resume TBO-1241 TBO-1242 --to COPILOT_FIX
+```
+
+- **Refuses while the work is claimed or in flight.** This is the half a
+  person cannot do safely by hand, and the reason the command belongs here
+  rather than in a script.
+- Backs the record up beside it — the store is one file per record, and a
+  sibling with another extension is invisible to `all()` — and prints what
+  changed.
+- Clears the attempts of the state it resumes into, and of the state it
+  leaves.
+- Appends a history entry saying a person resumed it, so `amy status` and
+  the log still tell the truth about how it got there.
+
+`--to` is optional only when the workflow says where. The core knows
+`state`, `attempts` and `history`; everything else on the record belongs to
+the workflow that folded it. So the runtime contribution grows two optional
+members:
+
+```ts
+resumeTarget?(record: R): string | null   // where this record goes on
+resumed?(record: R, to: string): R        // drop what this escalation wrote
+```
+
+Core does the safe half — claim check, backup, attempts, history — and asks
+the workflow for the rest. A workflow that implements neither still resumes
+with `--to`, and refuses rather than guesses without one.
+
+`amy attempts <workId> --clear <state>` covers the narrower case: the state
+is right and only the counter is a lie.
+
+The bare `amy resume` keeps releasing the handbrake
+(`packages/cli/src/index.ts:385`); work ids are what make it a withdrawal.
+Two levers that share a subject, and a script that typed `amy resume`
+yesterday means today what it meant yesterday.
+
+The log grows a `work.resumed` kind, so the repair is an event like every
+other thing that happened to the work.
+
+## The gate
+
+The command is driven against a real store and queue from the CLI tests, as
+`poke` is: a record at a ceiling resumes, refuses while claimed, and comes
+back with an honest counter. The workflow's half — dropping its own
+escalation fields — is proven where the fold lives.
+
+## Acceptance criteria
+
+- [ ] A resumed record starts its next look with no attempts spent in the
+      state it re-enters (proof: test:packages/cli/tests/resume.test.ts)
+- [ ] Resume refuses a piece of work that is claimed or in flight
+      (proof: test:packages/cli/tests/resume.test.ts)
+- [ ] The record is backed up before it is changed, and the backup is not
+      listed as work (proof: test:packages/cli/tests/resume.test.ts)
+- [ ] The history says a person resumed it, and `amy status` still tells
+      the truth about how it got there
+      (proof: test:packages/cli/tests/resume.test.ts)
+- [ ] A workflow that folds its own escalation fields drops them on resume
+      (proof: test:packages/workflow-ticket-to-qa/tests/plugin.test.ts)
+- [ ] A workflow that implements no hook still resumes with `--to`, and
+      refuses rather than guesses without one
+      (proof: test:packages/workflow-ticket-to-qa/tests/plugin.test.ts)
+- [ ] `amy attempts --clear` resets one state's counter and touches nothing
+      else (proof: test:packages/cli/tests/attempts.test.ts)
+- [ ] The log carries a `work.resumed` line the contract knows
+      (proof: test:packages/core/tests/event-contract.test.ts)
+
+**Exit condition:** a record that escalated on a defect comes back by a
+command — counter honest, history truthful, and the daemon never once raced
+the repair.

--- a/plans/next-steps.md
+++ b/plans/next-steps.md
@@ -17,6 +17,11 @@ rather than by how wrong they are: 12, 13 and 16 are additive and help
 somebody who already has a workflow, 14, 15 and 17 change what a workflow
 package looks like and are worth doing together, once.
 
+Rows 18 to 22 come from a day of a private workflow driving this machine
+against real pull requests — five findings, filed as issues and converted
+here. 18 is first because 21 adds six methods to one port and every one of
+them should have to get past 18 on arrival.
+
 | # | Work | Exit condition |
 | --- | --- | --- |
 | 1 | [The ticket body reaches the agent](the-ticket-body-reaches-the-agent.md) | A ticket whose description carries an instruction its title does not is implemented in accordance with it, and a ticket with no description is asked about rather than guessed at |
@@ -36,3 +41,8 @@ package looks like and are worth doing together, once.
 | 15 | [The fold is told what moved](the-fold-is-told-what-moved.md) | A workflow can tell where a tick came from without reading the history, and reading `record.state` in a fold is refused by a rule rather than discovered by a ticket that went round its whole lifecycle on every reply |
 | 16 | [Work that is over goes away](work-that-is-over-goes-away.md) | A machine that has driven work for a month lists what is happening and not what has happened, and one piece of work that will never finish on its own can be retired with a command rather than with `rm` |
 | 17 | [The ports belong to the core](the-ports-belong-to-the-core.md) | A workflow nobody shipped declares every port it needs by importing `@amykit/core`, and no plugin in the install depends on a workflow package to know what a tracker is |
+| 18 | [No port method ships unproven](no-port-method-ships-unproven.md) | The interface reads as five capabilities because five capabilities are proven, and a port method a plugin claims cannot reach a workflow as its first consumer |
+| 19 | [A reply inside a thread reaches the agent](a-reply-inside-a-thread-reaches-the-agent.md) | A reply written inside a thread is read by the agent answering that thread, and a workflow can tell whose turn a thread is from the view alone |
+| 20 | [The threads close when they are answered](the-threads-close-when-they-are-answered.md) | A state whose exit is "no automated thread unresolved" reaches that exit — the threads it answered are closed, and the ceiling is for work that is genuinely stuck |
+| 21 | [The forge is asked, not run beside](the-forge-is-asked-not-run-beside.md) | A workflow that needs what the plugins know asks the mounted plugin, and no registry ever again says there are two code hosts because a workflow had to mount one of its own |
+| 22 | [An escalation can be withdrawn](an-escalation-can-be-withdrawn.md) | A record that escalated on a defect comes back by a command — counter honest, history truthful, and the daemon never once raced the repair |

--- a/plans/no-port-method-ships-unproven.md
+++ b/plans/no-port-method-ships-unproven.md
@@ -1,0 +1,77 @@
+# No port method ships unproven
+
+`reviewsRequestedOf` cannot succeed as written. The GraphQL document names
+its variable `$query`:
+
+```graphql
+query ReviewRequests($query: String!) { search(query: $query, ...) }
+```
+
+(`plugins/github/src/GitHubCodeHost.ts:65`) and `GitHubCodeHost.graphql()`
+passes the document as `-f query=<document>` and every variable as
+`-F <name>=<value>` (`:255`). So the command line carries the field `query`
+twice, and `gh` refuses before GitHub is reached:
+
+```console
+$ gh api graphql -f query='query Q($query: String!) { ... }' -F query='is:pr is:open'
+unexpected override existing field under "query"
+```
+
+Renaming the variable — `$search`, anything but `query` — fixes it.
+
+## The part worth more than the fix
+
+The method has shipped broken for as long as it has existed, and nothing
+noticed, because no shipped workflow calls it. `ticket-to-qa` counts review
+load with `reviewLoad` and finds its own pull requests with
+`findPullRequest`; the first consumer of `reviewsRequestedOf` was a private
+workflow's discovery, in production, on a real board — and discovery failed
+on the first run of the install.
+
+**A port method no shipped workflow calls has nothing proving it works** —
+not a test, not a run, not a mount. The five-method `CodeHost` interface
+read as five capabilities and was four.
+
+The workaround in the consuming workflow was `gh pr list --search`, one call
+per repository and no GraphQL at all — which is its own finding, recorded as
+[the forge is asked, not run beside](the-forge-is-asked-not-run-beside.md).
+
+## What changes
+
+- The variable is `$search`. The defect is in the argv, so the proof is an
+  assertion on the argv: the scripted runner already records every call, and
+  the test asserts that the document and its variables never claim the same
+  field — no `-F query=` may follow a `-f query=`.
+- The guardrail: every method on a port a plugin claims is exercised by
+  something. A test per plugin walks the adapter's own public methods — read
+  from the adapter source, not restated in a list, because a contract
+  restated is a contract that can disagree — and fails naming any method
+  nothing in the suite calls. A new method reaches this test red until
+  something proves it; that is the property the broken method lacked.
+
+The same guardrail mounts for the tracker, which is the other port an
+install cannot run without.
+
+## The gate
+
+`plugins/github/tests/every-method-is-exercised.test.ts` and
+`plugins/linear/tests/every-method-is-exercised.test.ts` are the guardrail;
+the rename's proof lives in the existing adapter test beside the ones that
+already assert argv shapes.
+
+## Acceptance criteria
+
+- [ ] `gh` never receives a GraphQL document whose variables collide with
+      the document field itself
+      (proof: test:plugins/github/tests/GitHubCodeHost.test.ts)
+- [ ] A method on the forge port nothing exercises fails a test naming it
+      (proof: test:plugins/github/tests/every-method-is-exercised.test.ts)
+- [ ] A method on the tracker port nothing exercises fails a test naming it
+      (proof: test:plugins/linear/tests/every-method-is-exercised.test.ts)
+- [ ] Removing a method's only test turns the guardrail red, which is the
+      property the guardrail exists for
+      (proof: test:plugins/github/tests/every-method-is-exercised.test.ts)
+
+**Exit condition:** the interface reads as five capabilities because five
+capabilities are proven, and a port method a plugin claims cannot reach a
+workflow as its first consumer.

--- a/plans/the-forge-is-asked-not-run-beside.md
+++ b/plans/the-forge-is-asked-not-run-beside.md
@@ -1,0 +1,116 @@
+# The forge is asked, not run beside
+
+Two adapters live in a workflow package somewhere, and neither of them
+should exist. One shells out to `gh` beside the plugin that already owns
+`gh`; the other opens its own GraphQL connection to Linear beside the
+tracker that already has one. Everything in both is the plugins' job.
+
+This is not a complaint about the ports being small. It is that **every gap
+in a port becomes an adapter in whoever hits it**, and the second workflow
+that hits the same gap writes it again.
+
+## What the adapters contain, and where each thing belongs
+
+The `gh` adapter exists for eleven methods. Three of them are answered by
+plans already in the order: `resolveThread` by
+[the threads close when they are answered](the-threads-close-when-they-are-answered.md),
+`reviewsRequestedOf` (which was broken, and found because this workflow was
+its first consumer) by
+[no port method ships unproven](no-port-method-ships-unproven.md), and
+`mergedAndBase` by the view growth below. The rest:
+
+| the workflow needed | why the port did not have it |
+| --- | --- |
+| `merge` | `CodeHost` cannot merge |
+| `submitReview` | `CodeHost` cannot review |
+| `createIssue` | no port files an issue |
+| `pullRequest(repo, number)` | `findPullRequest` takes a branch, and a review request only ever knows a number |
+| `merged`/`base` on the view | `PullRequestView` carries neither |
+| `ticketsWithChangesRequested` | discovery by review state; nothing offers it |
+| `freezeIsClear` | commit statuses, which no ruleset enforces |
+
+The Linear reader exists for three: `description` and `comments` are
+[the ticket body](the-ticket-body-reaches-the-agent.md) and
+[an answer](an-answer-reaches-the-agent.md) already; `labels` is below. A
+label is how a team says what a ticket *is*: two epics labelled `Feature`
+were picked up as work to implement, and their sub-issues were the actual
+tickets.
+
+## What it costs
+
+- `gh` is invoked from two places with two shapes. One retries, one does
+  not; one reports the exit code, one reported an empty string for a killed
+  process for a day.
+- The same pull request is read twice per look — once by the port for its
+  threads, once by the forge for `merged` and `base`.
+- The mount has to claim a port kind of its own, because `code-host` is
+  taken and claiming a kind twice is refused — so the registry says there
+  are two code hosts, and one of them is a workflow.
+- `LINEAR_API_KEY` is read by the plugin and, separately, by a reader inside
+  a workflow. Two clients, two caches, one key.
+- The next workflow that answers a review thread or reads a ticket body
+  writes all of this again.
+
+## What changes
+
+**The tracker carries what a ticket is.** `ISSUE_FIELDS` grows
+`labels { nodes { name } }` (`plugins/linear/src/LinearTracker.ts:16`) and
+`Ticket` grows `labels: string[]`. With the description and the comments
+from the two plans above, the Linear reader has nothing left in it.
+
+**The forge answers by number, and says what a pull request is.**
+`CodeHost` grows `pullRequest(repo, number)` — readable merged or not,
+because the open-only filter belongs to the by-branch search — and
+`PullRequestView` grows `merged` and `base`, from the same node in the same
+query.
+
+**The forge does what a workflow would otherwise shell out for.** It grows
+`merge(repo, number, method)` — the method the base's ruleset allows is the
+caller's to name, so the port stays domain-free; `submitReview(repo, number,
+review)`, with the state as forge vocabulary and the decision to submit as
+workflow policy; `createIssue(repo, { title, body })`; and
+`commitStatuses(repo, sha)`, so a freeze is a workflow's reading of a status
+list rather than a private `gh api` of its own.
+
+**Discovery by review state.** `reviewsRequestedOf` answers "what is waiting
+on my review"; the missing mirror is "where did my review leave changes
+requested", which is the search behind `ticketsWithChangesRequested`. It
+grows as one more scoped search on the same port, and the workflow filters
+by state.
+
+What stays in the workflow is policy: which review state to submit, whose
+thread to close, what counts as a freeze. With the port grown, those are
+decisions over port answers rather than a second `gh` — and
+[no port method ships unproven](no-port-method-ships-unproven.md) is what
+keeps each new method honest on arrival.
+
+## The gate
+
+Every method above lands with an adapter test asserting the argv against
+the scripted runner, which the guardrail plan then holds in place. The
+Linear change lands beside the existing `ISSUE_FIELDS` mapping tests.
+
+## Acceptance criteria
+
+- [ ] A pull request is readable by number, merged or not
+      (proof: test:plugins/github/tests/GitHubCodeHost.test.ts)
+- [ ] The view says whether a pull request merged and what its base is
+      (proof: test:plugins/github/tests/GitHubCodeHost.test.ts)
+- [ ] A pull request is merged through the port, by the method the caller
+      named (proof: test:plugins/github/tests/GitHubCodeHost.test.ts)
+- [ ] A review is submitted through the port
+      (proof: test:plugins/github/tests/GitHubCodeHost.test.ts)
+- [ ] An issue is filed through the port
+      (proof: test:plugins/github/tests/GitHubCodeHost.test.ts)
+- [ ] A commit's statuses are readable through the port, freeze or no
+      freeze (proof: test:plugins/github/tests/GitHubCodeHost.test.ts)
+- [ ] A ticket carries its labels
+      (proof: test:plugins/linear/tests/LinearTracker.test.ts)
+- [ ] The private workflow deletes both adapters
+      (proof: unspecified:the deletion happens in a repository this one does
+      not contain; what this plan ships is every port method the adapters
+      were compensating for)
+
+**Exit condition:** a workflow that needs what the plugins know asks the
+mounted plugin, and no registry ever again says there are two code hosts
+because a workflow had to mount one of its own.

--- a/plans/the-threads-close-when-they-are-answered.md
+++ b/plans/the-threads-close-when-they-are-answered.md
@@ -1,0 +1,95 @@
+# The threads close when they are answered
+
+GitHub resolves nothing by itself. A thread stays open after the code that
+answers it is pushed; someone has to say it is settled. `CodeHost` mounts
+five methods (`packages/core/src/ports/CodeHost.ts:127`) and none of them
+closes a thread — so a workflow state whose exit is "no thread is
+unresolved" has an exit no effect it can emit will ever bring about.
+
+What such a state does instead, on a real board, is this:
+
+1. send an agent to fix the code,
+2. look again, see the same open thread,
+3. count an attempt, and repeat until the ceiling.
+
+The escalation it then writes is *"the automated threads were not resolved
+in three attempts"* — literally true, and it reads as the agent failing at
+the work rather than as a missing button. Three tickets on one install did
+exactly that, having had their code fixed each round:
+
+```
+TBO-1241  attempts {"COPILOT_FIX": 3}  the automated threads were not resolved in three attempts
+TBO-1242  attempts {"COPILOT_FIX": 3}  idem
+TBO-1243  attempts {"COPILOT_FIX": 3}  idem
+```
+
+The same shape is one state away here: `COPILOT_FIX` exits when every
+automated thread has been judged
+(`packages/workflow-ticket-to-qa/src/machine.ts:239`), and a judged thread
+is one the record has an opinion about — not one the forge agrees is
+settled.
+
+## What changes
+
+```ts
+resolveReviewThread(threadId: string): Promise<void>
+unresolveReviewThread(threadId: string): Promise<void>
+```
+
+`ReviewThread.id` is already the GraphQL node id — `GitHubCodeHost` maps
+`id: thread.id` — so the caller has everything it needs and the mutation is
+one call, verified against the API:
+
+```sh
+gh api graphql -f query='mutation Resolve($id: ID!) {
+  resolveReviewThread(input: {threadId: $id}) { thread { id isResolved } }
+}' -F id=<threadId>
+```
+
+`unresolveReviewThread` mounts beside it: a machine that closed a thread on
+a fix that later got reverted should be able to put it back.
+
+The action catalogue grows one entry,
+`"resolve-review-thread": { port: "code-host", method: "resolveReviewThread" }`,
+so a workflow emits it the way it emits `open-pull-request`, and a mount
+that cannot run it is refused at boot by name.
+
+**Who may close what is the workflow's policy, not the port's.** This
+machine closes the automated reviewer's threads once it has answered them,
+and never a colleague's — only the author of an objection decides it is
+settled, so a human thread stays open for the human to close, and `HUMAN_FIX`
+does not emit the effect at all. The port only has to make it possible.
+
+The move, inside `COPILOT_FIX`: threads the record already judged `fixed`
+and the forge still holds open get one act of `resolve-review-thread`
+effects; the next look sees them resolved and the state leaves the way its
+exit condition says it does.
+
+## The gate
+
+The adapter test asserts the argv against the scripted runner — the
+mutation, the variable, one call. The machine tests drive the decision
+purely, as every state here is driven, and the walkthrough proves the
+lifecycle: a ticket that would have escalated at the ceiling now leaves
+`COPILOT_FIX` because nothing is unresolved.
+
+## Acceptance criteria
+
+- [ ] `resolveReviewThread` closes a thread by its id in one call
+      (proof: test:plugins/github/tests/GitHubCodeHost.test.ts)
+- [ ] `unresolveReviewThread` puts back what a reverted fix had closed
+      (proof: test:plugins/github/tests/GitHubCodeHost.test.ts)
+- [ ] The core dispatches `resolve-review-thread` to the code-host port
+      (proof: test:packages/workflow-ticket-to-qa/tests/plugin.test.ts)
+- [ ] A thread the agent answered is closed by the machine, and the next
+      look sees it closed
+      (proof: test:packages/workflow-ticket-to-qa/tests/machine.test.ts)
+- [ ] A colleague's thread is never closed by the machine, however it was
+      judged (proof: test:packages/workflow-ticket-to-qa/tests/machine.test.ts)
+- [ ] `COPILOT_FIX` leaves because no automated thread is unresolved, not
+      because the attempts ran out
+      (proof: test:packages/workflow-ticket-to-qa/tests/walkthrough.test.ts)
+
+**Exit condition:** a state whose exit is "no automated thread unresolved"
+reaches that exit — the threads it answered are closed, and the ceiling is
+for work that is genuinely stuck.


### PR DESCRIPTION
## What this is

Issues #36 to #40, filed from a day of a private workflow driving this
machine against real pull requests, converted into plans and five rows in
the execution order — the house's way of deciding work: a plan in `plans/`
with an exit condition, listed in `next-steps.md`, each criterion naming
the check that proves it.

| Row | Plan | From |
| --- | --- | --- |
| 18 | [No port method ships unproven](plans/no-port-method-ships-unproven.md) | #39 |
| 19 | [A reply inside a thread reaches the agent](plans/a-reply-inside-a-thread-reaches-the-agent.md) | #38 |
| 20 | [The threads close when they are answered](plans/the-threads-close-when-they-are-answered.md) | #37 |
| 21 | [The forge is asked, not run beside](plans/the-forge-is-asked-not-run-beside.md) | #40 |
| 22 | [An escalation can be withdrawn](plans/an-escalation-can-be-withdrawn.md) | #36 |

18 is first because 21 adds six methods to one port and every one of them
should have to get past 18 on arrival.

Plans only — no code changes. `sf check --allow-commands` is green, and the
pre-commit hooks (build, typecheck, docs, tests, lint, `sf verify`,
`sf check`) passed on the commit.