### PR TITLE
Plans: a worktree per work item, and no retry is free

### DIFF
--- a/plans/next-steps.md
+++ b/plans/next-steps.md
@@ -22,6 +22,14 @@ against real pull requests — five findings, filed as issues and converted
 here. 16 is first because 19 adds six methods to one port and every one of
 them should have to get past 16 on arrival.
 
+Rows 21 and 22 come from two issues filed against that same private
+workflow's day on real tickets (#46, #45), converted the way issues are:
+grounded in the code first, one plan each. 21 is first because it changes
+where work *runs* — every effect, gate and git action answers for one work
+item's own tree — and 22's progress signals are about whether another run
+in that tree is worth anything; a workflow should not learn to count
+no-evidence retries against a tree two tickets can still contend for.
+
 | # | Work | Exit condition |
 | --- | --- | --- |
 | 1 | [A spec is a name, a URL or a path](a-spec-is-a-name-a-url-or-a-path.md) | One function turns any of the five forms into what npm installs and what the config names, and nothing else in the CLI parses a spec |
@@ -44,3 +52,5 @@ them should have to get past 16 on arrival.
 | 18 | [The threads close when they are answered](the-threads-close-when-they-are-answered.md) | A state whose exit is "no automated thread unresolved" reaches that exit — the threads it answered are closed, and the ceiling is for work that is genuinely stuck |
 | 19 | [The forge is asked, not run beside](the-forge-is-asked-not-run-beside.md) | A workflow that needs what the plugins know asks the mounted plugin, and no registry ever again says there are two code hosts because a workflow had to mount one of its own |
 | 20 | [An escalation can be withdrawn](an-escalation-can-be-withdrawn.md) | A record that escalated on a defect comes back by a command — counter honest, history truthful, and the daemon never once raced the repair |
+| 21 | [The worktree is the workplace](the-worktree-is-the-workplace.md) | Two work items in the same repository drive their whole lifecycle concurrently, each in its own worktree, and no workflow had to invent isolation, cleanup, discovery or recovery to get it |
+| 22 | [No retry is free](no-retry-is-free.md) | A retry that produces no new evidence is refused before the agent starts, by every workflow, with the reason a person can read — and no workflow had to write a counter of its own to get it |

--- a/plans/no-retry-is-free.md
+++ b/plans/no-retry-is-free.md
@@ -1,0 +1,106 @@
+# No retry is free
+
+Every retry is charged like useful work. `AttemptOutcome` is
+`{ ok, output, at }` with no account of what a run changed
+(`packages/workflow-ticket-to-qa/src/record.ts:20`), and an `ok: false`
+attempt folds back into the record only to be retried until a per-state
+ceiling answers (`packages/workflow-ticket-to-qa/src/machine.ts:162`) — so
+a retry that produces no new evidence is billed exactly like one that
+produced the fix. The machine's only stops are those ceilings and the
+token/USD windows (`packages/core/src/budget.ts:83`), and a `wait`
+re-queues the work with `delayMs` and no question about whether another
+look is worth anything (`plugins/serial-engine/src/Worker.ts:210`). A
+ticket that fails the same way three times burns three full agent runs —
+three times the tokens, three times the USD — before `maxImplementAttempts`
+ever answers, and the `parked` refusal is only about money already spent,
+not money about to be wasted (`plugins/serial-engine/src/Worker.ts:246`).
+
+This was found on the Revv workflow (issue #45), but it is not Revv's to
+fix: any workflow whose agent can answer without changing anything needs
+the same accounting, and today each one would build its own counter and
+its own diagnostic. The core already owns one honest bookkeeping seam —
+`applyPlan` counts attempts per state (`packages/core/src/work.ts:80`) —
+and the engine already owns one refusal seam — `parked` parks before a
+spending action runs (`plugins/serial-engine/src/Worker.ts:177`). What is
+missing is the middle: a signal the workflow sends about its own domain
+facts, and a stop rule the engine owns.
+
+## What changes
+
+**The outcome carries what a run changed.** `AttemptOutcome` gains
+`progress`:
+
+```ts
+type Progress =
+  | { kind: "advanced"; key: string }
+  | { kind: "unchanged"; key: string; detail: string }
+  | { kind: "handoff"; detail: string };
+```
+
+The workflow decides the domain fact — git diff changed, a review
+fingerprint moved, the request needs a person — and the core never parses a
+diff or review prose. The serial engine owns the generic half: consecutive
+`unchanged` counts per `workId + state + key`, reset by `advanced`, and a
+durable reason in the queue item and the event log. `handoff` parks
+immediately and never consumes a retry.
+
+**The stop is a budget over evidence, not over money.** The engine, before
+executing actions that dispatch to an agent, applies the workflow's
+progress policy: at `maxUnchanged` consecutive `unchanged` signals for one
+key the next agent start is refused, the work is parked with the key and
+detail in the reason, and a `progress.parked` event says what was about to
+be spent and why (`packages/core/events.json` gains the kind; the contract
+check `checkEvent` is what keeps the line honest). The refusal reuses the
+existing `parked` path — the record is not saved, the queue item keeps its
+attempt — so a park costs nothing, which is the point.
+
+**Opt-in, with a conservative default.** No workflow changes behaviour
+until it emits progress signals or the policy is enabled. `ProgressPolicy`
+lives on the workflow runtime contribution (`packages/core/src/runtime.ts:43`)
+as an optional member, the same seam as `resumed?` — a workflow without it
+runs exactly as today. `maxUnchanged` defaults to 2 and `handoff` to
+`park`; the config slice names them `agent.budget.progress.maxUnchanged`
+and `agent.budget.progress.handoff`, and `parseBudget`
+(`packages/core/src/budget-config.ts:22`) grows the nested shape beside
+`perFiveHours`/`perWeek` rather than a second parser.
+
+**The operator sees the waste prevented.** `amy budget` gains the count of
+refused starts and the runs they would have cost, read off the event log
+the same way `spendSince` reads `agent.run` lines
+(`packages/core/src/budget.ts:55`) — a second tally is a second thing to
+disagree with what actually happened.
+
+## The gate
+
+`plugin-serial-engine`, extended — it owns the park-before-spend seam and
+the failure announcements. The scenario drives a record whose agent
+answers `unchanged` three times over the same key:
+
+- `engine.a_no_op_attempt_parks_before_the_next_agent_run`
+- `engine.a_changed_key_resets_only_its_own_streak`
+- `engine.a_handoff_never_consumes_a_retry`
+- `engine.park_reasons_carry_the_key_and_detail`
+
+`amy budget` reads prevented starts from the log, so
+`lifecycle.what_the_agents_spent_is_read_off_the_log` grows a prevented
+line beside the spent line.
+
+## Acceptance criteria
+
+- [ ] An `unchanged` signal prevents the configured next expensive start
+      and the reason names the key and the detail
+      (proof: assertion:engine.a_no_op_attempt_parks_before_the_next_agent_run)
+- [ ] A changed key or `advanced` resets only its own streak
+      (proof: assertion:engine.a_changed_key_resets_only_its_own_streak)
+- [ ] A `handoff` parks immediately and never consumes a retry budget
+      (proof: assertion:engine.a_handoff_never_consumes_a_retry)
+- [ ] A workflow that emits no progress runs exactly as before the policy
+      existed (proof: test:plugins/serial-engine/tests/Worker.test.ts)
+- [ ] `parseBudget` accepts the nested `progress` block and refuses a
+      `handoff` it does not know (proof: test:packages/core/tests/budget-config.test.ts)
+- [ ] `amy budget` reports prevented starts from the log, not from a
+      counter of its own (proof: test:packages/cli/tests/budget.test.ts)
+
+**Exit condition:** a retry that produces no new evidence is refused before
+the agent starts, by every workflow, with the reason a person can read —
+and no workflow had to write a counter of its own to get it.

--- a/plans/the-worktree-is-the-workplace.md
+++ b/plans/the-worktree-is-the-workplace.md
@@ -1,0 +1,131 @@
+# The worktree is the workplace
+
+One checkout per repository is one shared mutable tree, and everything that
+touches it contends for it. `Git.prepareBranch` runs `git checkout -B`
+against `origin/<branch>` (`packages/core/src/git.ts:41`), which resets the
+checkout to the ticket's branch in place — so two tickets on the same
+repository cannot implement at the same time, an interrupted run leaves a
+dirty tree that blocks the next ticket's gate, and `git checkout -B` can
+repoint a branch an existing PR is built on merely to prepare another item.
+The workflows compensate rather than isolate: every runtime calls
+`git.prepareBranch` then `git.pathFor` (`packages/workflow-note-to-plan/src/runtime.ts:128`)
+and passes that path to the agent, the gate runs `cwd: this.git.pathFor(repo)`
+(`plugins/command-gate/src/CommandGate.ts:48`), and the harness writes into
+the same tree the agent is about to change
+(`packages/agent-kit/src/HarnessAgent.ts:248`). Workflows should not each
+have to invent checkout isolation, cleanup, discovery and recovery.
+
+This was found on a private workflow driving amy against real pull
+requests (issue #46), but the checkout is amy's shared surface, not one
+workflow's: the fix is a core seam, not a workflow plugin.
+
+## What changes
+
+**The core grows a worktree port.** `packages/core/src/ports/` gains
+`Worktree.ts` with three capabilities — `acquire(workId, repo)` returns the
+path of an isolated tree on the ticket's branch and creates or reuses it;
+`states()` answers which worktrees exist and what state each is in (clean,
+dirty, in-flight, terminal); `release(workId, repo)` removes a tree that
+has become safe to remove. The mount gains the port kind `worktree` beside
+`code-host` and `tracker` (`packages/core/src/mount.ts`), and a core action
+backing it lands in `CORE_ACTIONS` (`packages/core/src/actions.ts`) so a
+workflow never shells out to `git worktree` on its own.
+
+**`Git` grows worktree mode without losing shared-checkout mode.** The same
+`Git` class answers both: `pathFor` resolves through the worktree manager
+when worktrees are enabled for the mount, and through `workspaceRoot` when
+they are not, so every caller — `HarnessAgent.ask`
+(`packages/agent-kit/src/HarnessAgent.ts:248`), `PlanCommandCheck`
+(`plugins/plan-check/src/PlanCommandCheck.ts:50`), `CommandGate`
+(`plugins/command-gate/src/CommandGate.ts:48`) — receives its own path and
+no caller changes its shape. `prepareBranch` inside a worktree does not
+repoint the shared checkout's branch: it cuts the worktree from the
+configured base without touching the standing checkout, so **two work
+items in one repository can run concurrently without branch interference**
+and an interrupted item never leaves the shared tree dirty. A workflow may
+opt out only with a documented shared-checkout need
+(`worktrees.enabled: false` per workflow slice).
+
+**Storage, retention, and operator surface.** Trees live under
+`~/.amy/worktrees/<workflow>/<work-id>/<owner-repo>/`, predictable and
+outside any repository. Terminal, clean trees are prunable after
+`worktrees.retentionDays` (default 7) and removals log an event-log entry
+explaining every removal — the same honesty as `run.idle` and
+`budget.parked` (`packages/core/src/ports/EventLog.ts:100`). Dirty, failed
+or escalated trees are retained by default and `amy worktrees list` names
+state, workflow, work id, repository, branch, cleanliness and retention
+eligibility; `amy worktrees remove <work-id>` refuses in-flight or dirty
+trees unless `--force`. The daemon runs the same safety predicates on
+startup and after terminal work, and every automatic removal carries the
+same event. Orphaned trees (their work id no longer in the store) are
+offered for recovery by `amy worktrees list` before any prune touches
+them.
+
+**Configuration.**
+
+```yaml
+worktrees:
+  enabled: true
+  root: ~/.amy/worktrees
+  retentionDays: 7
+  pruneOnStart: true
+```
+
+`enabled: true` is the default the plan ships, because the acceptance
+criteria demand concurrent work as the ordinary case, not the exception. The
+field is read in `fromParsed` with `~` expanded the way `workspaceRoot`
+already is (`packages/cli/src/config.ts:193`), and the six-place config
+sweep applies: interface, `DEFAULT_CONFIG`, `EXAMPLE_CONFIG` template prose,
+`slices.ts` derived map, `doctor.ts` checks, every `worktrees:`-shaped
+literal in `packages/cli/tests`.
+
+**Migration is honest about the standing checkout.** The worktree manager
+never touches an existing checkout's uncommitted work: acquiring a worktree
+does not reset or repoint anything, and an install whose `workspaceRoot`
+holds dirty checkouts keeps them, with `amy doctor` reporting both roots.
+Existing installs migrate by running `amy worktrees list` and pruning what
+is retention-eligible — nothing moves under them.
+
+## The gate
+
+`ticket-to-qa`, extended — it is the gate that drives work in a checkout,
+and isolation is only real if a piece of work runs in its own tree:
+
+- `worktree.two_items_in_one_repository_run_concurrently`
+- `worktree.the_agent_the_gate_and_git_effects_receive_the_own_path`
+- `worktree.a_crash_or_dirty_tree_never_deletes_a_worktree`
+- `worktree.a_terminal_clean_tree_is_prunable_after_retention`
+- `worktree.the_list_names_state_workflow_repo_branch_and_cleanliness`
+- `worktree.an_orphaned_tree_is_offered_for_recovery`
+- `worktree.prune_refuses_an_in_flight_tree`
+- `worktree.preparing_an_item_never_repoints_the_shared_checkout_branch`
+
+Its scenario drives two pieces of work in the same repository concurrently
+and asserts the branch each PR lands on, the worktree paths the agent and
+gate saw, and the event-log line for each removal.
+
+## Acceptance criteria
+
+- [ ] Two work items in the same repository implement and gate concurrently
+      without branch or dirty-tree interference
+      (proof: assertion:worktree.two_items_in_one_repository_run_concurrently)
+- [ ] Agent, gate and git effects for an item receive only its own
+      worktree path (proof: assertion:worktree.the_agent_the_gate_and_git_effects_receive_the_own_path)
+- [ ] A crash, escalation, failed action or dirty tree never triggers
+      automatic deletion (proof: assertion:worktree.a_crash_or_dirty_tree_never_deletes_a_worktree)
+- [ ] A terminal, clean worktree is prunable after retention and the
+      removal is logged (proof: assertion:worktree.a_terminal_clean_tree_is_prunable_after_retention)
+- [ ] `amy worktrees list` names state, workflow, work id, repository,
+      branch, cleanliness and retention eligibility
+      (proof: assertion:worktree.the_list_names_state_workflow_repo_branch_and_cleanliness)
+- [ ] An orphaned worktree is offered for recovery before pruning
+      (proof: assertion:worktree.an_orphaned_tree_is_offered_for_recovery)
+- [ ] Preparing another item never resets or repoints an existing ticket
+      branch (proof: assertion:worktree.preparing_an_item_never_repoints_the_shared_checkout_branch)
+- [ ] Existing installs keep their uncommitted work and both roots are
+      reported by `amy doctor`
+      (proof: test:packages/cli/tests/doctor.test.ts)
+
+**Exit condition:** two work items in the same repository drive their whole
+lifecycle concurrently, each in its own worktree, and no workflow had to
+invent isolation, cleanup, discovery or recovery to get it.


### PR DESCRIPTION
## What

Converts the two open issues into plans, the way issues are converted here: grounded in the code first, one plan each, one row each in `plans/next-steps.md`.

- #46 → `plans/the-worktree-is-the-workplace.md` (row 21) — a dedicated Git worktree per work item as the default execution environment: a core `Worktree` port, `Git` answering both modes without changing any caller's shape, `amy worktrees list/prune/remove`, retention with safety predicates, orphan recovery, and an extended `ticket-to-qa` scenario driving two items in one repository concurrently.
- #45 → `plans/no-retry-is-free.md` (row 22) — an optional `Progress` signal on effect outcomes (`advanced`/`unchanged`/`handoff`), engine-owned bookkeeping of consecutive `unchanged` per `workId + state + key`, and a park-before-spend refusal that stops no-evidence retries before the agent starts; opt-in, conservative defaults, `amy budget` reporting prevented starts off the log.

## Why this order

Row 21 first: it changes where work *runs* — every effect, gate and git action answers for one work item's own tree. Row 22's progress signals are about whether another run in that tree is worth anything; a workflow should not learn to count no-evidence retries against a tree two tickets can still contend for.

Both rows keep existing workflows unchanged until they opt in (22 is opt-in by design; 21 ships `worktrees.enabled: true` as the plan's default with a per-workflow opt-out).

## Plans → rows

- `plans/the-worktree-is-the-workplace.md` → row 21 (source: issue #46)
- `plans/no-retry-is-free.md` → row 22 (source: issue #45)

The issues will be deleted after this lands, per the house convention: the plans are their durable record.

## Verification

- `sf check --allow-commands`: green, 33 rules, no findings.
- No code, config or package.json touched — plans and roadmap only; no changeset needed, no seals needed, no gates activated by these paths.