### PR TITLE
docs(plans): a skill for the half-step, and a stack knows its parent

### DIFF
--- a/plans/a-skill-for-the-half-step.md
+++ b/plans/a-skill-for-the-half-step.md
@@ -1,0 +1,79 @@
+# A skill for the half-step
+
+A workflow can send several logical steps through one agent action, and
+the runtime already keys by them: `HarnessRelay.ask` reads
+`context.step` (`packages/agent-kit/src/HarnessRelay.ts:46`) and
+`rungsFor` reads the same name for the model ladder
+(`packages/agent-kit/src/ladders.ts:36`), so `run-errand` passing
+`step: "self-review"` reaches the ladder machinery today
+(`packages/workflow-errand/src/runtime.ts:110`).
+
+The validator does not. `parseSkills` refuses any key that is not a core
+action dispatching to the agent port — *"`skills.<step>` is not a step an
+agent performs"* (`plugins/agent-relay/src/skills.ts:31`) — so
+`skills: self-review: [/antikus-code-review]` is refused at boot even
+though the runtime honors it. Workflow-revv's workaround is to attach the
+skill to `run-errand` whole, which then fires on triage, implementation
+and self-review alike: the wrong ladder for three of the four steps it
+was not about. The same blindness will meet `ladderByStep` the day a
+workflow routes a half-step to a cheaper model.
+
+This was found on the Revv workflow (issue #48), but no workflow is
+exempt: any workflow that phases one action — ask, then check, then
+review — has half-steps the config cannot name. The sibling plan for the
+action-name half of this ([a-skill-ladder-for-your-own-steps.md](a-skill-ladder-for-your-own-steps.md))
+widens the list to `usesActions`; this plan is about the steps *between*
+actions, which no list on the workflow declares.
+
+## What changes
+
+**The workflow declares its half-steps.** `Workflow` gains an optional
+`declaredSteps?: readonly string[]` (`packages/core/src/plugin.ts:18`) —
+the names the workflow itself may put in `AskContext.step` that are not
+its own action names. Optional, for the same reason every new seam on the
+runtime contribution is: a workflow without it works exactly as today.
+
+**One check, two lists.** The step-name validation moves out of
+`parseSkills`'s `CORE_ACTIONS`-only world into a list built at mount:
+core actions that dispatch to `agent`, plus the mounted workflow's
+`usesActions` that resolve to the agent port, plus its `declaredSteps`.
+A key on none of those is a typo, and it is cheaper to say so at boot
+with the list of steps there were than to leave a ladder that never
+fires — the refusal message names the steps it knows, the same shape as
+every other refusal in this codebase. `ladderByStep` goes through the
+same check; today nothing validates its keys at all.
+
+**Where the check runs.** In `ready`, beside the step-ladder check of
+the sibling plan, because the workflow has registered by then and the
+mount can still refuse (`core/src/mount.ts` second pass). The scenario's
+outside-repository workflow gains a `declaredSteps: ["self-review"]`, so
+the assertion proves a half-step key is accepted, one nobody declares is
+refused with the list, and a model ladder keys on the same half-step.
+
+## The gate
+
+`plugin-agent-relay`, extended — it owns both ladders and the scenario
+already mounts a workflow written outside this repository:
+
+- `relay.a_declared_half_step_can_have_a_skill`
+- `relay.a_half_step_nobody_declares_is_refused_at_boot`
+- `relay.the_half_step_refusal_lists_the_steps_there_were`
+- `relay.a_model_ladder_can_key_on_a_declared_half_step`
+
+## Acceptance criteria
+
+- [ ] A skill keyed by a workflow-declared half-step is accepted and
+      fires for that step only
+      (proof: assertion:relay.a_declared_half_step_can_have_a_skill)
+- [ ] A half-step key nobody declares is refused at boot
+      (proof: assertion:relay.a_half_step_nobody_declares_is_refused_at_boot)
+- [ ] The refusal lists the steps there were
+      (proof: assertion:relay.the_half_step_refusal_lists_the_steps_there_were)
+- [ ] `ladderByStep` keys on a declared half-step through the same rule
+      (proof: assertion:relay.a_model_ladder_can_key_on_a_declared_half_step)
+- [ ] A workflow with no `declaredSteps` mounts and runs exactly as
+      before (proof: test:plugins/agent-relay/tests/skills.test.ts)
+
+**Exit condition:** a workflow that phases one action into several steps
+can give each of them its own skill and its own model ladder, from
+`config.yaml`, with the typos refused at boot by name.

--- a/plans/a-stack-knows-its-parent.md
+++ b/plans/a-stack-knows-its-parent.md
@@ -1,0 +1,95 @@
+# A stack knows its parent
+
+Workflows that stack pull requests need one explicit stack parent, and
+today they cannot say so: `OpenPullRequestRequest` carries no base
+(`packages/core/src/ports/CodeHost.ts:98`), and the GitHub adapter
+resolves the default branch internally on every open
+(`plugins/github/src/GitHubCodeHost.ts:139`), so every PR amy opens is a
+root with no stack above it. The base a stacked PR must land on is not
+the repository's default branch — it is its parent's head.
+
+The read side is blinder than the write side. `findPullRequest` queries
+`states: [OPEN]` (`plugins/github/src/GitHubCodeHost.ts:18`), so a merged
+parent is invisible: the stack resolution the workflows need — open
+parent => its remote head branch; merged parent => its recorded base;
+absent or closed-unmerged => wait — cannot be answered through the port
+at all, and each workflow would reimplement the GitHub-specific lookup
+on its own. The Revv workflow hit this driving stacked PRs against real
+repositories (issue #48).
+
+Not every workflow stacks PRs, so nothing here may be required of a
+workflow that does not: this is a port growing a capability, not a new
+obligation on every port implementor.
+
+## What changes
+
+**The port grows stack facts.** `OpenPullRequestRequest` gains optional
+`base?: string` — the branch to target; absent still means the
+repository's default, which is every install today. `PullRequestView`
+gains `baseBranch: string`, so the fold can compare the head against the
+base it actually opened on. Neither field breaks an implementor that
+ignores them, which is what keeps a second workflow's stacked PR from
+being this port's problem.
+
+**The port grows the parent lookup.** `CodeHost` gains
+`pullRequestAncestry(repo, number): Promise<PullRequestAncestry | null>`
+returning `{ state: "open" | "merged" | "closed-unmerged" | "absent",
+headBranch, baseBranch }` — the resolved base every observation can
+recompute from, with no workflow learning what a forge is. The GitHub
+adapter answers it from the same GraphQL surface it already queries,
+with `states:` widened so a merged parent is a result and not a
+blank. An implementor that cannot answer returns null, and the workflow
+waits.
+
+**Where the stack parent is recorded.** The tracker's many product
+dependencies stay the tracker's; the stack parent is one field on the
+work item's own record, written when the item is created and read every
+observation through the port — never a second copy in the config. The
+workflow folds `state: "merged"` into "my base is the parent's recorded
+base", `open` into "my base is the parent's head branch", and everything
+else into a wait with a reason, which is the whole of the domain logic
+and all of it stays workflow-side.
+
+**The six-place config sweep does not apply.** No new config field ships
+with this plan: the base is data on the record and facts from the
+forge, not a setting. The only config-adjacent move is the template's
+skills section gaining a half-step example, delivered by the sibling
+plan ([a-skill-for-the-half-step.md](a-skill-for-the-half-step.md)).
+
+## The gate
+
+`plugin-github`, extended — it owns the adapter the ancestry query
+lives in, and its scenario already stands up a stand-in forge:
+
+- `stack.a_pull_request_opens_on_the_parent_head_while_it_is_open`
+- `stack.a_merged_parent_answers_its_recorded_base`
+- `stack.an_absent_parent_or_one_closed_unmerged_waits`
+- `stack.no_workflow_learns_the_word_github`
+
+There is no `plugin-github` gate today. One ships with this plan, with
+the same shape as the file-queue one: activation on
+`plugins/github/src/**`, evidence at
+`.software-factory/evidence/plugin-github.json`, assertions on the
+built artifacts against the stand-in forge the repo already has, so the
+ancestry lookup is proven against a server-shaped thing rather than a
+mock that answers whatever the test asked.
+
+## Acceptance criteria
+
+- [ ] A pull request opens with an explicit base and lands on it
+      (proof: assertion:stack.a_pull_request_opens_on_the_parent_head_while_it_is_open)
+- [ ] A merged parent resolves to its recorded base through the port
+      (proof: assertion:stack.a_merged_parent_answers_its_recorded_base)
+- [ ] An absent or closed-unmerged parent yields a wait, not a guess
+      (proof: assertion:stack.an_absent_parent_or_one_closed_unmerged_waits)
+- [ ] No workflow package names a forge
+      (proof: assertion:stack.no_workflow_learns_the_word_github)
+- [ ] An implementor that ignores the new fields passes unchanged
+      (proof: test:packages/core/tests/CodeHost.test.ts)
+- [ ] `findPullRequest` on an open PR still returns its view, and the
+      view names the base it opened on
+      (proof: test:plugins/github/tests/GitHubCodeHost.test.ts)
+
+**Exit condition:** a workflow that stacks pull requests names one
+explicit parent per item, resolves the base from the remote code host on
+every observation, and never learns which forge answered.

--- a/plans/next-steps.md
+++ b/plans/next-steps.md
@@ -30,6 +30,15 @@ item's own tree — and 22's progress signals are about whether another run
 in that tree is worth anything; a workflow should not learn to count
 no-evidence retries against a tree two tickets can still contend for.
 
+Rows 23 and 24 come from issue #48, another day of that private workflow
+driving amy — two findings, filed together because they arrived together,
+split the way they must be: 23 is about who answers a step the config
+cannot even name, 24 is a port growing what a stacked pull request needs.
+23 comes first because its sibling (row 6) already has an approved plan,
+and the two must not disagree about which list a step is checked against;
+24 ships a new gate with it, so what it adds to one port has to get past
+the same boot that 23 tightens.
+
 | # | Work | Exit condition |
 | --- | --- | --- |
 | 1 | [A spec is a name, a URL or a path](a-spec-is-a-name-a-url-or-a-path.md) | One function turns any of the five forms into what npm installs and what the config names, and nothing else in the CLI parses a spec |
@@ -54,3 +63,5 @@ no-evidence retries against a tree two tickets can still contend for.
 | 20 | [An escalation can be withdrawn](an-escalation-can-be-withdrawn.md) | A record that escalated on a defect comes back by a command — counter honest, history truthful, and the daemon never once raced the repair |
 | 21 | [The worktree is the workplace](the-worktree-is-the-workplace.md) | Two work items in the same repository drive their whole lifecycle concurrently, each in its own worktree, and no workflow had to invent isolation, cleanup, discovery or recovery to get it |
 | 22 | [No retry is free](no-retry-is-free.md) | A retry that produces no new evidence is refused before the agent starts, by every workflow, with the reason a person can read — and no workflow had to write a counter of its own to get it |
+| 23 | [A skill for the half-step](a-skill-for-the-half-step.md) | A workflow that phases one action into several steps can give each of them its own skill and its own model ladder, from `config.yaml`, with the typos refused at boot by name |
+| 24 | [A stack knows its parent](a-stack-knows-its-parent.md) | A workflow that stacks pull requests names one explicit parent per item, resolves the base from the remote code host on every observation, and never learns which forge answered |


### PR DESCRIPTION
# A skill for the half-step, and a stack knows its parent

Issue #48 carried two findings that arrived together and were split the way they must be: one is about who answers a step the config cannot name, the other is a port growing what a stacked pull request needs.

## What arrived

The issue reported that `skills: self-review: [...]` is refused at boot even though the runtime honors it — `HarnessRelay` keys skill dispatch by `AskContext.step`, but `parseSkills` validates keys against `CORE_ACTIONS` only, so a workflow that phases one action into several logical steps (triage → implement → self-review through one `run-errand`) cannot give any of them a skill, and the workaround (attaching the skill to the whole action) fires it on every step alike.

The second half of the issue: workflows that stack pull requests need one explicit stack parent, resolved from the remote code host on every observation — open parent → its head branch; merged → its recorded base; absent/closed-unmerged → wait. Today the `CodeHost` port cannot say any of that: `OpenPullRequestRequest` carries no base, the adapter always targets the default branch, and `findPullRequest` only sees open PRs, so a merged parent is invisible.

## What this PR does

Both became plans, grounded in the code first:

- `plans/a-skill-for-the-half-step.md` → **row 23**. The workflow declares its half-steps (`declaredSteps?` on `Workflow`), and one validation checks `skills:`/`ladderByStep:` keys against core agent actions + the mounted workflow's `usesActions` + its `declaredSteps`. Refusals at boot name the steps there were. This is the sibling of row 6 (which widens the list to `usesActions`); the two plans agree on which list a step is checked against, and row 23 covers the steps *between* actions that no `usesActions` entry names.
- `plans/a-stack-knows-its-parent.md` → **row 24**. `OpenPullRequestRequest` gains optional `base?`, `PullRequestView` gains `baseBranch`, and `CodeHost` grows `pullRequestAncestry(repo, number)` returning the parent's state (open/merged/closed-unmerged/absent) and branches. A `plugin-github` gate ships with the plan, same shape as the file-queue gate.

Both rows keep the optional-members convention (a workflow/port implementor without the new surface works exactly as today), and the cross-references between the sibling plans are relative links.

## Source issues

- Issue #48 — read in full, grounded, converted to rows 23 and 24. The issue will be deleted; these two plans and the board rows are its record.